### PR TITLE
Add file permalink button

### DIFF
--- a/conf/locale/locale_de-DE.ini
+++ b/conf/locale/locale_de-DE.ini
@@ -341,6 +341,7 @@ releases=Veröffentlichungen
 file_raw=Roh
 file_history=Verlauf
 file_view_raw=Ansicht Roh
+file_permalink=Permalink
 
 commits.commits=Commits
 commits.search=Durchsuche Commits

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -343,6 +343,7 @@ releases = Releases
 file_raw = Raw
 file_history = History
 file_view_raw = View Raw
+file_permalink = Permalink
 
 commits.commits = Commits
 commits.search = Search commits

--- a/conf/locale/locale_es-ES.ini
+++ b/conf/locale/locale_es-ES.ini
@@ -343,6 +343,7 @@ releases=Releases
 file_raw=Raw
 file_history=Histórico
 file_view_raw=Ver Raw
+file_permalink=Permalink
 
 commits.commits=Commits
 commits.search=Buscar Commits

--- a/conf/locale/locale_fr-FR.ini
+++ b/conf/locale/locale_fr-FR.ini
@@ -341,6 +341,7 @@ releases=Publications
 file_raw=Raw
 file_history=Historique
 file_view_raw=Voir le Raw
+file_permalink=Permalink
 
 commits.commits=Commissions
 commits.search=Rechercher des commissions

--- a/conf/locale/locale_ja-JP.ini
+++ b/conf/locale/locale_ja-JP.ini
@@ -341,6 +341,7 @@ releases=リリース
 file_raw=生データ
 file_history=履歴
 file_view_raw=生データを見る
+file_permalink=Permalink
 
 commits.commits=コミット
 commits.search=コミットの検索

--- a/conf/locale/locale_lv-LV.ini
+++ b/conf/locale/locale_lv-LV.ini
@@ -341,6 +341,7 @@ releases=Laidieni
 file_raw=Neapstrādāts
 file_history=Vēsture
 file_view_raw=Rādīt neapstrādātu
+file_permalink=Permalink
 
 commits.commits=Revīzijas
 commits.search=Meklēt revīzijas

--- a/conf/locale/locale_nl-NL.ini
+++ b/conf/locale/locale_nl-NL.ini
@@ -343,6 +343,7 @@ releases=Publicaties
 file_raw=Ruwe
 file_history=Geschiedenis
 file_view_raw=Weergave ruwe
+file_permalink=Permalink
 
 commits.commits=Commits
 commits.search=Zoeken

--- a/conf/locale/locale_pl-PL.ini
+++ b/conf/locale/locale_pl-PL.ini
@@ -343,6 +343,7 @@ releases=Wydania
 file_raw=Czysty
 file_history=Historia
 file_view_raw=Zobacz czysty
+file_permalink=Permalink
 
 commits.commits=Commity
 commits.search=Przeszukaj commity

--- a/conf/locale/locale_pt-BR.ini
+++ b/conf/locale/locale_pt-BR.ini
@@ -341,6 +341,7 @@ releases=Lançamentos
 file_raw=Cru
 file_history=Histórico
 file_view_raw=Ver cru
+file_permalink=Permalink
 
 commits.commits=Commits
 commits.search=Pesquisar commits

--- a/conf/locale/locale_ru-RU.ini
+++ b/conf/locale/locale_ru-RU.ini
@@ -341,6 +341,7 @@ releases=Релизы
 file_raw=Исходник
 file_history=История
 file_view_raw=Посмотреть исходник
+file_permalink=Permalink
 
 commits.commits=Коммиты
 commits.search=Поиск коммитов

--- a/conf/locale/locale_zh-CN.ini
+++ b/conf/locale/locale_zh-CN.ini
@@ -343,6 +343,7 @@ releases=版本发布
 file_raw=原始文件
 file_history=文件历史
 file_view_raw=查看原始文件
+file_permalink=Permalink
 
 commits.commits=次代码提交
 commits.search=搜索提交历史

--- a/conf/locale/locale_zh-HK.ini
+++ b/conf/locale/locale_zh-HK.ini
@@ -341,6 +341,7 @@ releases=版本發佈
 file_raw=原始文件
 file_history=文件歷史
 file_view_raw=查看原始文件
+file_permalink=Permalink
 
 commits.commits=次代碼提交
 commits.search=搜索提交歷史

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -12,6 +12,11 @@
             <strong class="file-name">{{.FileName}}</strong><span class="file-size">{{FileSize .FileSize}}</span>
 	    {{end}}
         {{if not .ReadmeInList}}
+            {{if not .IsCommit}}
+                <a class="right" href="{{.RepoLink}}/src/{{.CommitId}}/{{.TreeName}}">
+                    <button class="btn btn-medium btn-gray btn-right-radius btn-comb">{{.i18n.Tr "repo.file_permalink"}}</button>
+                </a>
+            {{end}}
             <a class="right" href="{{.RepoLink}}/commits/{{EscapePound .BranchName}}/{{.TreeName}}">
                 <button class="btn btn-medium btn-gray btn-right-radius btn-comb">{{.i18n.Tr "repo.file_history"}}</button>
             </a>


### PR DESCRIPTION
The button appears when a file is viewed in a branch or a tag. It points
to a URL containing the branch's (or tag's) current commit id so that
it'll always point to the same content.