### PR TITLE
43bfee0d4872932c1da185e8367e21795bc4ceb5 reverted my change

### DIFF
--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -26,12 +26,7 @@ func ServeBlob(ctx *middleware.Context, blob *git.Blob) error {
 	}
 
 	_, isTextFile := base.IsTextFile(buf)
-	if isTextFile {
-		charset, _ := base.DetectEncoding(buf)
-		if charset != "UTF-8" {
-			ctx.Resp.Header().Set("Content-Type", "text/plain; charset="+charset)
-		}
-	} else {
+	if ! isTextFile {
 		_, isImageFile := base.IsImageFile(buf)
 		if !isImageFile {
 			ctx.Resp.Header().Set("Content-Disposition", "attachment; filename="+path.Base(ctx.Repo.TreeName))


### PR DESCRIPTION
423b1c69be7828c331a47467b66217d190e916b9, which in turn
causes all content to be served as text/plain. Let go decide
what the mime type is (e.g. text/html instead of text/plain).