### PR TITLE
Exclude HTML tags from markdown post-processing

### DIFF
--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -112,9 +112,9 @@ const HtmlAttributePattern =
     `(?:` + // optional value
       `\s*=\s*` +
       `(?P<attr_value>` +
-        `"[^\x00\p{Cc}"]*"` + // double-quoted
-        `'[^\x00\p{Cc}']*'` + // single-quoted
-        `[^\x00\p{Cc}\s"'=<>\x60]+` +   // unquoted
+        `"[^\x00\p{Cc}"]*"|` + // double-quoted
+        `'[^\x00\p{Cc}']*'|` + // single-quoted
+        `[^\x00\p{Cc}\s"'=<>\x60]+` + // unquoted
       `)` +
     `)?` +
   `)`

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -257,7 +257,7 @@ func CreateIssuePost(ctx *middleware.Context, form auth.CreateIssueForm) {
 	}
 
 	// Update mentions.
-	ms := base.MentionPattern.FindAllString(issue.Content, -1)
+	ms := base.MentionRegex.FindAllString(issue.Content, -1)
 	if len(ms) > 0 {
 		for i := range ms {
 			ms[i] = ms[i][1:]
@@ -820,7 +820,7 @@ func Comment(ctx *middleware.Context) {
 			}
 
 			// Update mentions.
-			ms = base.MentionPattern.FindAllString(issue.Content, -1)
+			ms = base.MentionRegex.FindAllString(issue.Content, -1)
 			if len(ms) > 0 {
 				for i := range ms {
 					ms[i] = ms[i][1:]


### PR DESCRIPTION
Ok, I took a stab at this. Please review carefully, as I have no prior experience programming in go.

The general idea is to split the input into HTML and not-HTML. `GetPostProcessableParts` is fairly ugly, but I don't know that it can really be helped.

This would fix #637 and #738.