### PR TITLE
Fixed issues spanish localization

### DIFF
--- a/conf/locale/locale_es-ES.ini
+++ b/conf/locale/locale_es-ES.ini
@@ -354,6 +354,34 @@ commits.date=Fecha
 commits.older=Anterior
 commits.newer=Posterior
 
+issues.new = Nueva Incidencia
+issues.new_label = Nueva Etiqueta
+issues.new_label_placeholder = Nombre etiqueta...
+issues.open_tab = %d abiertas
+issues.close_tab = %d cerradas
+issues.filter_label = Etiqueta
+issues.filter_label_no_select = Ninguna etiqueta seleccionada
+issues.filter_milestone = Milestone
+issues.filter_assignee = Asignada por
+issues.filter_type = Tipo
+issues.filter_type.all_issues = Todas las incidencias
+issues.filter_type.assigned_to_you = Asignada a ti
+issues.filter_type.created_by_you = Creada por ti
+issues.filter_type.mentioning_you = Citado en
+issues.opened_by = abierta %[1]s por <a href="/%[2]s">%[2]s</a>
+issues.previous = Página Anterior
+issues.next = Página Siguiente
+issues.label_title = Nombre etiqueta
+issues.label_color = Color etiqueta
+issues.label_count = %d etiquetas
+issues.label_open_issues = %d incidencias abiertas
+issues.label_edit = Editar
+issues.label_delete = Borrar
+issues.label_modify = Modificación de Etiqueta
+issues.label_deletion = Borrado de Etiqueta
+issues.label_deletion_desc = Al borrar la etiqueta su información será eliminada de todas las incidencias relacionadas. Desea continuar?
+issues.label_deletion_success = Etiqueta borrada con éxito!
+
 settings=Configuración
 settings.options=Opciones
 settings.collaboration=Colaboración


### PR DESCRIPTION
The spanish localization file doesn't include the strings that are already localized in issues templates.

The bindata.go file contains hexadecimal values where someone could include fake data so I think the needed go-bindata should be done by project owner in a different commit. In my opinion is reasonable to do it this way. Hope that is ok.