### PR TITLE
column belongs always into a ui grid

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -52,106 +52,108 @@
 
 		{{if not .PageIsInstall}}
 		<div class="following bar light">
-		  <div class="ui container">
-		    <div class="column">
-		      <div class="ui top secondary menu">
-						<a class="item brand" href="{{AppSubUrl}}/">
-							<img class="ui mini image" src="{{AppSubUrl}}/img/favicon.png">
-						</a>
+			<div class="ui container">
+				<div class="ui grid">
+					<div class="column">
+						<div class="ui top secondary menu">
+							<a class="item brand" href="{{AppSubUrl}}/">
+								<img class="ui mini image" src="{{AppSubUrl}}/img/favicon.png">
+							</a>
 
-						{{if .IsSigned}}
-		      	<a class="item{{if .PageIsDashboard}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "dashboard"}}</a>
-						{{else}}
-		      	<a class="item{{if .PageIsHome}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "home"}}</a>
-						{{end}}
+							{{if .IsSigned}}
+							<a class="item{{if .PageIsDashboard}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "dashboard"}}</a>
+							{{else}}
+							<a class="item{{if .PageIsHome}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "home"}}</a>
+							{{end}}
 
-		      	<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore">{{.i18n.Tr "explore"}}</a>
-		      	<!-- <div class="item">
-		      	  <div class="ui icon input">
-		      	    <input class="searchbox" type="text" placeholder="{{.i18n.Tr "search_project"}}">
-		      	    <i class="search icon"></i>
-		      	  </div>
-		      	</div> -->
+							<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore">{{.i18n.Tr "explore"}}</a>
+							<!-- <div class="item">
+								<div class="ui icon input">
+									<input class="searchbox" type="text" placeholder="{{.i18n.Tr "search_project"}}">
+									<i class="search icon"></i>
+								</div>
+							</div> -->
 
-  	      	{{if .IsSigned}}
-		      	<a class="item{{if .PageIsIssues}} active{{end}}" href="{{AppSubUrl}}/issues">{{.i18n.Tr "issues"}}</a>
-  		      <div class="right menu">
-  						<div class="ui dropdown head link jump item poping up" data-content="{{.i18n.Tr "create_new"}}" data-variation="tiny inverted">
-  							<span class="text">
-  								<i class="octicon octicon-plus"></i>
-  								<i class="octicon octicon-triangle-down"></i>
-  							</span>
-  			        <div class="menu">
-  			          <a class="item" href="{{AppSubUrl}}/repo/create">
-										<i class="octicon octicon-repo-create"></i> {{.i18n.Tr "new_repo"}}
-									</a>
-  			          <a class="item" href="{{AppSubUrl}}/repo/migrate">
-										<i class="octicon octicon-repo-clone"></i> {{.i18n.Tr "new_migrate"}}
-									</a>
-  			          <a class="item" href="{{AppSubUrl}}/org/create">
-										<i class="octicon octicon-organization"></i> {{.i18n.Tr "new_org"}}
-									</a>
-  							</div><!-- end content create new menu -->
-  						</div><!-- end dropdown menu create new -->
+							{{if .IsSigned}}
+							<a class="item{{if .PageIsIssues}} active{{end}}" href="{{AppSubUrl}}/issues">{{.i18n.Tr "issues"}}</a>
+							<div class="right menu">
+								<div class="ui dropdown head link jump item poping up" data-content="{{.i18n.Tr "create_new"}}" data-variation="tiny inverted">
+									<span class="text">
+										<i class="octicon octicon-plus"></i>
+										<i class="octicon octicon-triangle-down"></i>
+									</span>
+									<div class="menu">
+										<a class="item" href="{{AppSubUrl}}/repo/create">
+											<i class="octicon octicon-repo-create"></i> {{.i18n.Tr "new_repo"}}
+										</a>
+										<a class="item" href="{{AppSubUrl}}/repo/migrate">
+											<i class="octicon octicon-repo-clone"></i> {{.i18n.Tr "new_migrate"}}
+										</a>
+										<a class="item" href="{{AppSubUrl}}/org/create">
+											<i class="octicon octicon-organization"></i> {{.i18n.Tr "new_org"}}
+										</a>
+									</div><!-- end content create new menu -->
+								</div><!-- end dropdown menu create new -->
 
