### PR TITLE
Use client certificate for SMTP over TLS

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -105,6 +105,10 @@ SUBJECT = %(APP_NAME)s
 HOST =
 ; Do not verify the certificate of the server. Only use this for self-signed certificates
 SKIP_VERIFY = 
+; Use client certificate
+; USE_CERTIFICATE = true
+; CERT_FILE = custom/mailer/cert.pem
+; KEY_FILE = custom/mailer/key.pem
 ; Mail from address, RFC 5322. This can be just an email address, or the "Name" <email@example.com> format 
 FROM =
 ; Mailer user name and password

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -106,9 +106,9 @@ HOST =
 ; Do not verify the certificate of the server. Only use this for self-signed certificates
 SKIP_VERIFY = 
 ; Use client certificate
-; USE_CERTIFICATE = true
-; CERT_FILE = custom/mailer/cert.pem
-; KEY_FILE = custom/mailer/key.pem
+USE_CERTIFICATE = false
+CERT_FILE = custom/mailer/cert.pem
+KEY_FILE = custom/mailer/key.pem
 ; Mail from address, RFC 5322. This can be just an email address, or the "Name" <email@example.com> format 
 FROM =
 ; Mailer user name and password

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -72,15 +72,17 @@ func sendMail(settings *setting.Mailer, recipients []string, msgContent []byte) 
 		return err
 	}
 
-	cert, err := tls.LoadX509KeyPair(settings.CertFile, settings.KeyFile)
-	if err != nil {
-		return err
-	}
-
 	tlsconfig := &tls.Config{
 		InsecureSkipVerify: settings.SkipVerify,
 		ServerName:         host,
-		Certificates:       []tls.Certificate{cert},
+	}
+
+	if settings.UseCertificate {
+		cert, err := tls.LoadX509KeyPair(settings.CertFile, settings.KeyFile)
+		if err != nil {
+			return err
+		}
+		tlsconfig.Certificates = []tls.Certificate{cert}
 	}
 
 	conn, err := net.Dial("tcp", net.JoinHostPort(host, port))

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -72,9 +72,15 @@ func sendMail(settings *setting.Mailer, recipients []string, msgContent []byte) 
 		return err
 	}
 
+	cert, err := tls.LoadX509KeyPair(settings.CertFile, settings.KeyFile)
+	if err != nil {
+		return err
+	}
+
 	tlsconfig := &tls.Config{
 		InsecureSkipVerify: settings.SkipVerify,
 		ServerName:         host,
+		Certificates:       []tls.Certificate{cert},
 	}
 
 	conn, err := net.Dial("tcp", net.JoinHostPort(host, port))

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -451,6 +451,7 @@ type Mailer struct {
 	From              string
 	User, Passwd      string
 	SkipVerify        bool
+	UseCertificate    bool
 	CertFile, KeyFile string
 }
 
@@ -479,13 +480,14 @@ func newMailService() {
 	}
 
 	MailService = &Mailer{
-		Name:       sec.Key("NAME").MustString(AppName),
-		Host:       sec.Key("HOST").String(),
-		User:       sec.Key("USER").String(),
-		Passwd:     sec.Key("PASSWD").String(),
-		SkipVerify: sec.Key("SKIP_VERIFY").MustBool(),
-		CertFile:   sec.Key("CERT_FILE").String(),
-		KeyFile:    sec.Key("KEY_FILE").String(),
+		Name:           sec.Key("NAME").MustString(AppName),
+		Host:           sec.Key("HOST").String(),
+		User:           sec.Key("USER").String(),
+		Passwd:         sec.Key("PASSWD").String(),
+		SkipVerify:     sec.Key("SKIP_VERIFY").MustBool(),
+		UseCertificate: sec.Key("USE_CERTIFICATE").MustBool(),
+		CertFile:       sec.Key("CERT_FILE").String(),
+		KeyFile:        sec.Key("KEY_FILE").String(),
 	}
 	MailService.From = sec.Key("FROM").MustString(MailService.User)
 	log.Info("Mail Service Enabled")

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -446,11 +446,12 @@ func newSessionService() {
 
 // Mailer represents mail service.
 type Mailer struct {
-	Name         string
-	Host         string
-	From         string
-	User, Passwd string
-	SkipVerify   bool
+	Name              string
+	Host              string
+	From              string
+	User, Passwd      string
+	SkipVerify        bool
+	CertFile, KeyFile string
 }
 
 type OauthInfo struct {
@@ -483,6 +484,8 @@ func newMailService() {
 		User:       sec.Key("USER").String(),
 		Passwd:     sec.Key("PASSWD").String(),
 		SkipVerify: sec.Key("SKIP_VERIFY").MustBool(),
+		CertFile:   sec.Key("CERT_FILE").String(),
+		KeyFile:    sec.Key("KEY_FILE").String(),
 	}
 	MailService.From = sec.Key("FROM").MustString(MailService.User)
 	log.Info("Mail Service Enabled")


### PR DESCRIPTION
Some SMTP servers may be configured to check client certificate and do not accept arbitrary self-signed ones.

This pull request adds new keys to app.ini to specify cert and key files in the same way as for HTTPS certificate. Key names are the same as for HTTPS (CERT_FILE, KEY_FILE), so in the case there is a single certificate for both HTTPS and mail, it can be specified once in the default section of the app.ini.