### PR TITLE
Set USER env variable so installation can complete successfully.

### DIFF
--- a/scripts/init/debian/gogs
+++ b/scripts/init/debian/gogs
@@ -48,11 +48,11 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
+	sh -c "USER=$USER start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
 			--test --chdir $WORKINGDIR --chuid $USER \\
 			--exec $DAEMON -- $DAEMON_ARGS > /dev/null \\
 			|| return 1"
-	sh -c "start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
+	sh -c "USER=$USER start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \\
 			--background --chdir $WORKINGDIR --chuid $USER \\
 			--exec $DAEMON -- $DAEMON_ARGS \\
 			|| return 2"


### PR DESCRIPTION
In testing startup on Ubuntu/Debian, it seems the `USER` environment variable is not present when Gogs is running using the default init script.

There may be a better way to fix this and make sure start-stop-daemon preserves the preconfigured environment, but I was at least able to complete installation (instead of getting an annoying `Run user isn't the current user: git ->` message (note the empty string for the 'CurrentUsername()' as picked up by the environment).