-							<div class="ui dropdown head link jump item poping up" tabindex="-1" data-content="{{.i18n.Tr "user_profile_and_more"}}" data-variation="tiny inverted">
-								<span class="text avatar">
-									<img class="ui small rounded image" src="{{.SignedUser.AvatarLink}}">
-									<i class="octicon octicon-triangle-down" tabindex="-1"></i>
-								</span>
-								<div class="menu" tabindex="-1">
-									<div class="ui header">
+								<div class="ui dropdown head link jump item poping up" tabindex="-1" data-content="{{.i18n.Tr "user_profile_and_more"}}" data-variation="tiny inverted">
+									<span class="text avatar">
+										<img class="ui small rounded image" src="{{.SignedUser.AvatarLink}}">
+										<i class="octicon octicon-triangle-down" tabindex="-1"></i>
+									</span>
+									<div class="menu" tabindex="-1">
+										<div class="ui header">
 										{{.i18n.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
-									</div>
+										</div>
 
-									<div class="divider"></div>
-									<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}">
-										<i class="octicon icon octicon-person"></i>
-										{{.i18n.Tr "your_profile"}}<!-- Your profile -->
-									</a>
-									<a class="item" href="{{AppSubUrl}}/user/settings">
-										<i class="octicon icon octicon-settings"></i>
-										{{.i18n.Tr "your_settings"}}<!-- Your settings -->
-									</a>
-									<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">
-										<i class="octicon icon octicon-question"></i>
-										{{.i18n.Tr "help"}}<!-- Help -->
-									</a>
-									{{if .IsAdmin}}
-									<div class="divider"></div>
+										<div class="divider"></div>
+										<a class="item" href="{{AppSubUrl}}/{{.SignedUser.Name}}">
+											<i class="octicon icon octicon-person"></i>
+											{{.i18n.Tr "your_profile"}}<!-- Your profile -->
+										</a>
+										<a class="item" href="{{AppSubUrl}}/user/settings">
+											<i class="octicon icon octicon-settings"></i>
+											{{.i18n.Tr "your_settings"}}<!-- Your settings -->
+										</a>
+										<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">
+											<i class="octicon icon octicon-question"></i>
+											{{.i18n.Tr "help"}}<!-- Help -->
+										</a>
+										{{if .IsAdmin}}
+										<div class="divider"></div>
 
-									<a class="item" href="{{AppSubUrl}}/admin">
-										<i class="icon settings"></i>
-										{{.i18n.Tr "admin_panel"}}<!-- Admin Panel -->
-									</a>
-									{{end}}
+										<a class="item" href="{{AppSubUrl}}/admin">
+											<i class="icon settings"></i>
+											{{.i18n.Tr "admin_panel"}}<!-- Admin Panel -->
+										</a>
+										{{end}}
 
-									<div class="divider"></div>
-									<a class="item" href="{{AppSubUrl}}/user/logout">
-										<i class="octicon icon octicon-sign-out"></i>
-										{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
-									</a>
-								</div><!-- end content avatar menu -->
-							</div><!-- end dropdown avatar menu -->
-  		      </div><!-- end signed user right menu -->
+										<div class="divider"></div>
+										<a class="item" href="{{AppSubUrl}}/user/logout">
+											<i class="octicon icon octicon-sign-out"></i>
+											{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
+										</a>
+									</div><!-- end content avatar menu -->
+								</div><!-- end dropdown avatar menu -->
+							</div><!-- end signed user right menu -->
 
-  	      	{{else}}
+							{{else}}
 
-						<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">{{.i18n.Tr "help"}}</a>
-  		      <div class="right menu">
-  		      	{{if .ShowRegistrationButton}}
-  		      	<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
-								<i class="octicon octicon-person-add"></i> {{.i18n.Tr "register"}}
-							</a>
-  		      	{{end}}
-  		      	<a class="item{{if .PageIsSignIn}} active{{end}}" href="{{AppSubUrl}}/user/login">
-								<i class="octicon octicon-sign-in"></i> {{.i18n.Tr "sign_in"}}
-							</a>
-  		      </div><!-- end anonymous right menu -->
+							<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">{{.i18n.Tr "help"}}</a>
+							<div class="right menu">
+								{{if .ShowRegistrationButton}}
+								<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
+									<i class="octicon octicon-person-add"></i> {{.i18n.Tr "register"}}
+								</a>
+								{{end}}
+								<a class="item{{if .PageIsSignIn}} active{{end}}" href="{{AppSubUrl}}/user/login">
+									<i class="octicon octicon-sign-in"></i> {{.i18n.Tr "sign_in"}}
+								</a>
+							</div><!-- end anonymous right menu -->
 
-  		      {{end}}
-		      </div><!-- end top menu -->
-		    </div><!-- end column -->
-		  </div><!-- end container -->
+							{{end}}
+						</div><!-- end top menu -->
+					</div><!-- end column -->
+				</div><!-- end grid -->
+			</div><!-- end container -->
 		</div><!-- end bar -->
 		{{end}}


### PR DESCRIPTION
Looks like a lot of changes but the only change is a new `.ui.grid` layer that contains the `.column` layer.

Because columns always belong to a `ui grid` and we forgot to include that layer.

All looks exactly the same after this change though there are some new margins and paddings that change nothing because they collapse in the same way than before the change.

Anyway for completeness this is needed and could lead to strange, not easy to debug, CSS problems if in future the semantic theme is changed.