### PR TITLE
changing concordance and the first letter to upper-case

### DIFF
--- a/conf/locale/locale_pt-BR.ini
+++ b/conf/locale/locale_pt-BR.ini
@@ -247,7 +247,7 @@ social_desc=Esta é uma lista de contas sociais. Remova qualquer ligação que v
 unbind=Desvincular
 unbind_success=A conta social foi desvinculada.
 
-manage_access_token=Gerenciar Tokens de Acesso pessoais
+manage_access_token=Gerenciar Tokens de Acesso Pessoal
 generate_new_token=Gerar novo Token
 tokens_desc=Tokens gerados por você que podem ser usados para acessar a API Gogs.
 new_token_desc=Por enquanto, todo token terá acesso completo à sua conta.


### PR DESCRIPTION
In addition I want to make a proposal: In portuguese it is better to leave some technical terms in english. I realize that you are using "Branch" as "Ramo", we all know this term as branch here in Brazil.
If you agree i can make the change.