### PR TITLE
Set Content-Type to text/plain for http status 401

### DIFF
--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -139,6 +139,13 @@ func (ctx *Context) Handle(status int, title string, err error) {
 	ctx.HTML(status, base.TplName(fmt.Sprintf("status/%d", status)))
 }
 
+func (ctx *Context) HandleText(status int, title string) {
+	if (status / 100 == 4) || (status / 100 == 5) {
+		log.Error(4, "%s", title)
+	}
+	ctx.RenderData(status, []byte(title))
+}
+
 func (ctx *Context) HandleAPI(status int, obj interface{}) {
 	var message string
 	if err, ok := obj.(error); ok {

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -96,12 +96,12 @@ func Http(ctx *middleware.Context) {
 		// FIXME: middlewares/context.go did basic auth check already,
 		// maybe could use that one.
 		if len(auths) != 2 || auths[0] != "Basic" {
-			ctx.Handle(401, "no basic auth and digit auth", nil)
+			ctx.HandleText(401, "no basic auth and digit auth")
 			return
 		}
 		authUsername, authPasswd, err = base.BasicAuthDecode(auths[1])
 		if err != nil {
-			ctx.Handle(401, "no basic auth and digit auth", nil)
+			ctx.HandleText(401, "no basic auth and digit auth")
 			return
 		}
 
@@ -116,7 +116,7 @@ func Http(ctx *middleware.Context) {
 			token, err := models.GetAccessTokenBySha(authUsername)
 			if err != nil {
 				if err == models.ErrAccessTokenNotExist {
-					ctx.Handle(401, "invalid token", nil)
+					ctx.HandleText(401, "invalid token")
 				} else {
 					ctx.Handle(500, "GetAccessTokenBySha", err)
 				}
@@ -138,23 +138,23 @@ func Http(ctx *middleware.Context) {
 
 			has, err := models.HasAccess(authUser, repo, tp)
 			if err != nil {
-				ctx.Handle(401, "no basic auth and digit auth", nil)
+				ctx.HandleText(401, "no basic auth and digit auth")
 				return
 			} else if !has {
 				if tp == models.ACCESS_MODE_READ {
 					has, err = models.HasAccess(authUser, repo, models.ACCESS_MODE_WRITE)
 					if err != nil || !has {
-						ctx.Handle(401, "no basic auth and digit auth", nil)
+						ctx.HandleText(401, "no basic auth and digit auth")
 						return
 					}
 				} else {
-					ctx.Handle(401, "no basic auth and digit auth", nil)
+					ctx.HandleText(401, "no basic auth and digit auth")
 					return
 				}
 			}
 
 			if !isPull && repo.IsMirror {
-				ctx.Handle(401, "can't push to mirror", nil)
+				ctx.HandleText(401, "can't push to mirror")
 				return
 			}
 		}


### PR DESCRIPTION
Set `Content-Type` to `text/plain` for http status 401
This is because git command line shows the failure reason only if `Content-Type` is `text/plain`.