### PR TITLE
Do not hardcode your personal path to gogs executable

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -56,7 +56,7 @@ func handleServerConn(keyId string, chans <-chan ssh.NewChannel) {
 				case "exec":
 					os.Setenv("SSH_ORIGINAL_COMMAND", strings.TrimLeft(payload, "'("))
 					log.Info("Payload: %v", strings.TrimLeft(payload, "'("))
-					cmd := exec.Command("/Users/jiahuachen/Applications/Go/src/github.com/gogits/gogs/gogs", "serv", "key-"+keyId)
+					cmd := exec.Command(os.Args[0], "serv", "key-"+keyId)
 					cmd.Stdout = channel
 					cmd.Stdin = channel
 					cmd.Stderr = channel.Stderr()


### PR DESCRIPTION
Do not hardcode your personal path to gogs executable.
Use the path of current gogs instead.