### PR TITLE
Fix bug introduced in #1759 preventing ssh server to launch

### DIFF
--- a/docker/s6/openssh/setup
+++ b/docker/s6/openssh/setup
@@ -1,23 +1,23 @@
 #!/bin/sh
 
 # Check if host keys are present, else create them
-if ! test -d /data/ssh/ssh_host_key; then
+if ! test -f /data/ssh/ssh_host_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
 fi
 
-if ! test -d /data/ssh/ssh_host_rsa_key; then
+if ! test -f /data/ssh/ssh_host_rsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
 fi
 
-if ! test -d /data/ssh/ssh_host_dsa_key; then
+if ! test -f /data/ssh/ssh_host_dsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_dsa_key -N '' -t dsa
 fi
 
-if ! test -d /data/ssh/ssh_host_ecdsa_key; then
+if ! test -f /data/ssh/ssh_host_ecdsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi
 
-if ! test -d /data/ssh/ssh_host_ed25519_key; then
+if ! test -f /data/ssh/ssh_host_ed25519_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_ed25519_key -N '' -t ed25519
 fi
 


### PR DESCRIPTION
- ssh/setup: test directive now check if a file exist in key path instead of a folder
- ssh/setup script was hanging waiting for an input about rewriting the key as the test case was returning true, when it should have been false (check if file is a folder instead of a file)