### PR TITLE
Remove use of PID and fix stderr redirection

### DIFF
--- a/scripts/init/centos/gogs
+++ b/scripts/init/centos/gogs
@@ -28,7 +28,6 @@ GOGS_HOME=/home/git/gogs
 GOGS_PATH=${GOGS_HOME}/$NAME
 GOGS_USER=git
 SERVICENAME="Gogs Go Git Service"
-PID=/var/run/$NAME.pid
 LOCKFILE=/var/lock/subsys/gogs
 LOGFILE=${GOGS_HOME}/log/gogs.log
 RETVAL=0
@@ -39,7 +38,7 @@ RETVAL=0
 # Don't do anything if nothing is installed
 [ -x ${GOGS_PATH} ] || exit 0
 
-DAEMON_OPTS=""
+DAEMON_OPTS="--check $NAME"
 
 # Set additional options, if any
 [ ! -z "$GOGS_USER" ] && DAEMON_OPTS="$DAEMON_OPTS --user=${GOGS_USER}"
@@ -47,8 +46,7 @@ DAEMON_OPTS=""
 start() {
   cd ${GOGS_HOME}
   echo -n "Starting ${SERVICENAME}: "
-  daemon $DAEMON_OPTS  --pidfile=${PID} "${GOGS_PATH} web 2>&1 > ${LOGFILE} &"
-  echo $! > ${PID}
+  daemon $DAEMON_OPTS "${GOGS_PATH} web > ${LOGFILE} 2>&1 &"
   RETVAL=$?
   echo
   [ $RETVAL = 0 ] && touch ${LOCKFILE}
@@ -59,10 +57,10 @@ start() {
 stop() {
   cd ${GOGS_HOME}
         echo -n "Shutting down ${SERVICENAME}: "
-        killproc -p ${PID} ${NAME}
+        killproc ${NAME}
         RETVAL=$?
         echo
-        [ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PID}
+        [ $RETVAL = 0 ] && rm -f ${LOCKFILE} 
 }
 
 case "$1" in
@@ -74,7 +72,7 @@ case "$1" in
         stop
         ;;
     status)
-        status -p ${PID} ${NAME}
+        status ${NAME}
         ;;
     restart)
         stop


### PR DESCRIPTION
I tested the script in a Centos 6.6 server and it didn't work. Looks like `$!` didn't write the pid. After removing the use of pid it worked correctly.  
Also, the redirection should be `> ${LOGFILE} 2>&1` instead of `2>&1 > ${LOGFILE}` (see http://stackoverflow.com/a/637838/237761)