### PR TITLE
Docker repository path backward compatibility fix

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -12,7 +12,11 @@ fi
 
 cd /app/gogs
 
+# Link volumed data with app data
 ln -sf /data/gogs/log  ./log
 ln -sf /data/gogs/data ./data
+
+# Backward Compatibility with Docker v0.6.15
+ln -sf /data/git /home/git
 
 chown -R git:git /data /app/gogs ~git/

--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -16,7 +16,7 @@ cd /app/gogs
 ln -sf /data/gogs/log  ./log
 ln -sf /data/gogs/data ./data
 
-# Backward Compatibility with Docker v0.6.15
+# Backward Compatibility with Gogs Container v0.6.15
 ln -sf /data/git /home/git
 
 chown -R git:git /data /app/gogs ~git/


### PR DESCRIPTION
- resolve #1765
- create link to old git repository path: `/home/git/gogs-repository` for backward compatibility