### PR TITLE
Allow start.sh from any working directory

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,4 +12,4 @@ USER=$(whoami)
 HOME=$(grep "^$USER:" /etc/passwd | cut -d: -f6)
 export USER HOME PATH
 
-cd "$(pwd)" && exec ./gogs web
+cd "$(dirname "$0")/.." && exec ./gogs web


### PR DESCRIPTION
This change to start.sh allows it to be executed from any working directory and always reference the gogs binary in the parent directory. Very helpful when calling start.sh from an init script.