### PR TITLE
Add function in cron to autofix counters in repository

### DIFF
--- a/modules/cron/manager.go
+++ b/modules/cron/manager.go
@@ -19,6 +19,7 @@ func NewCronContext() {
 	if setting.Git.Fsck.Enable {
 		c.AddFunc("Repository health check", fmt.Sprintf("@every %dh", setting.Git.Fsck.Interval), models.GitFsck)
 	}
+	c.AddFunc("Check repository statistics", "@every 24h", models.CheckRepoStats)
 	c.Start()
 }
 


### PR DESCRIPTION
Add function in cron to autofix counters in repository after erros in db

```
MariaDB [gogs_git]> select r.id, (select count(*) from star s where s.repo_id=r.id) as stars,r.num_stars,(select count(*) from watch w where w.repo_id=r.id) as watchs,r.num_watches from repository r limit 10;
+----+-------+-----------+--------+-------------+
| id | stars | num_stars | watchs | num_watches |
+----+-------+-----------+--------+-------------+
|  2 |     0 |         0 |      0 |           0 |
|  7 |     0 |         0 |      1 |           1 |
|  8 |     0 |         0 |      1 |           0 |
| 10 |     0 |         0 |      1 |           0 |
| 11 |     0 |         0 |      1 |           0 |
| 12 |     0 |         0 |      1 |           0 |
| 14 |     0 |         0 |      1 |           0 |
| 15 |     1 |         1 |      1 |           0 |
| 16 |     0 |         0 |      0 |          -1 |
| 17 |     0 |         0 |      1 |           0 |
+----+-------+-----------+--------+-------------+
```