### PR TITLE
Commit messages now rendered with line breaks and prefix spacing.

### DIFF
--- a/templates/repo/diff.tmpl
+++ b/templates/repo/diff.tmpl
@@ -6,12 +6,12 @@
     {{template "repo/commits_table" .}}
     {{else}}
     <h4 class="ui top attached info header">
-      {{RenderCommitMessage .Commit.Message $.RepoLink}}
       <div class="ui right">
         <a class="ui blue tiny button" href="{{EscapePound .SourcePath}}">
           {{.i18n.Tr "repo.diff.browse_source"}}
         </a>
       </div>
+      {{RenderCommitMessage .Commit.Message $.RepoLink}}
     </h4>
     <div class="ui attached info segment">
       {{if .Author}}


### PR DESCRIPTION
This commit improves the way that commit messages are rendered, especially in the diff view. First, it fixes the 'diff' template so that the 'browse source' button correctly floats to the right of the message. Second, it renders line breaks and prefix spacing in commit messages.

Previously, when a commit message appeared in the log as:

```
Change 1 did this. Change 2 did this.

These changes were very good. I'm pretty happy with them. Here they are:
    * Change 1
    * Change 2
```

Gogs would render it is as:

```
Change 1 did this. Change 2 did this. These changes were very good. I'm pretty happy with them. Here they are: * Change 1 * Change 2
```

With this commit, Gogs will render the message just as it was in the log.