### PR TITLE
Add/Fix app sub url for color picker js lib inclusion

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -96,7 +96,7 @@
         </div>
     </div>
 </div>
-<script src="/js/bootstrap-colorpicker.min.js"></script>
+<script src="{{AppSubUrl}}/js/bootstrap-colorpicker.min.js"></script>
 <script>
     $(function(){
         $('.label-color-picker').colorpicker({


### PR DESCRIPTION
Currently, the js file doesn't take into account the possibility of a sub url being used (wich is my case :) wich prevents its inclusion.