### PR TITLE
Fixed minor gramatical error in the US install success msg

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -83,7 +83,7 @@ invalid_repo_path = Repository root path is invalid: %v
 run_user_not_match = Run user isn't the current user: %s -> %s
 save_config_failed = Fail to save configuration: %v
 invalid_admin_setting = Admin account setting is invalid: %v
-install_success = Welcome! We're glad that you choose Gogs, have fun and take care.
+install_success = Welcome! We're glad that you chose Gogs, have fun and take care.
 
 [home]
 uname_holder = Username or E-mail


### PR DESCRIPTION
choose should be in the past tense form of "chose" 