### PR TITLE
Allow explicit charset/codepage setting for ANSI source files to alle…

### DIFF
--- a/modules/base/template.go
+++ b/modules/base/template.go
@@ -55,6 +55,9 @@ func ShortSha(sha1 string) string {
 func DetectEncoding(content []byte) (string, error) {
 	detector := chardet.NewTextDetector()
 	result, err := detector.DetectBest(content)
+	if result.Charset == "ISO-8859-1" {
+		return setting.AnsiCharset, err
+	}
 	return result.Charset, err
 }
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -84,6 +84,7 @@ var (
 	// Repository settings.
 	RepoRootPath string
 	ScriptType   string
+	AnsiCharset  string
 
 	// UI settings.
 	IssuePagingNum int
@@ -312,6 +313,7 @@ func NewConfigContext() {
 		RepoRootPath = path.Clean(RepoRootPath)
 	}
 	ScriptType = sec.Key("SCRIPT_TYPE").MustString("bash")
+	AnsiCharset = sec.Key("ANSI_CHARSET").MustString("ISO-8859-1")
 
 	// UI settings.
 	IssuePagingNum = Cfg.Section("ui").Key("ISSUE_PAGING_NUM").MustInt(10)


### PR DESCRIPTION
…viate issue #1088 

This is a simple fix to alleviate charset issues with ANSI (single-byte) files for old languages in online view file and diffs.

The trouble with auto-detection per se is that most of the source files in any programming language are usually in English. Only a small portion of the files (usually in string literals) can be for instance in cyrillic letters for Russion.

Current auto-detection is based on confidence levels and string literals are usually much less that language keywords in English, thus it fairly confidently defaults to ISO-8859-1 which is useless.

This patch allows to swap ISO-8859-1 with any other charset at service level as a whole by configuring `ANSI_CHARSET` value in `[repository]` section (ANSI files in all projects are affected). Obviously best would be to be able to configure this on a per project level but I'm not sure how this can be done.