### PR TITLE
Updated - Lang Selection Width

### DIFF
--- a/public/ng/less/gogs/base.less
+++ b/public/ng/less/gogs/base.less
@@ -101,7 +101,7 @@ clear: both;
         height: -3+31*@langNum;
         z-index: 100;
         font-size: 12px;
-        width: 120%;
+        width: 170%;
         min-width: 140px;
         li > a {
             padding: 3px 9px;


### PR DESCRIPTION
Seems to have a small problem because of the long language `Português do Brasil`:

![image](https://cloud.githubusercontent.com/assets/2222562/9453269/3396b64e-4a87-11e5-83ad-f1ae0aacfe28.png) ![image](https://cloud.githubusercontent.com/assets/2222562/9453272/3e333050-4a87-11e5-89d0-db704f71edf5.png)

This pushed down the rest, and ruined the 31px assumption. This just makes it wider so it doesn't run into that problem. Let me know if you run into any problems.