### PR TITLE
Project-level Dockerfile & docker-compose script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM google/golang:latest
+
+ENV TAGS="sqlite redis memcache cert" USER="git" HOME="/home/git"
+
+COPY  . /gopath/src/github.com/gogits/gogs/
+WORKDIR /gopath/src/github.com/gogits/gogs/
+
+RUN  go get -v -tags="$TAGS" github.com/gogits/gogs \
+  && go build -tags="$TAGS" \
+  && useradd -d $HOME -m $USER \
+  && chown -R $USER .
+
+USER $USER
+
+ENTRYPOINT [ "./gogs" ]
+
+CMD [ "web" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+web:
+  build: .
+  links:
+    - mysql
+  ports:
+    - "3000:3000"
+
+mysql:
+  image: mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD=gogs
+    - MYSQL_DATABASE=gogs


### PR DESCRIPTION
Using this is easy:

1. Download & install `docker-compose` using instructions from here: https://docs.docker.com/compose/install/
2. Run `docker-compose up` from the project root
3. At the /install page, use "MySQL" for the database with the "root" user and "gogs" as the root password

That should be all you need to do to get running with Docker 1.5.0.