### PR TITLE
Fix in url if cache avatar is enabled

### DIFF
--- a/modules/avatar/avatar.go
+++ b/modules/avatar/avatar.go
@@ -38,10 +38,12 @@ import (
 
 var gravatarSource string
 
-func init() {
+func UpdateGravatarSource() {
 	gravatarSource = setting.GravatarSource
+	log.Debug("avatar.UpdateGravatarSource(gavatar source): %s", gravatarSource)
 	if !strings.HasPrefix(gravatarSource, "http:") {
 		gravatarSource = "http:" + gravatarSource
+		log.Debug("avatar.UpdateGravatarSource(update gavatar source): %s", gravatarSource)
 	}
 }
 
@@ -131,11 +133,13 @@ func (this *Avatar) Encode(wr io.Writer, size int) (err error) {
 
 // get image from gravatar.com
 func (this *Avatar) Update() {
+	UpdateGravatarSource()
 	thunder.Fetch(gravatarSource+this.Hash+"?"+this.reqParams,
 		this.imagePath)
 }
 
 func (this *Avatar) UpdateTimeout(timeout time.Duration) (err error) {
+	UpdateGravatarSource()
 	select {
 	case <-time.After(timeout):
 		err = fmt.Errorf("get gravatar image %s timeout", this.Hash)


### PR DESCRIPTION
Fixes a bug with the generation of addresses to download avatar.
For some reason, init() does not work.

    2015/01/19 20:31:30 [D] avatar.fetch(fetch new avatar): http:39b285bb1127ed8bbc927e9690f74e19?d=retro&r=pg&size=200
    2015/01/19 20:31:30 [T] avatar update error: Get http:39b285bb1127ed8bbc927e9690f74e19?d=retro&r=pg&size=200: http: no Host in request URL