### PR TITLE
Refactor collaborations into its own table

### DIFF
--- a/models/access.go
+++ b/models/access.go
@@ -78,3 +78,23 @@ func HasAccess(uname, repoName string, mode AccessType) (bool, error) {
 	}
 	return true, nil
 }
+
+// GetAccessibleRepositories finds all repositories where a user has access to,
+// besides his own.
+func (u *User) GetAccessibleRepositories() (map[*Repository]AccessType, error) {
+	accesses := make([]*Access, 0, 10)
+	if err := x.Find(&accesses, &Access{UserName: u.LowerName}); err != nil {
+		return nil, err
+	}
+
+	repos := make(map[*Repository]AccessType, len(accesses))
+	for _, access := range accesses {
+		repo, err := GetRepositoryByRef(access.RepoName)
+		if err != nil {
+			return nil, err
+		}
+		repos[repo] = access.Mode
+	}
+
+	return repos, nil
+}

--- a/models/issue.go
+++ b/models/issue.go
@@ -282,10 +282,10 @@ type IssueUser struct {
 }
 
 // NewIssueUserPairs adds new issue-user pairs for new issue of repository.
-func NewIssueUserPairs(rid, iid, oid, pid, aid int64, repoName string) (err error) {
-	iu := &IssueUser{IssueId: iid, RepoId: rid}
+func NewIssueUserPairs(repo *Repository, iid, oid, pid, aid int64) (err error) {
+	iu := &IssueUser{IssueId: iid, RepoId: repo.Id}
 
-	us, err := GetCollaborators(repoName)
+	us, err := repo.GetCollaborators()
 	if err != nil {
 		return err
 	}

--- a/models/repo.go
+++ b/models/repo.go
@@ -1065,71 +1065,74 @@ func GetRepositoryCount(user *User) (int64, error) {
 	return x.Count(&Repository{OwnerId: user.Id})
 }
 
-// GetCollaboratorNames returns a list of user name of repository's collaborators.
-func GetCollaboratorNames(repoName string) ([]string, error) {
-	accesses := make([]*Access, 0, 10)
-	if err := x.Find(&accesses, &Access{RepoName: strings.ToLower(repoName)}); err != nil {
+// GetCollaborators returns the collaborators for a repository
+func (r *Repository) GetCollaborators() ([]*User, error) {
+	collaborations := make([]*Collaboration, 0)
+	if err := x.Find(&collaborations, &Collaboration{RepoId: r.Id}); err != nil {
 		return nil, err
 	}
 
-	names := make([]string, len(accesses))
-	for i := range accesses {
-		names[i] = accesses[i].UserName
-	}
-	return names, nil
-}
-
-// CollaborativeRepository represents a repository with collaborative information.
-type CollaborativeRepository struct {
-	*Repository
-	CanPush bool
-}
-
-// GetCollaborativeRepos returns a list of repositories that user is collaborator.
-func GetCollaborativeRepos(uname string) ([]*CollaborativeRepository, error) {
-	uname = strings.ToLower(uname)
-	accesses := make([]*Access, 0, 10)
-	if err := x.Find(&accesses, &Access{UserName: uname}); err != nil {
-		return nil, err
-	}
-
-	repos := make([]*CollaborativeRepository, 0, 10)
-	for _, access := range accesses {
-		infos := strings.Split(access.RepoName, "/")
-		if infos[0] == uname {
-			continue
-		}
-
-		u, err := GetUserByName(infos[0])
+	users := make([]*User, len(collaborations))
+	for i, c := range collaborations {
+		user, err := GetUserById(c.UserId)
 		if err != nil {
 			return nil, err
 		}
-
-		repo, err := GetRepositoryByName(u.Id, infos[1])
-		if err != nil {
-			return nil, err
-		}
-		repo.Owner = u
-		repos = append(repos, &CollaborativeRepository{repo, access.Mode == WRITABLE})
+		users[i] = user
 	}
-	return repos, nil
+	return users, nil
 }
 
-// GetCollaborators returns a list of users of repository's collaborators.
-func GetCollaborators(repoName string) (us []*User, err error) {
-	accesses := make([]*Access, 0, 10)
-	if err = x.Find(&accesses, &Access{RepoName: strings.ToLower(repoName)}); err != nil {
-		return nil, err
+// Add collaborator and accompanying access
+func (r *Repository) AddCollaborator(u *User) error {
+	collaboration := &Collaboration{RepoId: r.Id, UserId: u.Id}
+
+	has, err := x.Get(collaboration)
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
 	}
 
-	us = make([]*User, len(accesses))
-	for i := range accesses {
-		us[i], err = GetUserByName(accesses[i].UserName)
+	if _, err = x.InsertOne(collaboration); err != nil {
+		return err
+	}
+
+	if err = r.GetOwner(); err != nil {
+		return err
+	}
+
+	return AddAccess(&Access{UserName: u.LowerName, RepoName: path.Join(r.Owner.LowerName, r.LowerName), Mode: WRITABLE})
+}
+
+// Delete collaborator and accompanying access
+func (r *Repository) DeleteCollaborator(u *User) error {
+	collaboration := &Collaboration{RepoId: r.Id, UserId: u.Id}
+
+	if has, err := x.Delete(collaboration); err != nil || has == 0 {
+		return err
+	}
+
+	if err := r.GetOwner(); err != nil {
+		return err
+	}
+
+	needDelete := true
+	if r.Owner.IsOrganization() {
+		auth, err := GetHighestAuthorize(r.Owner.Id, u.Id, r.Id, 0)
 		if err != nil {
-			return nil, err
+			return err
+		}
+		if auth > 0 {
+			needDelete = false
 		}
 	}
-	return us, nil
+	if needDelete {
+		return DeleteAccess(&Access{UserName: u.LowerName, RepoName: path.Join(r.Owner.LowerName, r.LowerName), Mode: WRITABLE})
+	}
+
+	return nil
 }
 
 type SearchOption struct {
@@ -1546,4 +1549,12 @@ func ForkRepository(u *User, oldRepo *Repository, name, desc string) (*Repositor
 	}
 
 	return repo, nil
+}
+
+// A Collaboration is a relation between an individual and a repository
+type Collaboration struct {
+	Id      int64
+	RepoId  int64     `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	UserId  int64     `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	Created time.Time `xorm:"CREATED"`
 }

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -174,7 +174,7 @@ func CreateIssue(ctx *middleware.Context) {
 		return
 	}
 
-	us, err := models.GetCollaborators(strings.TrimPrefix(ctx.Repo.RepoLink, "/"))
+	us, err := ctx.Repo.Repository.GetCollaborators()
 	if err != nil {
 		ctx.Handle(500, "issue.CreateIssue(GetCollaborators)", err)
 		return
@@ -218,7 +218,7 @@ func CreateIssuePost(ctx *middleware.Context, form auth.CreateIssueForm) {
 		return
 	}
 
-	_, err = models.GetCollaborators(strings.TrimPrefix(ctx.Repo.RepoLink, "/"))
+	_, err = ctx.Repo.Repository.GetCollaborators()
 	if err != nil {
 		send(500, nil, err)
 		return
@@ -246,8 +246,8 @@ func CreateIssuePost(ctx *middleware.Context, form auth.CreateIssueForm) {
 	if err := models.NewIssue(issue); err != nil {
 		send(500, nil, err)
 		return
-	} else if err := models.NewIssueUserPairs(issue.RepoId, issue.Id, ctx.Repo.Owner.Id,
-		ctx.User.Id, form.AssigneeId, ctx.Repo.Repository.Name); err != nil {
+	} else if err := models.NewIssueUserPairs(ctx.Repo.Repository, issue.Id, ctx.Repo.Owner.Id,
+		ctx.User.Id, form.AssigneeId); err != nil {
 		send(500, nil, err)
 		return
 	}
@@ -384,7 +384,7 @@ func ViewIssue(ctx *middleware.Context) {
 	}
 
 	// Get all collaborators.
-	ctx.Data["Collaborators"], err = models.GetCollaborators(strings.TrimPrefix(ctx.Repo.RepoLink, "/"))
+	ctx.Data["Collaborators"], err = ctx.Repo.Repository.GetCollaborators()
 	if err != nil {
 		ctx.Handle(500, "issue.CreateIssue(GetCollaborators)", err)
 		return
@@ -1122,18 +1122,18 @@ func IssueGetAttachment(ctx *middleware.Context) {
 
 // testing route handler for new issue ui page
 // todo : move to Issue() function
-func Issues2(ctx *middleware.Context){
-	ctx.HTML(200,"repo/issue2/list")
+func Issues2(ctx *middleware.Context) {
+	ctx.HTML(200, "repo/issue2/list")
 }
 
-func PullRequest2(ctx *middleware.Context){
-	ctx.HTML(200,"repo/pr2/list")
+func PullRequest2(ctx *middleware.Context) {
+	ctx.HTML(200, "repo/pr2/list")
 }
 
-func Labels2(ctx *middleware.Context){
-	ctx.HTML(200,"repo/issue2/labels")
+func Labels2(ctx *middleware.Context) {
+	ctx.HTML(200, "repo/issue2/labels")
 }
 
-func Milestones2(ctx *middleware.Context){
-	ctx.HTML(200,"repo/milestone2/list")
+func Milestones2(ctx *middleware.Context) {
+	ctx.HTML(200, "repo/milestone2/list")
 }

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"path"
 
 	"github.com/Unknwon/com"
 
@@ -170,19 +169,9 @@ func SettingsCollaboration(ctx *middleware.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.settings")
 	ctx.Data["PageIsSettingsCollaboration"] = true
 
-	repoLink := path.Join(ctx.Repo.Owner.LowerName, ctx.Repo.Repository.LowerName)
-
 	if ctx.Req.Method == "POST" {
 		name := strings.ToLower(ctx.Query("collaborator"))
 		if len(name) == 0 || ctx.Repo.Owner.LowerName == name {
-			ctx.Redirect(setting.AppSubUrl + ctx.Req.URL.Path)
-			return
-		}
-		has, err := models.HasAccess(name, repoLink, models.WRITABLE)
-		if err != nil {
-			ctx.Handle(500, "HasAccess", err)
-			return
-		} else if has {
 			ctx.Redirect(setting.AppSubUrl + ctx.Req.URL.Path)
 			return
 		}
@@ -205,9 +194,8 @@ func SettingsCollaboration(ctx *middleware.Context) {
 			return
 		}
 
-		if err = models.AddAccess(&models.Access{UserName: name, RepoName: repoLink,
-			Mode: models.WRITABLE}); err != nil {
-			ctx.Handle(500, "AddAccess", err)
+		if err = ctx.Repo.Repository.AddCollaborator(u); err != nil {
+			ctx.Handle(500, "AddCollaborator", err)
 			return
 		}
 
@@ -226,50 +214,27 @@ func SettingsCollaboration(ctx *middleware.Context) {
 	// Delete collaborator.
 	remove := strings.ToLower(ctx.Query("remove"))
 	if len(remove) > 0 && remove != ctx.Repo.Owner.LowerName {
-		needDelete := true
-		if ctx.User.IsOrganization() {
-			// Check if user belongs to a team that has access to this repository.
-			auth, err := models.GetHighestAuthorize(ctx.Repo.Owner.Id, ctx.User.Id, ctx.Repo.Repository.Id, 0)
-			if err != nil {
-				ctx.Handle(500, "GetHighestAuthorize", err)
-				return
-			}
-			if auth > 0 {
-				needDelete = false
-			}
+		u, err := models.GetUserByName(remove)
+		if err != nil {
+			ctx.Handle(500, "GetUserByName", err)
+			return
 		}
-
-		if needDelete {
-			if err := models.DeleteAccess(&models.Access{UserName: remove, RepoName: repoLink}); err != nil {
-				ctx.Handle(500, "DeleteAccess", err)
-				return
-			}
+		if err := ctx.Repo.Repository.DeleteCollaborator(u); err != nil {
+			ctx.Handle(500, "DeleteCollaborator", err)
+			return
 		}
 		ctx.Flash.Success(ctx.Tr("repo.settings.remove_collaborator_success"))
 		ctx.Redirect(ctx.Repo.RepoLink + "/settings/collaboration")
 		return
 	}
 
-	names, err := models.GetCollaboratorNames(repoLink)
+	users, err := ctx.Repo.Repository.GetCollaborators()
 	if err != nil {
 		ctx.Handle(500, "GetCollaborators", err)
 		return
 	}
 
-	collaborators := make([]*models.User, 0, len(names))
-	for _, name := range names {
-		u, err := models.GetUserByName(name)
-		if err != nil {
-			ctx.Handle(500, "GetUserByName", err)
-			return
-		}
-		// Does not show organization members.
-		if ctx.Repo.Owner.IsOrganization() && ctx.Repo.Owner.IsOrgMember(u.Id) {
-			continue
-		}
-		collaborators = append(collaborators, u)
-	}
-	ctx.Data["Collaborators"] = collaborators
+	ctx.Data["Collaborators"] = users
 	ctx.HTML(200, COLLABORATION)
 }
 

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -49,13 +49,19 @@ func Dashboard(ctx *middleware.Context) {
 	} else {
 		// Normal user.
 		ctxUser = ctx.User
-		collaborates, err := models.GetCollaborativeRepos(ctxUser.Name)
+		collaborates, err := ctx.User.GetAccessibleRepositories()
 		if err != nil {
-			ctx.Handle(500, "GetCollaborativeRepos", err)
+			ctx.Handle(500, "GetAccessibleRepositories", err)
 			return
 		}
-		ctx.Data["CollaborateCount"] = len(collaborates)
-		ctx.Data["CollaborativeRepos"] = collaborates
+
+		repositories := make([]*models.Repository, 0, len(collaborates))
+		for repo := range collaborates {
+			repositories = append(repositories, repo)
+		}
+
+		ctx.Data["CollaborateCount"] = len(repositories)
+		ctx.Data["CollaborativeRepos"] = repositories
 	}
 	ctx.Data["ContextUser"] = ctxUser
 


### PR DESCRIPTION
This PR introduces a new Collaboration struct which is a direct relation between a repository and a non-organization user. Introducing this table will make it much easier to refactor the access table.