### PR TITLE
Tweak CSS for markdown list items

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -291,21 +291,20 @@ img.avatar-100 {
 .markdown h6 {
   font-size: 1em;
 }
-.markdown ul {
-  padding: 10px 0 0 15px;
+.markdown ul,
+.markdown ol {
+  padding-left: 1.2em;
 }
-.markdown ul li {
-  list-style: inside;
+.markdown ul > li,
+.markdown ol > li {
+  list-style: outside;
+  margin-top: 0.4em;
 }
 .markdown ol > li {
-  list-style: decimal inside;
+  list-style: decimal;
 }
 .markdown li {
   line-height: 1.6;
-  margin-top: 6px;
-}
-.markdown li:first-child {
-  margin-top: 0;
 }
 .markdown code {
   padding: 0.2em 0.5em;


### PR DESCRIPTION
I have tweaked the CSS for list items generated with markdown.

Intended to solve issues:
https://github.com/gogits/gogs/issues/1416
https://github.com/gogits/gogs/issues/1415 (the ugly large space between nested lists when there are new lines)

Needs to be tested.

The padding-left 1.2em on `ul` and `ol` is not an arbitrary choice and comes from:
```
.panel .panel-content {
    padding: 1em 1.2em;
}
```