### PR TITLE
Updated gogs.css - monospace font for hash

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1218,6 +1218,9 @@ The register and sign-in page style
 #repo-files-table {
   margin-bottom: 20px;
 }
+#repo-files-table .sha .label {
+font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+}
 #repo-files-table th,
 #repo-files-table td {
   text-align: left;


### PR DESCRIPTION
Updated gogs.css to set the font-family of .sha .label in the #repo-files-table to a monospace font to make it look nicer so the label boxes have the same width and don't differ by a few pixels.