### PR TITLE
User Issues Template fix

### DIFF
--- a/templates/user/issues.tmpl
+++ b/templates/user/issues.tmpl
@@ -25,7 +25,7 @@
 		        </div>
 		        <div class="issues list-group">
 		            {{range .Issues}}{{if .}}
-		            <div class="list-group-item issue-item" id="issue-{{.Id}}" onclick="window.location.href='{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}'">
+		            <div class="list-group-item issue-item" id="issue-{{.ID}}" onclick="window.location.href='{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}'">
 		                <span class="number pull-right">#{{.Index}}</span>
 		                <h5 class="title"><a href="{{AppSubUrl}}/{{.Repo.Owner.Name}}/{{.Repo.Name}}/issues/{{.Index}}">{{.Name}}</a></h5>
 		                <p class="info">


### PR DESCRIPTION
```
template: user/issues:28:66: executing "user/issues" at <.Id>: Id is not a field of struct type *models.Issue
```

On the template we have to use ID instead of Id

The code sometimes use Id in some structures and ID in others. Even on same file like in `models/issue.go`. It is not something good and it is easy to make a mistake later.