### PR TITLE
Change SignedInUser to use the models/login.go UserSignIn

### DIFF
--- a/modules/auth/auth.go
+++ b/modules/auth/auth.go
@@ -108,17 +108,12 @@ func SignedInUser(req *http.Request, sess session.Store) (*models.User, bool) {
 			auths := strings.Fields(baHead)
 			if len(auths) == 2 && auths[0] == "Basic" {
 				uname, passwd, _ := base.BasicAuthDecode(auths[1])
-				u, err := models.GetUserByName(uname)
+				u, err := models.UserSignIn(uname, passwd)
 				if err != nil {
-					if err != models.ErrUserNotExist {
-						log.Error(4, "GetUserByName: %v", err)
-					}
+					log.Error(4, "GetUserByName: %v", err)
 					return nil, false
 				}
-
-				if u.ValidtePassword(passwd) {
-					return u, true
-				}
+				return u, true
 			}
 		}
 		return nil, false


### PR DESCRIPTION
This is a patch for #898 

I hope this is acceptable and works as expected. It should permit users to pull and push using non-local accounts over HTTP, without having to change the password in the local database.