### PR TITLE
Fix that owners also see actions on their repositories

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -103,7 +103,12 @@ func Dashboard(ctx *middleware.Context) {
 	feeds := make([]*models.Action, 0, len(actions))
 	for _, act := range actions {
 		if act.IsPrivate {
-			if has, _ := models.HasAccess(ctx.User, &models.Repository{Id: act.RepoId, IsPrivate: true}, models.ACCESS_MODE_READ); !has {
+			repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
+			// This prevents having to retrieve the repository for each action
+			if act.RepoUserName == ctx.User.LowerName {
+				repo.OwnerId = ctx.User.Id
+			}
+			if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
 				continue
 			}
 		}
@@ -210,11 +215,12 @@ func Profile(ctx *middleware.Context) {
 				if !ctx.IsSigned {
 					continue
 				}
-				if has, _ := models.HasAccess(ctx.User,
-					&models.Repository{
-						Id:        act.RepoId,
-						IsPrivate: true,
-					}, models.ACCESS_MODE_READ); !has {
+				repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
+				// This prevents having to retrieve the repository for each action
+				if act.RepoUserName == ctx.User.LowerName {
+					repo.OwnerId = ctx.User.Id
+				}
+				if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
 					continue
 				}
 			}

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -103,14 +103,14 @@ func Dashboard(ctx *middleware.Context) {
 	feeds := make([]*models.Action, 0, len(actions))
 	for _, act := range actions {
 		if act.IsPrivate {
-			repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
 			// This prevents having to retrieve the repository for each action
-			if act.RepoUserName == ctx.User.LowerName {
-				repo.OwnerId = ctx.User.Id
+			repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
+			if act.RepoUserName != ctx.User.LowerName {
+				if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
+					continue
+				}
 			}
-			if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
-				continue
-			}
+
 		}
 		// FIXME: cache results?
 		u, err := models.GetUserByName(act.ActUserName)
@@ -215,14 +215,14 @@ func Profile(ctx *middleware.Context) {
 				if !ctx.IsSigned {
 					continue
 				}
-				repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
 				// This prevents having to retrieve the repository for each action
-				if act.RepoUserName == ctx.User.LowerName {
-					repo.OwnerId = ctx.User.Id
+				repo := &models.Repository{Id: act.RepoId, IsPrivate: true}
+				if act.RepoUserName != ctx.User.LowerName {
+					if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
+						continue
+					}
 				}
-				if has, _ := models.HasAccess(ctx.User, repo, models.ACCESS_MODE_READ); !has {
-					continue
-				}
+
 			}
 			// FIXME: cache results?
 			u, err := models.GetUserByName(act.ActUserName)


### PR DESCRIPTION
This is a balance between speed and nice code, where speed has won. To prevent a repository query for each action the ownername is match with the current user.

It would be "cleaner" or "better" if we fetch the repository each time. Another option is to add the RepoOwnerID to action