### PR TITLE
Add check to see if comments on an issue are by the repo owner

### DIFF
--- a/templates/repo/issue/view.tmpl
+++ b/templates/repo/issue/view.tmpl
@@ -69,7 +69,9 @@
                                 <a href="{{AppSubUrl}}/{{.Poster.Name}}" class="user">{{.Poster.Name}}</a> commented <span class="time">{{TimeSince .Created $.Lang}}</span>
                                 <!-- <a class="issue-comment-del pull-right issue-action" href="#" title="Edit Comment"><i class="fa fa-times-circle"></i></a>
                                 <a class="issue-comment-edit pull-right issue-action" href="#" title="Remove Comment" data-url="{remove-link}"><i class="fa fa-edit"></i></a> -->
+                                {{if eq .Poster.Id $.Owner.Id}}
                                 <span class="role label label-default pull-right">Owner</span>
+                                {{end}}
                             </div>
                             <div class="panel-body markdown">
                                 {{if len .Content}}


### PR DESCRIPTION
Fixed a bug where all comments on an issue would be marked as the "Owner" of the repository.

Before:
<img width="781" alt="screen shot 2015-08-08 at 5 18 54 pm" src="https://cloud.githubusercontent.com/assets/284902/9152519/b1e2080c-3df1-11e5-9e4f-39f3c4e8dddd.png">

After:
<img width="785" alt="screen shot 2015-08-08 at 5 19 39 pm" src="https://cloud.githubusercontent.com/assets/284902/9152520/b4db31c8-3df1-11e5-979e-98a78bdf5be4.png">

