### PR TITLE
Bugfix for wrong label count

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -561,7 +561,7 @@ func GetLabels(repoId int64) ([]*Label, error) {
 
 // UpdateLabel updates label information.
 func UpdateLabel(l *Label) error {
-	_, err := x.Id(l.Id).Update(l)
+	_, err := x.Id(l.Id).AllCols().Update(l)
 	return err
 }
 


### PR DESCRIPTION
According to the xorm logs, xorm ignores the num_issues and num_closed_issues columns when updating, even though the values did change.

This leads to wrong number of issues per label.

Listing the num_issue columns explicitly fixes the issue. 

However, we should consider just asking the DB for a correct count to fix existing, wrong counts. The query is basically instant for all use cases.

fixes #933 

\cc @Unknwon 