### PR TITLE
Fix command used by FreeBSD init script

### DIFF
--- a/scripts/init/freebsd/gogs
+++ b/scripts/init/freebsd/gogs
@@ -21,7 +21,7 @@ load_rc_config $name
 : ${gogs_enable:="NO"}
 : ${gogs_directory:="/home/git"}
 
-command="${gogs_directory}/scripts/start.sh"
+command="${gogs_directory}/gogs web"
 
 pidfile="${gogs_directory}/${name}.pid"
 


### PR DESCRIPTION
I recently installed Gogs on a FreeBSD system and found that the provided init script refers to start.sh which does not exist any more (since 6c84223). This change gets it working again.

Thanks.