### PR TITLE
Fix Fail to load gopmfile: could not parse line: github.com/mcuadros/go-version

### DIFF
--- a/.gopmfile
+++ b/.gopmfile
@@ -24,7 +24,7 @@ github.com/macaron-contrib/oauth2 = commit:8f394c3629
 github.com/macaron-contrib/session = commit:e48134e803
 github.com/macaron-contrib/toolbox = commit:acbfe36e16
 github.com/mattn/go-sqlite3 = commit:e28cd440fa
-github.com/mcuadros/go-version
+github.com/mcuadros/go-version = 
 github.com/microcosm-cc/bluemonday = commit:2b7763a06c
 github.com/mssola/user_agent = commit:f659b98638
 github.com/msteinert/pam = commit:9a42d39dbf


### PR DESCRIPTION
Fix Fail to load gopmfile: could not parse line: github.com/mcuadros/go-version