### PR TITLE
#1361 Bugfix constructing SSH address with default port 

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -247,7 +247,7 @@ func (repo *Repository) CloneLink() (cl CloneLink, err error) {
 	if setting.SSHPort != 22 {
 		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSHDomain, setting.SSHPort, repo.Owner.LowerName, repo.LowerName)
 	} else {
-		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSHDomain, repo.Owner.LowerName, repo.LowerName)
+		cl.SSH = fmt.Sprintf("ssh://%s@%s/%s/%s.git", setting.RunUser, setting.SSHDomain, repo.Owner.LowerName, repo.LowerName)
 	}
 	cl.HTTPS = fmt.Sprintf("%s%s/%s.git", setting.AppUrl, repo.Owner.LowerName, repo.LowerName)
 	return cl, nil


### PR DESCRIPTION
Now, Gogs renders the right ssh clone address when running the ssh deamon on the default port.

Issue #1361 (https://github.com/gogits/gogs/issues/1361)