### PR TITLE
Simplify disable Gravatar preference wording

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -257,7 +257,7 @@ continue = Continue
 cancel = Cancel
 
 enable_custom_avatar = Enable Custom Avatar
-enable_custom_avatar_helper = Enable this to disable fetch from Gravatar
+enable_custom_avatar_helper = Disable fetch from Gravatar
 choose_new_avatar = Choose new avatar
 update_avatar = Update Avatar Setting
 uploaded_avatar_not_a_image = Uploaded file is not a image.


### PR DESCRIPTION
"Enable this to disable..." is needlessly confusing, simplify it by being
upfront that this setting disables the Gravatar fetching.