### PR TITLE
fix systemd "Trailing garbage, ignoring." warning.

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -14,7 +14,7 @@ Group=git
 WorkingDirectory=/home/git/gogs
 ExecStart=/home/git/gogs/gogs web
 Restart=always
-Environment="USER=git","HOME=/home/git"
+Environment=USER=git HOME=/home/git
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Environment should be a space-separated list instead of comma-separated.
No need for double quoting when the values don't contain spaces.

http://0pointer.de/public/systemd-man/systemd.exec.html#Environment=