### PR TITLE
Volumed data setup changed to allow #1759

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -1,11 +1,7 @@
 #!/bin/sh
 
-if ! test -d /data/gogs; then
-    mkdir -p /data/gogs/data /data/gogs/conf /data/gogs/log /data/git
-fi
-
 if ! test -d ~git/.ssh; then
-    mkdir ~git/.ssh
+    mkdir -p ~git/.ssh
     chmod 700 ~git/.ssh
 fi
 

--- a/docker/s6/openssh/setup
+++ b/docker/s6/openssh/setup
@@ -1,12 +1,26 @@
 #!/bin/sh
 
-if ! test -d /data/ssh; then
-    mkdir -p /data/ssh
+# Check if host keys are present, else create them
+if ! test -d /data/ssh/ssh_host_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
-    ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
-    ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
-    ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
-    ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
-    chown -R root:root /data/ssh/*
-    chmod 600 /data/ssh/*
 fi
+
+if ! test -d /data/ssh/ssh_host_rsa_key; then
+    ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
+fi
+
+if ! test -d /data/ssh/ssh_host_dsa_key; then
+    ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
+fi
+
+if ! test -d /data/ssh/ssh_host_ecdsa_key; then
+    ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
+fi
+
+if ! test -d /data/ssh/ssh_host_ed25519_key; then
+    ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
+fi
+
+# Set correct right to ssh keys
+chown -R root:root /data/ssh/*
+chmod 600 /data/ssh/*

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,6 +5,13 @@
 rm -rf $(find /app/gogs/docker/s6/ -name 'event')
 rm -rf /app/gogs/docker/s6/SOCAT_*
 
+# Create VOLUME subfolder
+for f in /data/gogs/data /data/gogs/conf /data/gogs/log /data/git /data/ssh; do
+    if ! test -d $f; then
+        mkdir -p $f
+    fi
+done
+
 # Bind linked docker container to localhost socket using socat
 env | sed -En 's|(.*)_PORT_([0-9]*)_TCP=tcp://(.*):(.*)|\1_\2 socat -ls TCP4-LISTEN:\2,fork,reuseaddr TCP4:\3:\4|p' | \
 while read NAME CMD; do


### PR DESCRIPTION
- Fixes #1759 
- Volumed subfolder now created up in the ENTRYPOINT script, this way
  they are created before S6 even starts making VOLUME.
- The subfolder will be created during VOLUME creation too as ENTRYPOINT
  script will be run before /bin/true
- SSH Keys will now be created on a single key basis not replying on the
  existence of /data/ssh folder