### PR TITLE
fix dashboard padding

### DIFF
--- a/public/ng/css/gogs.css
+++ b/public/ng/css/gogs.css
@@ -932,7 +932,7 @@ ol.linenums {
   margin: -4px 10px 0 0;
 }
 #dashboard {
-  padding: 24px 0;
+  padding: 1.5em;
 }
 #dashboard-sidebar .panel-header h4 {
   margin: 0;


### PR DESCRIPTION
Dashboard padding is 0 in left right and it would look alot nicer if they were 1.5em as the header, 1.5em is also a nice replacement for 24px top and bottom.