### PR TITLE
remove dashboard operations table header

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -25,12 +25,6 @@
                             <div class="panel-body admin-panel">
                                 <div class="admin-table">
                                     <table class="table">
-                                        <thead>
-                                            <tr>
-                                                <th>{{.i18n.Tr "admin.dashboard.operation_name"}}</th>
-                                                <th>{{.i18n.Tr "admin.dashboard.operation_switch"}}</th>
-                                            </tr>
-                                        </thead>
                                         <tbody>
                                             <tr>
                                                 <td>{{.i18n.Tr "admin.dashboard.clean_unbind_oauth"}}</td>


### PR DESCRIPTION
The operations section of dashboard has a double header. The panel header that reads "Operations" and a table header that reads "Operation Name   |   Switch". The table header is redundant and can be removed.