### PR TITLE
New approach to Gogs Docker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
-.git/*
-conf/*
-packager/*
-scripts/*
+.git
+conf
+packager
+scripts
 *.yml
 *.md
 .bra.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/
  && apk -U --no-progress add ca-certificates git linux-pam s6@edge curl openssh socat \
  && chmod +x /usr/sbin/gosu
 
-# Configure SSH
-COPY docker/sshd_config /etc/ssh/sshd_config
-
 # Configure Go and build Gogs
 ENV GOPATH /tmp/go
 ENV PATH $PATH:$GOPATH/bin
@@ -26,6 +23,7 @@ ENV GOGS_CUSTOM /data/gogs
 RUN adduser -D -g 'Gogs Git User' git -h /data/git/ -s /bin/sh && passwd -u git
 RUN echo "export GOGS_CUSTOM=/data/gogs" >> /etc/profile
 
+# Configure Docker Container
 VOLUME ["/data"]
 EXPOSE 22 3000
 CMD ["./docker/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD https://github.com/tianon/gosu/releases/download/1.5/gosu-amd64 /usr/sbin/go
 RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
  && echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories \
  && apk -U --no-progress upgrade \
- && apk -U --no-progress add ca-certificates git linux-pam s6@edge curl openssh socat \
+ && apk -U --no-progress add ca-certificates bash git linux-pam s6@edge curl openssh socat \
  && chmod +x /usr/sbin/gosu
 
 # Configure Go and build Gogs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,31 @@
-FROM google/debian:wheezy
-MAINTAINER u@gogs.io
+FROM alpine:3.2
+MAINTAINER roemer.jp@gmail.com
 
-RUN echo "deb http://ftp.debian.org/debian/ wheezy-backports main" >> /etc/apt/sources.list && \
-	apt-get update -qqy && \
-	apt-get install --no-install-recommends -qqy \
-	curl build-essential ca-certificates git \ 
-	openssh-server libpam-dev && \
-	apt-get autoclean && \
-    apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
+# Install system utils & Gogs runtime dependencies
+ADD https://github.com/tianon/gosu/releases/download/1.5/gosu-amd64 /usr/sbin/gosu
+RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
+ && echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories \
+ && apk -U --no-progress upgrade \
+ && apk -U --no-progress add ca-certificates git linux-pam s6@edge curl openssh socat \
+ && chmod +x /usr/sbin/gosu
 
-ENV GOROOT /goroot
-ENV GOPATH /gopath
-ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+# Configure SSH
+COPY docker/sshd_config /etc/ssh/sshd_config
 
-COPY . /gopath/src/github.com/gogits/gogs/
-WORKDIR /gopath/src/github.com/gogits/gogs/
+# Configure Go and build Gogs
+ENV GOPATH /tmp/go
+ENV PATH $PATH:$GOPATH/bin
 
-# Build binary and clean up useless files
-RUN mkdir /goroot && \
-	curl https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz | tar xzf - -C /goroot --strip-components=1 && \
-	go get -v -tags "sqlite redis memcache cert pam" && \
-	go build -tags "sqlite redis memcache cert pam" && \
-	mkdir /app/ && \
-	mv /gopath/src/github.com/gogits/gogs/ /app/gogs/ && \
-	rm -r $GOROOT $GOPATH
-
+COPY . /app/gogs/
 WORKDIR /app/gogs/
+RUN ./docker/build.sh
 
-RUN useradd --shell /bin/bash --system --comment gogits git
-
-# SSH login fix, otherwise user is kicked off after login
-RUN mkdir /var/run/sshd && \
-	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
-	sed 's@UsePrivilegeSeparation yes@UsePrivilegeSeparation no@' -i /etc/ssh/sshd_config && \
-	echo "export VISIBLE=now" >> /etc/profile && \
-	echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
-
-# Setup server keys on startup
-RUN sed 's@^HostKey@\#HostKey@' -i /etc/ssh/sshd_config && \
-	echo "HostKey /data/ssh/ssh_host_key" >> /etc/ssh/sshd_config && \
-	echo "HostKey /data/ssh/ssh_host_rsa_key" >> /etc/ssh/sshd_config && \
-	echo "HostKey /data/ssh/ssh_host_dsa_key" >> /etc/ssh/sshd_config && \
-	echo "HostKey /data/ssh/ssh_host_ecdsa_key" >> /etc/ssh/sshd_config && \
-	echo "HostKey /data/ssh/ssh_host_ed25519_key" >> /etc/ssh/sshd_config
-
-# Prepare data
 ENV GOGS_CUSTOM /data/gogs
+
+# Create git user for Gogs
+RUN adduser -D -g 'Gogs Git User' git -h /data/git/ -s /bin/sh && passwd -u git
 RUN echo "export GOGS_CUSTOM=/data/gogs" >> /etc/profile
 
+VOLUME ["/data"]
 EXPOSE 22 3000
-ENTRYPOINT []
 CMD ["./docker/start.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Install build deps
+apk -U --no-progress add linux-pam-dev go@community gcc musl-dev
+
+# Init go environment to build Gogs
+mkdir -p ${GOPATH}/src/github.com/gogits/
+ln -s /app/gogs/ ${GOPATH}/src/github.com/gogits/gogs
+cd ${GOPATH}/src/github.com/gogits/gogs
+go get -v -tags "sqlite redis memcache cert pam"
+go build -tags "sqlite redis memcache cert pam"
+
+# Cleanup GOPATH
+rm -r $GOPATH
+
+# Remove build deps
+apk --no-progress del linux-pam-dev go gcc musl-dev

--- a/docker/s6/.s6-svscan/finish
+++ b/docker/s6/.s6-svscan/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/true

--- a/docker/s6/gogs/run
+++ b/docker/s6/gogs/run
@@ -1,0 +1,28 @@
+#!/bin/sh
+USER=git
+USERNAME=$USER
+
+if ! test -d /data/gogs; then
+	mkdir -p /data/gogs/data /data/gogs/conf /data/gogs/log /data/git
+fi
+
+if ! test -d ~git/.ssh; then
+    mkdir ~git/.ssh
+    chmod 700 ~git/.ssh
+fi
+
+if ! test -f ~git/.ssh/environment; then
+    echo "GOGS_CUSTOM=/data/gogs" > ~git/.ssh/environment
+    chown git:git ~git/.ssh/environment
+    chown 600 ~git/.ssh/environment
+fi
+
+ln -sf /data/gogs/log  /app/gogs/log
+ln -sf /data/gogs/data /app/gogs/data
+ln -sf /data/gogs/conf /app/gogs/conf
+
+chown -R git:git /data /app/gogs ~git/
+
+export USER
+export USERNAME
+exec gosu $USER /app/gogs/gogs web

--- a/docker/s6/openssh/run
+++ b/docker/s6/openssh/run
@@ -12,4 +12,4 @@ then
 	chmod 600 /data/ssh/*
 fi
 
-exec gosu root /usr/sbin/sshd -D -f /etc/ssh/sshd_config
+exec gosu root /usr/sbin/sshd -D -f /app/gogs/docker/sshd_config

--- a/docker/s6/openssh/run
+++ b/docker/s6/openssh/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if ! test -d /data/ssh
+then
+	mkdir -p /data/ssh
+	ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
+	ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
+	ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
+	ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
+	ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
+	chown -R root:root /data/ssh/*
+	chmod 600 /data/ssh/*
+fi
+
+exec gosu root /usr/sbin/sshd -D -f /etc/ssh/sshd_config

--- a/docker/sshd_config
+++ b/docker/sshd_config
@@ -1,0 +1,17 @@
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
+Protocol 2
+LogLevel INFO
+HostKey /data/ssh/ssh_host_key
+HostKey /data/ssh/ssh_host_rsa_key
+HostKey /data/ssh/ssh_host_dsa_key
+HostKey /data/ssh/ssh_host_ecdsa_key
+HostKey /data/ssh/ssh_host_ed25519_key
+PermitRootLogin no
+AuthorizedKeysFile	.ssh/authorized_keys
+PasswordAuthentication no
+UsePrivilegeSeparation no
+PermitUserEnvironment yes
+AllowUsers git


### PR DESCRIPTION
This is a complete rewrite of the current Gogs docker container.

Some stuff was bothering me like the size of the container or the fact that we could not use localhost to connect to linked database.

I've rewrite it for this purpose while implementing other stuff that people wanted

This PR provide the following:
- New container base on `alpine:3.2` making the base container lighter
- S6 as system init and process supervisor (does not require a scripting runtime and pretty straightforward to configure)
- A build script for the application, this help with the size of the container as only one layer is created when the application is compiled. This script install building dependencies, compile the software and then remove those dependencies. The resulting layer then only contains the app folder without the needed building dependencies.
- This container implement a `VOLUME` directive for the `/data` folder as requested in #1708 
- OpenSSH is configured to handle `rsa`,`dsa`,`ecdsa` and `ed25519` key fixing #1717
- Fixes  #1499

The resulting size of this docker container is 77mo.