### PR TITLE
Display author's name on explore page

### DIFF
--- a/templates/explore/repos.tmpl
+++ b/templates/explore/repos.tmpl
@@ -2,25 +2,25 @@
 {{template "ng/base/header" .}}
 <div id="setting-wrapper" class="main-wrapper">
     <div id="org-setting" class="container clear">
-	    {{template "explore/nav" .}}
+        {{template "explore/nav" .}}
         <div class="grid-4-5 left">
             <div class="setting-content">
-            	<div id="org-repo-list">
-					{{range .Repos}}
-					<div class="org-repo-item">
-			            <ul class="org-repo-status right">
-			                <li><i class="octicon octicon-star"></i> {{.NumStars}}</li>
-			                <li><i class="octicon octicon-git-branch"></i> {{.NumForks}}</li>
-			            </ul>
-				    <h2>
-				        <a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Owner.Name}} / {{.Name}}</a>
-				    </h2>
-						<p class="org-repo-description">{{.Description}}</p>
-						<p class="org-repo-updated">{{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Updated $.i18n.Lang}}</p>
-					</div>
-					{{end}}
-            	</div>
-			</div>
+                <div id="org-repo-list">
+                    {{range .Repos}}
+                    <div class="org-repo-item">
+                        <ul class="org-repo-status right">
+                            <li><i class="octicon octicon-star"></i> {{.NumStars}}</li>
+                            <li><i class="octicon octicon-git-branch"></i> {{.NumForks}}</li>
+                        </ul>
+                        <h2>
+                            <a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Owner.Name}} / {{.Name}}</a>
+                        </h2>
+                        <p class="org-repo-description">{{.Description}}</p>
+                        <p class="org-repo-updated">{{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Updated $.i18n.Lang}}</p>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/explore/repos.tmpl
+++ b/templates/explore/repos.tmpl
@@ -12,7 +12,9 @@
 			                <li><i class="octicon octicon-star"></i> {{.NumStars}}</li>
 			                <li><i class="octicon octicon-git-branch"></i> {{.NumForks}}</li>
 			            </ul>
-						<h2><a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></h2>
+				    <h2>
+				        <a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Owner.Name}} / {{.Name}}</a>
+				    </h2>
 						<p class="org-repo-description">{{.Description}}</p>
 						<p class="org-repo-updated">{{$.i18n.Tr "org.repo_updated"}} {{TimeSince .Updated $.i18n.Lang}}</p>
 					</div>


### PR DESCRIPTION
This simply changes the way the Explore page is displayed, allowing the viewer to see the author's name next to repository name.