### PR TITLE
Set IsAdmin using LDAP

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -761,6 +761,7 @@ auths.attribute_name = First name attribute
 auths.attribute_surname = Surname attribute
 auths.attribute_mail = E-mail attribute
 auths.filter = User Filter
+auths.admin_filter = Admin Filter
 auths.ms_ad_sa = Ms Ad SA
 auths.smtp_auth = SMTP Authorization Type
 auths.smtphost = SMTP Host

--- a/models/login.go
+++ b/models/login.go
@@ -257,7 +257,7 @@ func UserSignIn(uname, passwd string) (*User, error) {
 // Return the same LoginUserPlain semantic
 // FIXME: https://github.com/gogits/gogs/issues/672
 func LoginUserLdapSource(u *User, name, passwd string, sourceId int64, cfg *LDAPConfig, autoRegister bool) (*User, error) {
-	fn, sn, mail, logged := cfg.Ldapsource.SearchEntry(name, passwd)
+	fn, sn, mail, admin, logged := cfg.Ldapsource.SearchEntry(name, passwd)
 	if !logged {
 		// User not in LDAP, do nothing
 		return nil, ErrUserNotExist{0, name}
@@ -281,6 +281,7 @@ func LoginUserLdapSource(u *User, name, passwd string, sourceId int64, cfg *LDAP
 		LoginName:   name,
 		Passwd:      passwd,
 		Email:       mail,
+		IsAdmin:     admin,
 		IsActive:    true,
 	}
 	return u, CreateUser(u)

--- a/modules/auth/auth_form.go
+++ b/modules/auth/auth_form.go
@@ -23,6 +23,7 @@ type AuthenticationForm struct {
 	AttributeSurname  string
 	AttributeMail     string
 	Filter            string
+	AdminFilter       string
 	IsActived         bool
 	SMTPAuth          string `form:"smtp_auth"`
 	SMTPHost          string `form:"smtp_host"`

--- a/routers/admin/auths.go
+++ b/routers/admin/auths.go
@@ -71,6 +71,7 @@ func NewAuthSourcePost(ctx *middleware.Context, form auth.AuthenticationForm) {
 				BindPassword:      form.BindPassword,
 				UserBase:          form.UserBase,
 				Filter:            form.Filter,
+				AdminFilter:       form.AdminFilter,
 				AttributeName:     form.AttributeName,
 				AttributeSurname:  form.AttributeSurname,
 				AttributeMail:     form.AttributeMail,
@@ -160,6 +161,7 @@ func EditAuthSourcePost(ctx *middleware.Context, form auth.AuthenticationForm) {
 				AttributeSurname:  form.AttributeSurname,
 				AttributeMail:     form.AttributeMail,
 				Filter:            form.Filter,
+				AdminFilter:       form.AdminFilter,
 				Enabled:           true,
 			},
 		}

--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -60,6 +60,10 @@
                                     <input class="ipt ipt-large ipt-radius {{if .Err_Filter}}ipt-error{{end}}" id="filter" name="filter" value="{{.Source.LDAP.Filter}}" />
                                 </div>
                                 <div class="field">
+                                    <label class="req" for="filter">{{.i18n.Tr "admin.auths.admin_filter"}}</label>
+                                    <input class="ipt ipt-large ipt-radius {{if .Err_AdminFilter}}ipt-error{{end}}" id="admin_filter" name="admin_filter" value="{{.Source.LDAP.AdminFilter}}" />
+                                </div>
+                                <div class="field">
                                     <label for="attribute_name">{{.i18n.Tr "admin.auths.attribute_name"}}</label>
                                     <input class="ipt ipt-large ipt-radius {{if .Err_Attributes}}ipt-error{{end}}" id="attribute_name" name="attribute_name" value="{{.Source.LDAP.AttributeName}}" />
                                 </div>

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -56,6 +56,10 @@
                                         <input class="ipt ipt-large ipt-radius {{if .Err_Filter}}ipt-error{{end}}" id="filter" name="filter" value="{{.filter}}" />
                                     </div>
                                     <div class="field">
+                                        <label class="req" for="filter">{{.i18n.Tr "admin.auths.admin_filter"}}</label>
+                                        <input class="ipt ipt-large ipt-radius {{if .Err_AdminFilter}}ipt-error{{end}}" id="admin_filter" name="admin_filter" value="{{.admin_filter}}" />
+                                    </div>
+                                    <div class="field">
                                         <label for="attribute_name">{{.i18n.Tr "admin.auths.attribute_name"}}</label>
                                         <input class="ipt ipt-large ipt-radius {{if .Err_AttributeName}}ipt-error{{end}}" id="attribute_name" name="attribute_name" value="{{.attribute_name}}" />
                                     </div>


### PR DESCRIPTION
The IsAdmin flag is set based on whether the admin filter
returned any result. The admin filter is applied with the user dn
as the search root.

In the future, we should update IsAdmin as well on each login.
Alternately, we can have a periodic sync operation.