### PR TITLE
Remove GoGet option from repository and handle it with ?go-get=1 instead

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -281,8 +281,6 @@ init_readme = Initialize this repository with a README.md
 create_repo = Create Repository
 default_branch = Default Branch
 mirror_interval = Mirror Interval (hour)
-goget_meta = Go-Get Meta
-goget_meta_helper = This repository will be <span class="label label-blue label-radius">Go-Getable</span>
 
 need_auth = Need Authorization
 migrate_type = Migration Type

--- a/models/repo.go
+++ b/models/repo.go
@@ -154,7 +154,6 @@ type Repository struct {
 
 	IsPrivate bool
 	IsBare    bool
-	IsGoget   bool
 
 	IsMirror bool
 	*Mirror  `xorm:"-"`

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -52,7 +52,6 @@ type RepoSettingForm struct {
 	Branch      string `form:"branch"`
 	Interval    int    `form:"interval"`
 	Private     bool   `form:"private"`
-	GoGet       bool   `form:"goget"`
 }
 
 func (f *RepoSettingForm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -394,8 +394,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 		}
 		ctx.Data["CloneLink"] = ctx.Repo.CloneLink
 
-		if ctx.Repo.Repository.IsGoget {
-			ctx.Data["GoGetLink"] = fmt.Sprintf("%s%s/%s", setting.AppUrl, u.LowerName, repo.LowerName)
+		if ctx.Query("go-get") == "1" {
 			ctx.Data["GoGetImport"] = fmt.Sprintf("%s/%s/%s", setting.Domain, u.LowerName, repo.LowerName)
 		}
 

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
-	"path"
 
 	"github.com/Unknwon/com"
 
@@ -84,7 +84,6 @@ func SettingsPost(ctx *middleware.Context, form auth.RepoSettingForm) {
 		ctx.Repo.Repository.Description = form.Description
 		ctx.Repo.Repository.Website = form.Website
 		ctx.Repo.Repository.IsPrivate = form.Private
-		ctx.Repo.Repository.IsGoget = form.GoGet
 		if err := models.UpdateRepository(ctx.Repo.Repository); err != nil {
 			ctx.Handle(404, "UpdateRepository", err)
 			return

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -9,7 +9,7 @@
 		<meta name="description" content="Gogs(Go Git Service) is a GitHub-like clone in the Go Programming Language" />
 		<meta name="keywords" content="go, git">
 		<meta name="_csrf" content="{{.CsrfToken}}" />
-		{{if .Repository.IsGoget}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
+		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 
 		 <!-- Stylesheets -->
 		{{if CdnMode}}

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -7,7 +7,7 @@
 		<meta name="description" content="Gogs(Go Git Service) a painless self-hosted Git Service written in Go" />
 		<meta name="keywords" content="go, git, self-hosted, gogs">
 		<meta name="_csrf" content="{{.CsrfToken}}" />
-		{{if .Repository.IsGoget}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
+		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 
 		<link rel="shortcut icon" href="{{AppSubUrl}}/img/favicon.png" />
 

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -59,11 +59,6 @@
 					                <input class="ipt-chk" id="visibility" name="private" type="checkbox" {{if .Repository.IsPrivate}}checked{{end}} />
 					                <span>{{.i18n.Tr "repo.visiblity_helper" | Str2html}}</span>
 					            </div>
-					            <div class="field">
-					                <label for="goget">{{.i18n.Tr "repo.goget_meta"}}</label>
-					                <input class="ipt-chk" id="goget" name="goget" type="checkbox" {{if .Repository.IsGoget}}checked{{end}} />
-					                <span>{{.i18n.Tr "repo.goget_meta_helper" | Str2html}}</span>
-					            </div>
 	                            <div class="field">
 	                                <span class="form-label"></span>
 	                                <button class="btn btn-green btn-large btn-radius" id="change-reponame-btn" href="#change-reponame-modal">{{.i18n.Tr "repo.settings.update_settings"}}</button>


### PR DESCRIPTION
The normal go get protocol is to show the go-import meta tag when ?go-get=1 is appended to the url. This commit implements that behaviour and cleans the go-get option from the repository settings page.