### PR TITLE
Allow file and directory names to contain percent character

### DIFF
--- a/modules/base/template.go
+++ b/modules/base/template.go
@@ -178,7 +178,7 @@ var TemplateFuncs template.FuncMap = map[string]interface{}{
 	"Oauth2Name":            Oauth2Name,
 	"ToUtf8":                ToUtf8,
 	"EscapePound": func(str string) string {
-		return strings.Replace(str, "#", "%23", -1)
+		return strings.Replace(strings.Replace(str, "%", "%25", -1), "#", "%23", -1)
 	},
 	"RenderCommitMessage": RenderCommitMessage,
 }

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -48,7 +48,7 @@
                     {{ $l := Subtract $n 1}}
                     {{range $i, $v := .Treenames}}
                         {{if eq $i $l}}
-                        <span class="bread">{{EscapePound $v}}</span>
+                        <span class="bread">{{$v}}</span>
                         {{else}}
                         <span class="bread"><a href="{{EscapePound $.BranchLink}}/{{index $.Paths $i}}">{{$v}}</a></span>
                         {{end}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -50,7 +50,7 @@
                     <span class="octicon octicon-file-{{if or $entry.IsDir}}directory{{else}}text{{end}}"></span>
                 </td>
                 <td class="name">
-                    <a href="{{EscapePound $.BranchLink}}/{{$.TreePath}}{{$entry.Name}}" class="text-truncate">{{$entry.Name}}</a>
+                    <a href="{{EscapePound $.BranchLink}}/{{EscapePound $.TreePath}}{{EscapePound $entry.Name}}" class="text-truncate">{{$entry.Name}}</a>
                 </td>
                 {{end}}
                 <td class="sha">


### PR DESCRIPTION
This is a quick fix for #1137

`EscapePound` could be expanded to full blown url_encode probably using URL from `net/url` but I'm not sure how this will affect performance as it's a fairly frequently used function in templates.

Speaking of templates, every href attribute has to use `EscapePound` on user generated content i.e. various names (repo, user, directory, file) or risk invalid links.