### PR TITLE
Docker Container Restart Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docker/docker/Dockerfile
 docker/docker/init_gogs.sh
 gogs.sublime-project
 gogs.sublime-workspace
+.tags*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.2
 MAINTAINER roemer.jp@gmail.com
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.5/gosu-amd64 /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.6/gosu-amd64 /usr/sbin/gosu
 RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
  && echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories \
  && apk -U --no-progress upgrade \

--- a/docker/s6/.s6-svscan/finish
+++ b/docker/s6/.s6-svscan/finish
@@ -1,2 +1,5 @@
 #!/bin/sh
-exec /bin/true
+
+# Cleanup SOCAT services and s6 event folder
+rm -rf $(find /app/gogs/docker/s6/ -name 'event')
+rm -rf /app/gogs/docker/s6/SOCAT_*

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
+# Cleanup SOCAT services and s6 event folder
+# On start and on shutdown in case container has been killed
+rm -rf $(find /app/gogs/docker/s6/ -name 'event')
+rm -rf /app/gogs/docker/s6/SOCAT_*
+
 # Bind linked docker container to localhost socket using socat
 env | sed -En 's|(.*)_PORT_([0-9]*)_TCP=tcp://(.*):(.*)|\1_\2 socat -ls TCP4-LISTEN:\2,fork,reuseaddr TCP4:\3:\4|p' | \
 while read NAME CMD; do
-    mkdir -p /app/gogs/docker/s6/$NAME
-    echo -e "#!/bin/sh\nexec $CMD" > /app/gogs/docker/s6/$NAME/run
-    chmod +x /app/gogs/docker/s6/$NAME/run
+    mkdir -p /app/gogs/docker/s6/SOCAT_$NAME
+    echo -e "#!/bin/sh\nexec $CMD" > /app/gogs/docker/s6/SOCAT_$NAME/run
+    chmod +x /app/gogs/docker/s6/SOCAT_$NAME/run
 done
 
 # Exec CMD or S6 by default if nothing present


### PR DESCRIPTION
- Fix s6 fifodir error on container restart, cleanup is done twice
    - On start so that the issue does not happen when container is killed  via `docker kill`
    - On stop so the resulting stopped container is clean if accessed by other means
- Add .tags* to .gitignore (Atom auto ctags generation)