### PR TITLE
Prevent browsers from leaking referrer headers

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -6,6 +6,7 @@
 	<meta name="author" content="Gogs - Go Git Service" />
 	<meta name="description" content="Gogs(Go Git Service) a painless self-hosted Git Service written in Go" />
 	<meta name="keywords" content="go, git, self-hosted, gogs">
+	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />
 	{{if .GoGetImport}}
 	<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">

--- a/templates/base/head_old.tmpl
+++ b/templates/base/head_old.tmpl
@@ -8,6 +8,7 @@
         <meta name="author" content="Gogs - Go Git Service" />
 		<meta name="description" content="Gogs(Go Git Service) is a GitHub-like clone in the Go Programming Language" />
 		<meta name="keywords" content="go, git">
+		<meta name="referrer" content="no-referrer" />
 		<meta name="_csrf" content="{{.CsrfToken}}" />
 		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -6,6 +6,7 @@
         <meta name="author" content="Gogs - Go Git Service" />
 		<meta name="description" content="Gogs(Go Git Service) a painless self-hosted Git Service written in Go" />
 		<meta name="keywords" content="go, git, self-hosted, gogs">
+		<meta name="referrer" content="no-referrer" />
 		<meta name="_csrf" content="{{.CsrfToken}}" />
 		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
 


### PR DESCRIPTION
This commit disables the Referrer header normally sent by browsers.

Previously it was possible for private repo names, filenames etc. to be revealed to third-party sites. For example, if a readme or comment contained an external link then clicking on it would send the Gogs URL to that site. Users might not expect this to happen, especially for private repos.

The meta tag used here is part of the upcoming [Referrer Policy](https://w3c.github.io/webappsec/specs/referrer-policy/) spec. It's already implemented in Firefox and Chrome. (Chrome still sends referrers for embedded content such as images, but hopefully this will be fixed soon.)

Other options I considered were:

- Setting a Content-Security-Policy HTTP header, however the meta tag was simpler to implement.
- Setting a Content-Security-Policy meta tag. Also a good option but I went for `<meta name="referrer">` because it is a more straightforward standard which only covers referrers, unlike CSP.

Thanks for maintaining Gogs!