### PR TITLE
Change input field to type=password for the authentication templates.

### DIFF
--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -49,7 +49,7 @@
                                 </div>
                                 <div class="field">
                                     <label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
-                                    <input class="ipt ipt-large ipt-radius {{if .Err_BindPassword}}ipt-error{{end}}" id="bind_password" name="bind_password" value="{{.Source.LDAP.BindPassword}}" />
+                                    <input class="ipt ipt-large ipt-radius {{if .Err_BindPassword}}ipt-error{{end}}" id="bind_password" name="bind_password" type="password" value="{{.Source.LDAP.BindPassword}}" />
                                 </div>
                                 <div class="field">
                                     <label class="req" for="user_base">{{.i18n.Tr "admin.auths.user_base"}}</label>

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -45,7 +45,7 @@
                                     </div>
                                     <div class="field">
                                         <label class="req" for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
-                                        <input class="ipt ipt-large ipt-radius {{if .Err_BindPassword}}ipt-error{{end}}" id="bind_password" name="bind_password" value="{{.bind_password}}" />
+                                        <input class="ipt ipt-large ipt-radius {{if .Err_BindPassword}}ipt-error{{end}}" id="bind_password" name="bind_password" type="password" value="{{.bind_password}}" />
                                     </div>
                                     <div class="field">
                                         <label class="req" for="user_base">{{.i18n.Tr "admin.auths.user_base"}}</label>


### PR DESCRIPTION
Title pretty much says it all, the input box for the password field wasn't set to "type=password" so passwords were being displayed in plaintext on the screen. The change is pretty trivial.