### PR TITLE
Enhance copy clipboard

### DIFF
--- a/.gopmfile
+++ b/.gopmfile
@@ -33,6 +33,8 @@ golang.org/x/net = commit:937a34c9de13
 golang.org/x/text = commit:5b2527008a4c
 gopkg.in/ini.v1 = commit:caf3f03ad9
 gopkg.in/redis.v2 = commit:e617904962
+github.com/hashicorp/go-version = commit:999359b6b7
+github.com/mssola/user_agent = commit:f659b98638
 
 [res]
 include = etc|public|scripts|templates

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -16,6 +16,14 @@ import (
 	"github.com/gogits/gogs/modules/git"
 	"github.com/gogits/gogs/modules/log"
 	"github.com/gogits/gogs/modules/setting"
+
+	"github.com/hashicorp/go-version"
+	"github.com/mssola/user_agent"
+)
+
+const (
+	FIREFOX_COPY_SUPPORT = "41.0"
+	CHROME_COPY_SUPPORT = "43.0.2356"
 )
 
 func ApiRepoAssignment() macaron.Handler {
@@ -345,6 +353,24 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 
 		ctx.Data["BranchName"] = ctx.Repo.BranchName
 		ctx.Data["CommitId"] = ctx.Repo.CommitId
+
+		userAgent := ctx.Req.Header.Get("User-Agent")
+		ua := user_agent.New(userAgent);
+		browserName, browserVer := ua.Browser()
+
+		sliceVer := strings.Split(browserVer, ".")
+		var max int
+		if max = len(sliceVer); 3 < max {
+			max = 3
+		}
+		browserVer = strings.Join(sliceVer[:max], ".")
+
+		browserVersion, err := version.NewVersion(browserVer)
+		chromeConstraint, err := version.NewConstraint(">= " + CHROME_COPY_SUPPORT)
+		firefoxConstraint, err := version.NewConstraint(">= " + FIREFOX_COPY_SUPPORT)
+
+		ctx.Data["BrowserSupportsCopy"] = (browserName == "Chrome" && chromeConstraint.Check(browserVersion)) || (browserName == "Firefox" && firefoxConstraint.Check(browserVersion))
+
 	}
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -269,36 +269,62 @@ var Gogits = {};
         if ($(selector).hasClass('js-copy-bind')) {
             return;
         }
-        $(selector).zclip({
-            path: "/js/ZeroClipboard.swf",
-            copy: function () {
-                var t = $(this).data("copy-val");
-                var to = $($(this).data("copy-from"));
-                var str = "";
-                if (t == "txt") {
-                    str = to.text();
-                }
-                if (t == 'val') {
-                    str = to.val();
-                }
-                if (t == 'html') {
-                    str = to.html();
-                }
-                return str;
-            },
-            afterCopy: function () {
+
+        if ( document.documentElement.classList.contains("is-copy-enabled") ) {
+
+            $(selector).click(function(event) {
                 var $this = $(this);
-                $this.tooltip('hide')
-                    .attr('data-original-title', 'Copied OK');
+
+                var cfrom = $this.attr('data-copy-from');
+                $(cfrom).select();
+                document.execCommand('copy');
+                getSelection().removeAllRanges();
+
+                $this.tipsy("hide").attr('original-title', $this.data('after-title'));
                 setTimeout(function () {
-                    $this.tooltip("show");
+                    $this.tipsy("show");
                 }, 200);
                 setTimeout(function () {
-                    $this.tooltip('hide')
-                        .attr('data-original-title', 'Copy to Clipboard');
-                }, 3000);
-            }
-        }).addClass("js-copy-bind");
+                    $this.tipsy('hide').attr('original-title', $this.data('original-title'));
+                }, 2000);
+                
+                this.blur();
+                return;
+            });
+
+            $(selector).addClass("js-copy-bind");
+
+        } else {
+
+            $(selector).zclip({
+                path: Gogs.AppSubUrl + "/js/ZeroClipboard.swf",
+                copy: function () {
+                    var t = $(this).data("copy-val");
+                    var to = $($(this).data("copy-from"));
+                    var str = "";
+                    if (t == "txt") {
+                        str = to.text();
+                    }
+                    if (t == 'val') {
+                        str = to.val();
+                    }
+                    if (t == 'html') {
+                        str = to.html();
+                    }
+                    return str;
+                },
+                afterCopy: function () {
+                    var $this = $(this);
+                    $this.tipsy("hide").attr('original-title', $this.data('after-title'));
+                    setTimeout(function () {
+                        $this.tipsy("show");
+                    }, 200);
+                    setTimeout(function () {
+                        $this.tipsy('hide').attr('original-title', $this.data('original-title'));
+                    }, 2000);
+                }
+            }).addClass("js-copy-bind");
+        }
     }
 
     // api working

