### PR TITLE
Fix `go get` not working when there is a username or repository name with some uppercase letters.

### DIFF
--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -347,7 +347,7 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 		ctx.Data["CloneLink"] = ctx.Repo.CloneLink
 
 		if ctx.Query("go-get") == "1" {
-			ctx.Data["GoGetImport"] = fmt.Sprintf("%s/%s/%s", setting.Domain, u.LowerName, repo.LowerName)
+			ctx.Data["GoGetImport"] = fmt.Sprintf("%s/%s/%s", setting.Domain, u.Name, repo.Name)
 		}
 
 		// repo is bare and display enable


### PR DESCRIPTION
Already described in the title. At the moment, if you do `go get` to a repo hosted on a gogs instance, you must use a lowercase username and repo name, otherwise it won't work, because gogs returns in the meta tag the username and the repo name in lowercase, and so `go get` finds two different names, and will just output to the user `package repo.url/username/reponame: unrecognized import path "repo.url/username/reponame"`.