### PR TITLE
Improve look of the user email settings page

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -219,12 +219,13 @@ change_password_success = Password is changed successfully. You can now sign in 
 
 emails = E-mail Addresses
 manage_emails = Manage e-mail addresses
-email_desc = Current e-mail addresses
+email_desc = Your primary e-mail address will be used for notifications and other operations.
 primary = Primary
-primary_email = Make primary
+primary_email = Set as primary
 delete_email = Delete
 add_new_email = Add new e-mail address
 add_email = Add e-mail
+add_email_success = Your new E-mail address was successfully added.
 
 manage_ssh_keys = Manage SSH Keys
 add_key = Add Key

--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1813,6 +1813,7 @@ The register and sign-in page style
 #repo-hooks-history-panel,
 #user-social-panel,
 #user-applications-panel,
+#user-email-panel,
 #user-ssh-panel {
   margin-bottom: 20px;
 }
@@ -1820,6 +1821,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .setting-list,
 #user-social-panel .setting-list,
 #user-applications-panel .setting-list,
+#user-email-panel .setting-list,
 #user-ssh-panel .setting-list {
   background-color: #FFF;
 }
@@ -1827,6 +1829,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .setting-list li,
 #user-social-panel .setting-list li,
 #user-applications-panel .setting-list li,
+#user-email-panel .setting-list li,
 #user-ssh-panel .setting-list li {
   padding: 8px 20px;
   border-bottom: 1px solid #eaeaea;
@@ -1835,6 +1838,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .setting-list li.ssh:hover,
 #user-social-panel .setting-list li.ssh:hover,
 #user-applications-panel .setting-list li.ssh:hover,
+#user-email-panel .setting-list li.ssh:hover,
 #user-ssh-panel .setting-list li.ssh:hover {
   background-color: #ffffEE;
 }
@@ -1842,6 +1846,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .setting-list li i,
 #user-social-panel .setting-list li i,
 #user-applications-panel .setting-list li i,
+#user-email-panel .setting-list li i,
 #user-ssh-panel .setting-list li i {
   padding-right: 5px;
 }
@@ -1849,6 +1854,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .active-icon,
 #user-social-panel .active-icon,
 #user-applications-panel .active-icon,
+#user-email-panel .active-icon,
 #user-ssh-panel .active-icon {
   width: 10px;
   height: 10px;
@@ -1861,6 +1867,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .ssh-content,
 #user-social-panel .ssh-content,
 #user-applications-panel .ssh-content,
+#user-email-panel .ssh-content,
 #user-ssh-panel .ssh-content {
   margin-left: 24px;
 }
@@ -1868,6 +1875,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .ssh-content .octicon,
 #user-social-panel .ssh-content .octicon,
 #user-applications-panel .ssh-content .octicon,
+#user-email-panel .ssh-content .octicon,
 #user-ssh-panel .ssh-content .octicon {
   margin-right: 4px;
 }
@@ -1875,16 +1883,19 @@ The register and sign-in page style
 #repo-hooks-history-panel .ssh-content .print,
 #user-social-panel .ssh-content .print,
 #user-applications-panel .ssh-content .print,
+#user-email-panel .ssh-content .print,
 #user-ssh-panel .ssh-content .print,
 #repo-hooks-panel .ssh-content .access,
 #repo-hooks-history-panel .ssh-content .access,
 #user-social-panel .ssh-content .access,
 #user-applications-panel .ssh-content .access,
+#user-email-panel .ssh-content .access,
 #user-ssh-panel .ssh-content .access,
 #repo-hooks-panel .ssh-content .activity,
 #repo-hooks-history-panel .ssh-content .activity,
 #user-social-panel .ssh-content .activity,
 #user-applications-panel .ssh-content .activity,
+#user-email-panel .ssh-content .activity,
 #user-ssh-panel .ssh-content .activity {
   color: #888;
 }
@@ -1892,6 +1903,7 @@ The register and sign-in page style
 #repo-hooks-history-panel .ssh-content .access,
 #user-social-panel .ssh-content .access,
 #user-applications-panel .ssh-content .access,
+#user-email-panel .ssh-content .access,
 #user-ssh-panel .ssh-content .access {
   max-width: 500px;
 }
@@ -1899,8 +1911,13 @@ The register and sign-in page style
 #repo-hooks-history-panel .ssh-btn,
 #user-social-panel .ssh-btn,
 #user-applications-panel .ssh-btn,
+#user-email-panel .ssh-btn,
 #user-ssh-panel .ssh-btn {
   margin-top: 6px;
+}
+#user-email-panel .setting-list .field {
+  padding: 8px 20px;
+  border-bottom: 1px solid #eaeaea;
 }
 .form-settings-add .panel-body {
   background-color: #FFF;

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -131,7 +131,7 @@ func SettingsAvatar(ctx *middleware.Context, form auth.UploadAvatarForm) {
 func SettingsEmails(ctx *middleware.Context) {
 	ctx.Data["Title"] = ctx.Tr("settings")
 	ctx.Data["PageIsUserSettings"] = true
-	ctx.Data["PageIsSettingsEmails"] = true
+	ctx.Data["PageIsSettingsEmail"] = true
 
 	var err error
 	ctx.Data["Emails"], err = models.GetEmailAddresses(ctx.User.Id)
@@ -147,7 +147,7 @@ func SettingsEmails(ctx *middleware.Context) {
 func SettingsEmailPost(ctx *middleware.Context, form auth.AddEmailForm) {
 	ctx.Data["Title"] = ctx.Tr("settings")
 	ctx.Data["PageIsUserSettings"] = true
-	ctx.Data["PageIsSettingsEmails"] = true
+	ctx.Data["PageIsSettingsEmail"] = true
 
 	var err error
 	ctx.Data["Emails"], err = models.GetEmailAddresses(ctx.User.Id)

--- a/templates/user/settings/email.tmpl
+++ b/templates/user/settings/email.tmpl
@@ -41,11 +41,8 @@
 							<p class="panel-header"><strong>{{.i18n.Tr "settings.add_new_email"}}</strong></p>
 							<p class="field">
                                 <label class="req" for="email">{{.i18n.Tr "email"}}</label>
-                                <input class="ipt ipt-radius" id="email" name="email" type="text" required />
-                            </p>
-                            <p class="field">
-                                <label></label>
-                                <button class="btn btn-green btn-radius" id="email-add-btn">{{.i18n.Tr "settings.add_email"}}</button>
+                                <input class="ipt ipt-radius" id="email" size="40" name="email" type="text" required />
+                                <button class="right btn btn-green btn-radius" id="email-add-btn">{{.i18n.Tr "settings.add_email"}}</button>
                             </p>
 							</form>
                         </ul>


### PR DESCRIPTION
This PR tries to improve the look and feel of the email settings page.

It aligns the design to the other settings pages, adds highlightning of the current item
and introduces sorting of the email adresses listed. The primary address will always be listed first with the
others following in lexical order.