### PR TITLE
fix .keys route

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -152,6 +152,7 @@ func ShowSSHKeys(ctx *middleware.Context, uid int64) {
 	var buf bytes.Buffer
 	for i := range keys {
 		buf.WriteString(keys[i].OmitEmail())
+		buf.WriteString("\n")
 	}
 	ctx.RenderData(200, buf.Bytes())
 }


### PR DESCRIPTION
This change fixes the output from /{{ username }}.keys so that it can work in
a ~/.ssh/authorized_keys file