### PR TITLE
Changes to repo-header-download-drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.db
 *.log
+log/
 custom/
 data/
 .vendor/

--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -1066,6 +1066,9 @@ The register and sign-in page style
 #repo-header-download-drop .btn > i {
   margin-right: 6px;
 }
+#repo-header-download-drop input {
+  cursor: default;
+}
 #repo-header-download-drop button,
 #repo-header-download-drop input {
   font-size: 11px;

--- a/public/ng/less/gogs/repository.less
+++ b/public/ng/less/gogs/repository.less
@@ -81,6 +81,9 @@
     .btn>i {
         margin-right: 6px;
     }
+    input {
+        cursor: default;
+    }
     button, input {
         font-size: 11px;
     }

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -22,7 +22,7 @@
                         <button class="btn btn-blue left btn-left-radius" id="repo-clone-ssh" data-link="{{$.CloneLink.SSH}}">SSH</button>
                         {{end}}
                         <button class="btn {{if $.DisableSSH}}btn-blue{{else}}btn-gray{{end}} left" id="repo-clone-https" data-link="{{$.CloneLink.HTTPS}}">HTTPS</button>
-                        <input id="repo-clone-url" class="ipt ipt-disabled left" value="{{if $.DisableSSH}}{{$.CloneLink.HTTPS}}{{else}}{{$.CloneLink.SSH}}{{end}}" readonly />
+                        <input id="repo-clone-url" class="ipt ipt-disabled left" value="{{if $.DisableSSH}}{{$.CloneLink.HTTPS}}{{else}}{{$.CloneLink.SSH}}{{end}}" onclick="this.select();" readonly />
                         <button id="repo-clone-copy" class="btn btn-black left btn-right-radius" data-copy-val="val" data-copy-from="#repo-clone-url" original-title="{{$.i18n.Tr "repo.click_to_copy"}}" data-original-title="{{$.i18n.Tr "repo.click_to_copy"}}" data-after-title="{{$.i18n.Tr "repo.copied"}}">{{$.i18n.Tr "repo.copy_link"}}</button>
                         <p class="text-center" id="repo-clone-help">{{$.i18n.Tr "repo.clone_helper" "http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository" | Str2html}}</p>
                         <hr/>


### PR DESCRIPTION
Changed the repo-header-download-drop url input to behave slightly different. When clicking on the url input it now selects the whole url and you can copy it manually too. (When using a Flash Blocker for example.). Also I have replaced the Red Circle cursor (due to the default disabled class) with the default one. The behavior is now the same as on github.com.
Before:
![gogs7](https://cloud.githubusercontent.com/assets/9949033/6142955/a07e2bee-b1c0-11e4-9974-6167ae8d8d19.png)
After:
![gogs6](https://cloud.githubusercontent.com/assets/9949033/6142956/a82ee7a2-b1c0-11e4-9632-95fbb436fa57.png)