### PR TITLE
Factor out function to get the current user

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogits/gogs/modules/bindata"
 	"github.com/gogits/gogs/modules/log"
 	// "github.com/gogits/gogs/modules/ssh"
+	"github.com/gogits/gogs/modules/user"
 )
 
 type Scheme string
@@ -309,10 +310,7 @@ func NewConfigContext() {
 	}[Cfg.Section("time").Key("FORMAT").MustString("RFC1123")]
 
 	RunUser = Cfg.Section("").Key("RUN_USER").String()
-	curUser := os.Getenv("USER")
-	if len(curUser) == 0 {
-		curUser = os.Getenv("USERNAME")
-	}
+	curUser := user.CurrentUsername()
 	// Does not check run user when the install lock is off.
 	if InstallLock && RunUser != curUser {
 		log.Fatal(4, "Expect user(%s) but current user is: %s", RunUser, curUser)

--- a/modules/user/user.go
+++ b/modules/user/user.go
@@ -1,0 +1,18 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+       "os"
+)
+
+func CurrentUsername() string {
+	curUserName := os.Getenv("USER")
+	if len(curUserName) > 0 {
+		return curUserName
+	}
+
+	return os.Getenv("USERNAME")
+}

--- a/routers/install.go
+++ b/routers/install.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gogits/gogs/modules/middleware"
 	"github.com/gogits/gogs/modules/setting"
 	"github.com/gogits/gogs/modules/social"
+	"github.com/gogits/gogs/modules/user"
 )
 
 const (
@@ -111,10 +112,7 @@ func Install(ctx *middleware.Context) {
 	// Note(unknwon): it's hard for Windows users change a running user,
 	// 	so just use current one if config says default.
 	if setting.IsWindows && setting.RunUser == "git" {
-		form.RunUser = os.Getenv("USER")
-		if len(form.RunUser) == 0 {
-			form.RunUser = os.Getenv("USERNAME")
-		}
+		form.RunUser = user.CurrentUsername()
 	} else {
 		form.RunUser = setting.RunUser
 	}
@@ -201,10 +199,7 @@ func InstallPost(ctx *middleware.Context, form auth.InstallForm) {
 	}
 
 	// Check run user.
-	curUser := os.Getenv("USER")
-	if len(curUser) == 0 {
-		curUser = os.Getenv("USERNAME")
-	}
+	curUser := user.CurrentUsername()
 	if form.RunUser != curUser {
 		ctx.Data["Err_RunUser"] = true
 		ctx.RenderWithErr(ctx.Tr("install.run_user_not_match", form.RunUser, curUser), INSTALL, &form)


### PR DESCRIPTION
The same logic was duplicated in three places. Factor it
out in a single utility and improve it to also try
os/user.Current(). We need all the fallbacks because in
some cases it is better to not rely on the env vars, but
in other cases os/user.Current() fails with
"user: Current not implemented on linux/amd64".