### PR TITLE
Updated gogs.css - monospace font for hash

### DIFF
--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -247,6 +247,9 @@
 }
 #repo-files-table {
     margin-bottom: 20px;
+    .sha .label {
+     font-family: Monaco,Menlo,Consolas,"Courier New",monospace;   
+    }
     th, td {
         text-align: left;
         line-height: 32px;


### PR DESCRIPTION
Updated gogs.css to use monospaced font for sha hash label in repository view to make it look nicer because of equal label width.
Before:
![gogs3](https://cloud.githubusercontent.com/assets/9949033/6097306/8ec41584-afb9-11e4-88c4-2a42e34c6a63.png)
After:
![gogs4](https://cloud.githubusercontent.com/assets/9949033/6097309/93638746-afb9-11e4-90b0-0f305c5a3f98.png)
