### PR TITLE
Supported for binding with username in LDAP login

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -42,6 +42,9 @@ func (ls Ldapsource) FindUserDN(name, passwd string) (string, bool) {
 
 	log.Trace("Search for LDAP user: %s", name)
 	if ls.BindDN != "" {
+		var bd, bp string
+		// With palceholder in BindDN and no password,
+		// It will bind as combination define in BindDN with login password
 		if ls.BindPassword == "" {
 			bd = strings.Replace(ls.BindDN, "<username>", name, -1)
 			bp = passwd


### PR DESCRIPTION
As our LDAP server doesn't support anonymous search and I'm not admin, we need bind as combination like 'domain\username' with login password.
SO, i think the most economic way is adding a placeholder in BindDN setting and leaving Password blank.
How about you :-)