### PR TITLE
Properly calculate the number of open issues per label

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -182,6 +182,17 @@ func updateIssuesCommit(userId, repoId int64, repoUserName, repoName string, com
 				}
 				issue.IsClosed = true
 
+				if err = issue.GetLabels(); err != nil {
+					return err
+				}
+				for _, label := range issue.Labels {
+					label.NumClosedIssues++
+
+					if err = UpdateLabel(label); err != nil {
+						return err
+					}
+				}
+
 				if err = UpdateIssue(issue); err != nil {
 					return err
 				} else if err = UpdateIssueUserPairsByStatus(issue.Id, issue.IsClosed); err != nil {
@@ -229,6 +240,17 @@ func updateIssuesCommit(userId, repoId int64, repoUserName, repoName string, com
 					continue
 				}
 				issue.IsClosed = false
+
+				if err = issue.GetLabels(); err != nil {
+					return err
+				}
+				for _, label := range issue.Labels {
+					label.NumClosedIssues--
+
+					if err = UpdateLabel(label); err != nil {
+						return err
+					}
+				}
 
 				if err = UpdateIssue(issue); err != nil {
 					return err

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -549,6 +549,7 @@ func UpdateIssueLabel(ctx *middleware.Context) {
 				label.NumClosedIssues--
 			}
 		}
+
 		if err = models.UpdateLabel(label); err != nil {
 			ctx.Handle(500, "issue.UpdateIssueLabel(UpdateLabel)", err)
 			return
@@ -765,6 +766,24 @@ func Comment(ctx *middleware.Context) {
 			} else if err = models.UpdateIssueUserPairsByStatus(issue.Id, issue.IsClosed); err != nil {
 				send(500, nil, err)
 				return
+			}
+
+			if err = issue.GetLabels(); err != nil {
+				send(500, nil, err)
+				return
+			}
+
+			for _, label := range issue.Labels {
+				if issue.IsClosed {
+					label.NumClosedIssues++
+				} else {
+					label.NumClosedIssues--
+				}
+
+				if err = models.UpdateLabel(label); err != nil {
+					send(500, nil, err)
+					return
+				}
 			}
 
 			// Change open/closed issue counter for the associated milestone


### PR DESCRIPTION
Instead of doing this on multiple places all over the place I've opt'd
to just fetching the correct issue counts from the database. This only
happens when calling UpdateIssueCounts()

should fix #933