### PR TITLE
Docker Container: Init 1 & Initialisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,15 @@
 .git
+.git/
+.git/*
 conf
+conf/
+conf/*
 packager
+packager/
+packager/*
 scripts
+scripts/
+scripts/*
 *.yml
 *.md
 .bra.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN ./docker/build.sh
 # Configure Docker Container
 VOLUME ["/data"]
 EXPOSE 22 3000
-CMD ["docker/start.sh"]
+ENTRYPOINT ["docker/start.sh"]
+CMD ["/usr/bin/s6-svscan", "/app/gogs/docker/s6/"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ $ mkdir -p /var/gogs
 $ docker run --name=gogs -p 10022:22 -p 10080:3000 -v /var/gogs:/data gogs/gogs
 
 # Use `docker start` if you have stopped it.
-$ docker start gogs 
+$ docker start gogs
 ```
 
 Files will be store in local path `/var/gogs` in my case.
@@ -55,7 +55,7 @@ Most of settings are obvious and easy to understand, but there are some settings
 - **Domain**: fill in with Docker container IP(e.g. `192.168.99.100`). But if you want to access your Gogs instance from a different physical machine, please fill in with the hostname or IP address of the Docker host machine.
 - **SSH Port**: Use the exposed port from Docker container. For example, your SSH server listens on `22` inside Docker, but you expose it by `10022:22`, then use `10022` for this value.
 - **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, and you expose it by `10080:3000`, but you still use `3000` for this value.
-- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values(e.g. `http://192.168.99.100:10080/`). 
+- **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values(e.g. `http://192.168.99.100:10080/`).
 
 Full documentation of settings can be found [here](http://gogs.io/docs/advanced/configuration_cheat_sheet.html).
 
@@ -69,3 +69,8 @@ Steps to upgrade Gogs with Docker:
 - `docker stop gogs`
 - `docker rm gogs`
 - Finally, create container as the first time and don't forget to do same volume and port mapping.
+
+## Known Issues
+
+- [Use ctrl+c when clone through SSH makes Docker exit unexpectedly](https://github.com/gogits/gogs/issues/1499)
+- `.dockerignore` seems to be ignored during Docker Hub Automated build

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,5 +72,4 @@ Steps to upgrade Gogs with Docker:
 
 ## Known Issues
 
-- [Use ctrl+c when clone through SSH makes Docker exit unexpectedly](https://github.com/gogits/gogs/issues/1499)
 - `.dockerignore` seems to be ignored during Docker Hub Automated build

--- a/docker/s6/gogs/run
+++ b/docker/s6/gogs/run
@@ -1,26 +1,8 @@
 #!/bin/sh
-USER=git
 
-if ! test -d /data/gogs; then
-	mkdir -p /data/gogs/data /data/gogs/conf /data/gogs/log /data/git
+if test -f ./setup; then
+    source ./setup
 fi
 
-if ! test -d ~git/.ssh; then
-    mkdir ~git/.ssh
-    chmod 700 ~git/.ssh
-fi
-
-if ! test -f ~git/.ssh/environment; then
-    echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
-    chmod 600 ~git/.ssh/environment
-fi
-
-cd /app/gogs
-
-ln -sf /data/gogs/log  ./log
-ln -sf /data/gogs/data ./data
-
-chown -R git:git /data /app/gogs ~git/
-
-export USER
+export USER=git
 exec gosu $USER /app/gogs/gogs web

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if ! test -d /data/gogs; then
+    mkdir -p /data/gogs/data /data/gogs/conf /data/gogs/log /data/git
+fi
+
+if ! test -d ~git/.ssh; then
+    mkdir ~git/.ssh
+    chmod 700 ~git/.ssh
+fi
+
+if ! test -f ~git/.ssh/environment; then
+    echo "GOGS_CUSTOM=${GOGS_CUSTOM}" > ~git/.ssh/environment
+    chmod 600 ~git/.ssh/environment
+fi
+
+cd /app/gogs
+
+ln -sf /data/gogs/log  ./log
+ln -sf /data/gogs/data ./data
+
+chown -R git:git /data /app/gogs ~git/

--- a/docker/s6/openssh/run
+++ b/docker/s6/openssh/run
@@ -1,15 +1,7 @@
 #!/bin/sh
 
-if ! test -d /data/ssh
-then
-	mkdir -p /data/ssh
-	ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
-	ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
-	ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
-	ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
-	ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
-	chown -R root:root /data/ssh/*
-	chmod 600 /data/ssh/*
+if test -f ./setup; then
+    source ./setup
 fi
 
 exec gosu root /usr/sbin/sshd -D -f /app/gogs/docker/sshd_config

--- a/docker/s6/openssh/setup
+++ b/docker/s6/openssh/setup
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if ! test -d /data/ssh; then
+    mkdir -p /data/ssh
+    ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
+    ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
+    ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
+    ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
+    ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
+    chown -R root:root /data/ssh/*
+    chmod 600 /data/ssh/*
+fi

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,5 +8,9 @@ while read NAME CMD; do
     chmod +x /app/gogs/docker/s6/$NAME/run
 done
 
-# Exec S6 as process manager for gogs and dropbear ssh
-exec /usr/bin/s6-svscan /app/gogs/docker/s6/
+# Exec CMD or S6 by default if nothing present
+if [ $# -gt 0 ];then
+    exec "$@"
+else
+    exec /usr/bin/s6-svscan /app/gogs/docker/s6/
+fi


### PR DESCRIPTION
- Now using a setup script before starting the app. The separation of the run script and the setup script will make service initialization a little bit clearer
- Now calling start.sh script as ENTRYPOINT and S6 as CMD. This way when running the container with just a shell script, the start.sh script will be launched before, making debugging easier
- Added note about `.dockerignore` ignored during Docker Hub Automated Build