--- a/public/ng/js/gogs.js
+++ b/public/ng/js/gogs.js
@@ -333,25 +333,17 @@ var Gogs = {};
         if ($(selector).hasClass('js-copy-bind')) {
             return;
         }
-        $(selector).zclip({
-            path: Gogs.AppSubUrl + "/js/ZeroClipboard.swf",
-            copy: function () {
-                var t = $(this).data("copy-val");
-                var to = $($(this).data("copy-from"));
-                var str = "";
-                if (t == "txt") {
-                    str = to.text();
-                }
-                if (t == 'val') {
-                    str = to.val();
-                }
-                if (t == 'html') {
-                    str = to.html();
-                }
-                return str;
-            },
-            afterCopy: function () {
+
+        if ( document.documentElement.classList.contains("is-copy-enabled") ) {
+
+            $(selector).click(function(event) {
                 var $this = $(this);
+
+                var cfrom = $this.attr('data-copy-from');
+                $(cfrom).select();
+                document.execCommand('copy');
+                getSelection().removeAllRanges();
+
                 $this.tipsy("hide").attr('original-title', $this.data('after-title'));
                 setTimeout(function () {
                     $this.tipsy("show");
@@ -359,8 +351,44 @@ var Gogs = {};
                 setTimeout(function () {
                     $this.tipsy('hide').attr('original-title', $this.data('original-title'));
                 }, 2000);
-            }
-        }).addClass("js-copy-bind");
+                
+                this.blur();
+                return;
+            });
+
+            $(selector).addClass("js-copy-bind");
+
+        } else {
+
+            $(selector).zclip({
+                path: Gogs.AppSubUrl + "/js/ZeroClipboard.swf",
+                copy: function () {
+                    var t = $(this).data("copy-val");
+                    var to = $($(this).data("copy-from"));
+                    var str = "";
+                    if (t == "txt") {
+                        str = to.text();
+                    }
+                    if (t == 'val') {
+                        str = to.val();
+                    }
+                    if (t == 'html') {
+                        str = to.html();
+                    }
+                    return str;
+                },
+                afterCopy: function () {
+                    var $this = $(this);
+                    $this.tipsy("hide").attr('original-title', $this.data('after-title'));
+                    setTimeout(function () {
+                        $this.tipsy("show");
+                    }, 200);
+                    setTimeout(function () {
+                        $this.tipsy('hide').attr('original-title', $this.data('original-title'));
+                    }, 2000);
+                }
+            }).addClass("js-copy-bind");
+        }
     }
 })(jQuery);
 

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html{{if .BrowserSupportsCopy}} class="is-copy-enabled"{{end}}>
 	<head data-suburl="{{AppSubUrl}}">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>


### PR DESCRIPTION
I have added clipboard API support when available. First commit parses User-Agent header to add a class to html tag if the browser supports copy to clipboard. The second commit implements the javascript that copies directly to clipboard if the browser supports it or otherwise uses jquery zclip which uses an invisible flash to deal with the copy.

More details on https://github.com/gogits/gogs/issues/1396

Probably the minified version `public/ng/js/min/gogs-min.js` needs to be rebuilded.