### PR TITLE
in routers/repo/download.go, don't set mime type, let go figure it out.

### DIFF
--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -198,7 +198,7 @@ func RenderRawMarkdown(body []byte, urlPrefix string) []byte {
 	extensions |= blackfriday.EXTENSION_FENCED_CODE
 	extensions |= blackfriday.EXTENSION_AUTOLINK
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
-	extensions |= blackfriday.EXTENSION_HARD_LINE_BREAK
+	//extensions |= blackfriday.EXTENSION_HARD_LINE_BREAK
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
 	extensions |= blackfriday.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK
 

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -27,7 +27,6 @@ func ServeBlob(ctx *middleware.Context, blob *git.Blob) error {
 
 	_, isTextFile := base.IsTextFile(buf)
 	_, isImageFile := base.IsImageFile(buf)
-	ctx.Resp.Header().Set("Content-Type", "text/plain")
 	if !isTextFile && !isImageFile {
 		ctx.Resp.Header().Set("Content-Disposition", "attachment; filename="+path.Base(ctx.Repo.TreeName))
 		ctx.Resp.Header().Set("Content-Transfer-Encoding", "binary")


### PR DESCRIPTION
don't set mime type to text/plain. This will break serving e.g. raw images, html, etc

According to http://golang.org/pkg/net/http/#DetectContentType
"If the Header does not contain a Content-Type line, Write adds
a Content-Type set to the result of passing the initial 512 bytes
of written data to DetectContentType."