### PR TITLE
Add max-width to commit message of repo-files-table

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1250,6 +1250,9 @@ The register and sign-in page style
   color: #428BCA;
   text-decoration: underline;
 }
+#repo-files-table td.message .text-truncate {
+  max-width: 360px;
+}
 #repo-files-table tbody {
   background-color: #FFF;
 }

--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -281,6 +281,11 @@
         color: #428BCA;
         text-decoration: underline;
     }
+    td.message {
+        .text-truncate {
+            max-width: 360px;
+        }
+    }
     tbody {
         background-color: #FFF;
         tr:hover {


### PR DESCRIPTION
Prevent repository files table from overflow by a long commit message.

Before
![before](https://cloud.githubusercontent.com/assets/9127722/5609167/4c218c34-94d4-11e4-83a2-da36eb29a416.png)

After
![after](https://cloud.githubusercontent.com/assets/9127722/5609168/4ef815fe-94d4-11e4-90fe-1636697b1d8e.png)
