### PR TITLE
allow to specify WorkDir via env var

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -162,8 +162,12 @@ func ExecPath() (string, error) {
 
 // WorkDir returns absolute path of work directory.
 func WorkDir() (string, error) {
-	execPath, err := ExecPath()
-	return path.Dir(strings.Replace(execPath, "\\", "/", -1)), err
+	work := os.Getenv("WORK_DIR")
+	if len(work) == 0 {
+		execPath, err := ExecPath()
+		return path.Dir(strings.Replace(execPath, "\\", "/", -1)), err
+	}
+	return work, nil
 }
 
 func forcePathSeparator(path string) {


### PR DESCRIPTION
Sometimes (when package software) binaries lie on /usr/bin/ or /bin/, some path can be disable for execute for security reason, so providing WorkDir as env var may be very useful.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>