### PR TITLE
Show pagination only if needed on repo issues page

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -87,6 +87,7 @@
       {{end}}
 			
 			{{with .Page}}
+			{{if gt .Total 1}}
 			<div class="center page buttons">
 				<div class="ui borderless pagination menu">
 				  <a class="{{if not .HasPrevious}}disabled{{end}} item" {{if .HasPrevious}}href="{{$.RepoLink}}/issues?type={{$.ViewType}}&state={{$.State}}&labels={{$.SelectLabels}}&page={{.Previous}}"{{end}}>
@@ -104,6 +105,7 @@
 				  </a>
 				</div>
 			</div>
+			{{end}}
 			{{end}}
 		</div>
 	</div>


### PR DESCRIPTION
On repository issues page only show the pagination if needed. It is needed if one of the following conditions is true:
* It is not the first page (not IsFirst) because in that case is needed always.
* Or if we are in the first page (previous condition is false and that's why this second condition is evaluated, so it is the first page) and has more than one page (HasNext).
