### PR TITLE
update ng/css/gogs.css for the new repo icon

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -866,7 +866,7 @@ ol.linenums {
   border-top-right-radius: .3em;
 }
 #dashboard-new-repo .octicon {
-  font-size: 2em;
+  font-size: 1.5rem;
 }
 #dashboard-new-repo-menu {
   top: 33px;


### PR DESCRIPTION
the icon was oversized and running out of the new repository "button", the resizing centers it vertically and fits better with the rest of the similar content