### PR TITLE
Remove extra space from ssh authentication message

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -102,7 +102,7 @@ func runServ(c *cli.Context) {
 
 	cmd := os.Getenv("SSH_ORIGINAL_COMMAND")
 	if cmd == "" {
-		println("Hi", user.Name, "! You've successfully authenticated, but Gogs does not provide shell access.")
+		fmt.Printf("Hi, %s! You've successfully authenticated, but Gogs does not provide shell access.\n", user.Name)
 		if user.IsAdmin {
 			println("If this is unexpected, please log in with password and setup Gogs under another user.")
 		}


### PR DESCRIPTION
This simply changes the message that a user gets when connection via ssh without a given command from

> Hi user ! You've successfully authenticated, but Gogs does not provide shell access.

to

> Hi, user! You've successfully authenticated, but Gogs does not provide shell access.

[Plenks](https://en.wikipedia.org/wiki/Plenken) are evil ;)