### PR TITLE
nested unordered list inside order list issue

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -297,7 +297,7 @@ img.avatar-100 {
 .markdown ul li {
   list-style: inside;
 }
-.markdown ol li {
+.markdown ol > li {
   list-style: decimal inside;
 }
 .markdown li {


### PR DESCRIPTION
This will solve the nested unordered list inside an ordered list issue. It is just a CSS error.

Issue: https://github.com/gogits/gogs/issues/1415

About the other problem reported about an ugly line appearing that is a blackfriday issue (so it must be reported to that library) or a blackfriday configuration issue (don't know if there is a blackfriday extension to solve that or other configuration that could be included in gogs that would solve that).