### PR TITLE
fix error at admin/config

### DIFF
--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -61,7 +61,7 @@
                                     <dt>{{.i18n.Tr "admin.config.db_user"}}</dt>
                                     <dd>{{.DbCfg.User}}</dd>
                                     <dt>{{.i18n.Tr "admin.config.db_ssl_mode"}}</dt>
-                                    <dd>{{.DbCfg.SslMode}} {{.i18n.Tr "admin.config.db_ssl_mode_helper"}}</dd>
+                                    <dd>{{.DbCfg.SSLMode}} {{.i18n.Tr "admin.config.db_ssl_mode_helper"}}</dd>
                                     <dt>{{.i18n.Tr "admin.config.db_path"}}</dt>
                                     <dd>{{.DbCfg.Path}} {{.i18n.Tr "admin.config.db_path_helper"}}</dd>
                                 </dl>


### PR DESCRIPTION
Fix error at admin/config (wrong var name in template)
```
template: admin/config:64:48: executing "admin/config" at <.DbCfg.SslMode>: SslMode is not a field of struct type interface {}
```