### PR TITLE
Remove GOGS_CUSTOM and introduce config variable for CUSTOM_PATH

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -126,7 +126,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(i18n.I18n(i18n.Options{
 		SubURL:          setting.AppSubUrl,
 		Directory:       path.Join(setting.ConfRootPath, "locale"),
-		CustomDirectory: path.Join(setting.CustomPath, "conf/locale"),
+		CustomDirectory: path.Join(setting.CustomPath, "locale"),
 		Langs:           setting.Langs,
 		Names:           setting.Names,
 		Redirect:        true,

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -37,6 +37,10 @@ KEY_FILE = custom/https/key.pem
 ; Upper level of template and static file path
 ; default is the path where Gogs is executed
 STATIC_ROOT_PATH =
+; The location of the 'custom' directory. This directory can contain e.g. robots.txt
+; or specific gitignore files. By default it is the directory of the custom config file
+; (whose default is exe_path/custom/conf/app.ini)
+CUSTOM_PATH =
 ; Application level GZIP support
 ENABLE_GZIP = false
 ; Landing page for non-logged users, can be "home" or "explore"

--- a/models/repo.go
+++ b/models/repo.go
@@ -60,7 +60,7 @@ func LoadRepoConfig() {
 		if err != nil {
 			log.Fatal(4, "Fail to get %s files: %v", t, err)
 		}
-		customPath := path.Join(setting.CustomPath, "conf", t)
+		customPath := path.Join(setting.CustomPath, t)
 		if com.IsDir(customPath) {
 			customFiles, err := com.StatDir(customPath)
 			if err != nil {
@@ -464,7 +464,7 @@ func initRepository(f string, u *User, repo *Repository, initReadme bool, repoLa
 			}
 		} else {
 			// Check custom files.
-			filePath = path.Join(setting.CustomPath, "conf/gitignore", repoLang)
+			filePath = path.Join(setting.CustomPath, "gitignore", repoLang)
 			if com.IsFile(filePath) {
 				if err := com.Copy(filePath, targetPath); err != nil {
 					return err
@@ -485,7 +485,7 @@ func initRepository(f string, u *User, repo *Repository, initReadme bool, repoLa
 			}
 		} else {
 			// Check custom files.
-			filePath = path.Join(setting.CustomPath, "conf/license", license)
+			filePath = path.Join(setting.CustomPath, "license", license)
 			if com.IsFile(filePath) {
 				if err := com.Copy(filePath, targetPath); err != nil {
 					return err

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -169,13 +169,8 @@ func NewConfigContext() {
 		log.Fatal(4, "Fail to parse 'conf/app.ini': %v", err)
 	}
 
-	CustomPath = os.Getenv("GOGS_CUSTOM")
-	if len(CustomPath) == 0 {
-		CustomPath = path.Join(workDir, "custom")
-	}
-
 	if len(CustomConf) == 0 {
-		CustomConf = path.Join(CustomPath, "conf/app.ini")
+		CustomConf = path.Join(workDir, "custom", "conf", "app.ini")
 	}
 
 	if com.IsFile(CustomConf) {
@@ -219,6 +214,7 @@ func NewConfigContext() {
 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(workDir)
+	CustomPath = sec.Key("CUSTOM_PATH").MustString(path.Dir(CustomConf))
 	EnableGzip = sec.Key("ENABLE_GZIP").MustBool()
 
 	switch sec.Key("LANDING_PAGE").MustString("home") {


### PR DESCRIPTION
GOGS_CUSTOM environment variable will not be used anymore. robots.txt is now searched inside the custom/conf directory