### PR TITLE
Remove the "PHP" style formatting function

### DIFF
--- a/modules/base/template.go
+++ b/modules/base/template.go
@@ -126,8 +126,13 @@ var TemplateFuncs template.FuncMap = map[string]interface{}{
 		return a + b
 	},
 	"ActionIcon": ActionIcon,
-	"DateFormat": DateFormat,
-	"List":       List,
+	"DateFmtLong": func(t time.Time) string {
+		return t.Format(time.RFC1123Z)
+	},
+	"DateFmtShort": func(t time.Time) string {
+		return t.Format("Jan 02, 2006")
+	},
+	"List": List,
 	"Mail2Domain": func(mail string) string {
 		if !strings.Contains(mail, "@") {
 			return "try.gogs.io"

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -126,7 +126,7 @@ func VerifyTimeLimitCode(data string, minutes int, code string) bool {
 	retCode := CreateTimeLimitCode(data, minutes, start)
 	if retCode == code && minutes > 0 {
 		// check time is expired or not
-		before, _ := DateParse(start, "YmdHi")
+		before, _ := time.ParseInLocation("200601021504", start, time.Local)
 		now := time.Now()
 		if before.Add(time.Minute*time.Duration(minutes)).Unix() > now.Unix() {
 			return true
@@ -141,7 +141,7 @@ const TimeLimitCodeLength = 12 + 6 + 40
 // create a time limit code
 // code format: 12 length date time string + 6 minutes string + 40 sha1 encoded string
 func CreateTimeLimitCode(data string, minutes int, startInf interface{}) string {
-	format := "YmdHi"
+	format := "200601021504"
 
 	var start, end time.Time
 	var startStr, endStr string
@@ -149,16 +149,16 @@ func CreateTimeLimitCode(data string, minutes int, startInf interface{}) string 
 	if startInf == nil {
 		// Use now time create code
 		start = time.Now()
-		startStr = DateFormat(start, format)
+		startStr = start.Format(format)
 	} else {
 		// use start string create code
 		startStr = startInf.(string)
-		start, _ = DateParse(startStr, format)
-		startStr = DateFormat(start, format)
+		start, _ = time.ParseInLocation(format, startStr, time.Local)
+		startStr = start.Format(format)
 	}
 
 	end = start.Add(time.Minute * time.Duration(minutes))
-	endStr = DateFormat(end, format)
+	endStr = end.Format(format)
 
 	// create sha1 encode string
 	sh := sha1.New()
@@ -419,59 +419,4 @@ func Subtract(left interface{}, right interface{}) interface{} {
 	} else {
 		return fleft + float64(rleft) - (fright + float64(rright))
 	}
-}
-
-// DateFormat pattern rules.
-var datePatterns = []string{
-	// year
-	"Y", "2006", // A full numeric representation of a year, 4 digits   Examples: 1999 or 2003
-	"y", "06", //A two digit representation of a year   Examples: 99 or 03
-
-	// month
-	"m", "01", // Numeric representation of a month, with leading zeros 01 through 12
-	"n", "1", // Numeric representation of a month, without leading zeros   1 through 12
-	"M", "Jan", // A short textual representation of a month, three letters Jan through Dec
-	"F", "January", // A full textual representation of a month, such as January or March   January through December
-
-	// day
-	"d", "02", // Day of the month, 2 digits with leading zeros 01 to 31
-	"j", "2", // Day of the month without leading zeros 1 to 31
-
-	// week
-	"D", "Mon", // A textual representation of a day, three letters Mon through Sun
-	"l", "Monday", // A full textual representation of the day of the week  Sunday through Saturday
-
-	// time
-	"g", "3", // 12-hour format of an hour without leading zeros    1 through 12
-	"G", "15", // 24-hour format of an hour without leading zeros   0 through 23
-	"h", "03", // 12-hour format of an hour with leading zeros  01 through 12
-	"H", "15", // 24-hour format of an hour with leading zeros  00 through 23
-
-	"a", "pm", // Lowercase Ante meridiem and Post meridiem am or pm
-	"A", "PM", // Uppercase Ante meridiem and Post meridiem AM or PM
-
-	"i", "04", // Minutes with leading zeros    00 to 59
-	"s", "05", // Seconds, with leading zeros   00 through 59
-
-	// time zone
-	"T", "MST",
-	"P", "-07:00",
-	"O", "-0700",
-
-	// RFC 2822
-	"r", time.RFC1123Z,
-}
-
-// Parse Date use PHP time format.
-func DateParse(dateString, format string) (time.Time, error) {
-	replacer := strings.NewReplacer(datePatterns...)
-	format = replacer.Replace(format)
-	return time.ParseInLocation(format, dateString, time.Local)
-}
-
-// Date takes a PHP like date func to Go's time format.
-func DateFormat(t time.Time, format string) string {
-	replacer := strings.NewReplacer(datePatterns...)
-	format = replacer.Replace(format)
-	return t.Format(format)
 }

--- a/templates/admin/auth/list.tmpl
+++ b/templates/admin/auth/list.tmpl
@@ -34,8 +34,8 @@
 					                            <td><a href="{{AppSubUrl}}/admin/auths/{{.Id}}">{{.Name}}</a></td>
 					                            <td>{{.TypeString}}</td>
 					                            <td><i class="fa fa{{if .IsActived}}-check{{end}}-square-o"></i></td>
-					                            <td><span title="{{DateFormat .Updated "r"}}">{{DateFormat .Updated "M d, Y"}}</span></td>
-					                            <td><span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span></td>
+					                            <td><span title="{{DateFmtLong .Updated}}">{{DateFmtShort .Updated}}</span></td>
+					                            <td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>
 					                            <td><a href="{{AppSubUrl}}/admin/auths/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
 					                        </tr>
 					                        {{end}}

--- a/templates/admin/org/list.tmpl
+++ b/templates/admin/org/list.tmpl
@@ -35,7 +35,7 @@
 					                            <td>{{.NumTeams}}</td>
 					                            <td>{{.NumMembers}}</td>
 					                            <td>{{.NumRepos}}</td>
-					                            <td><span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span></td>
+					                            <td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>
 					                        </tr>
 					                        {{end}}
 					                    </tbody>

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -37,7 +37,7 @@
 					                            <td>{{.NumWatches}}</td>
 					                            <td>{{.NumStars}}</td>
 					                            <td>{{.NumIssues}}</td>
-					                            <td><span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span></td>
+					                            <td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>
 					                        </tr>
 					                        {{end}}
 					                    </tbody>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -37,7 +37,7 @@
 					                            <td><i class="fa fa{{if .IsActive}}-check{{end}}-square-o"></i></td>
 					                            <td><i class="fa fa{{if .IsAdmin}}-check{{end}}-square-o"></i></td>
 					                            <td>{{.NumRepos}}</td>
-					                            <td><span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span></td>
+					                            <td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created }}</span></td>
 					                            <td><a href="{{AppSubUrl}}/admin/users/{{.Id}}"><i class="fa fa-pencil-square-o"></i></a></td>
 					                        </tr>
 					                        {{end}}

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -28,7 +28,7 @@
                     {{if .Owner.Website}}
                     <li class="list-group-item"><i class="octicon octicon-link"></i>&nbsp;&nbsp;<a target="_blank" href="{{.Owner.Website}}">{{.Owner.Website}}</a></li>
                     {{end}}
-                    <li class="list-group-item"><i class="octicon octicon-clock"></i>&nbsp;&nbsp;{{.i18n.Tr "user.join_on"}} {{DateFormat .Owner.Created "M d, Y"}}</li>
+                    <li class="list-group-item"><i class="octicon octicon-clock"></i>&nbsp;&nbsp;{{.i18n.Tr "user.join_on"}} {{DateFmtShort .Owner.Created}}</li>
                 </ul>
                 <hr>
                 <ul class="list-no-style">

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -22,7 +22,7 @@
                                 <i class="fa fa-send fa-2x left"></i>
                                 <div class="ssh-content left">
                                     <p><strong>{{.Name}}</strong></p>
-                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span> —  <i class="octicon octicon-info"></i>{{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} {{DateFormat .Updated "M d, Y"}}{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i></p>
+                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span> —  <i class="octicon octicon-info"></i>{{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} {{DateFmtShort .Updated}}{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i></p>
                                 </div>
                                 <a href="{{AppSubUrl}}/user/settings/applications?remove={{.Id}}">
                                 	<button class="btn btn-small btn-red btn-radius ssh-btn right">{{$.i18n.Tr "settings.delete_token"}}</button>

--- a/templates/user/settings/social.tmpl
+++ b/templates/user/settings/social.tmpl
@@ -18,7 +18,7 @@
                                 <div class="ssh-content left">
                                     <p><strong>{{Oauth2Name .Type}}</strong></p>
                                     <p class="print">{{.Identity}}</p>
-                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span> —  <i class="octicon octicon-info"></i>{{$.i18n.Tr "settings.last_used"}} {{DateFormat .Updated "M d, Y"}}</i></p>
+                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span> —  <i class="octicon octicon-info"></i>{{$.i18n.Tr "settings.last_used"}} {{DateFmtShort .Updated}}</i></p>
                                 </div>
                                 <a class="right btn btn-small btn-red btn-header btn-radius" href="{{AppSubUrl}}/user/settings/social?remove={{.Id}}">{{$.i18n.Tr "settings.unbind"}}</a>
                             </li>

--- a/templates/user/settings/sshkeys.tmpl
+++ b/templates/user/settings/sshkeys.tmpl
@@ -23,7 +23,7 @@
                                 <div class="ssh-content left">
                                     <p><strong>{{.Name}}</strong></p>
                                     <p class="print">{{.Fingerprint}}</p>
-                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFormat .Created "r"}}">{{DateFormat .Created "M d, Y"}}</span> —  <i class="octicon octicon-info"></i>{{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span title="{{DateFormat .Updated "r"}}">{{DateFormat .Updated "M d, Y"}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i></p>
+                                    <p class="activity"><i>{{$.i18n.Tr "settings.add_on"}} <span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span> —  <i class="octicon octicon-info"></i>{{if .HasUsed}}{{$.i18n.Tr "settings.last_used"}} <span title="{{DateFmtLong .Updated}}">{{DateFmtShort .Updated}}</span>{{else}}{{$.i18n.Tr "settings.no_activity"}}{{end}}</i></p>
                                 </div>
                                 <form action="{{AppSubUrl}}/user/settings/ssh" method="post">
                                     {{$.CsrfTokenHtml}}


### PR DESCRIPTION
The "PHP" formatting function doesn't add anything, except an undocumented date format.

All usages in the templates have been replaced with DateFmtShort and DateFmtLong for convenience.