### PR TITLE
[docker] openssh-client provide ssh-keygen.

### DIFF
--- a/docker/blocks/docker_gogs/Dockerfile
+++ b/docker/blocks/docker_gogs/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:14.04
 
 RUN apt-get update && apt-get install -y \
 		build-essential ca-certificates curl \
-		bzr git mercurial \
+		bzr git mercurial openssh-client\
 		--no-install-recommends
 
 ENV GOLANG_VERSION 1.3

--- a/docker/blocks/docker_gogs_dev/Dockerfile
+++ b/docker/blocks/docker_gogs_dev/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:14.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 		apt-get install -qy \
 		build-essential ca-certificates curl \
-		bzr git mercurial \
+		bzr git mercurial openssh-client\
 		--no-install-recommends
 
 ENV GOLANG_VERSION 1.3


### PR DESCRIPTION
 GOGS needs that binary to add a ssh key to a user