### PR TITLE
Fix import path

### DIFF
--- a/modules/setting/setting_memcache.go
+++ b/modules/setting/setting_memcache.go
@@ -7,7 +7,7 @@
 package setting
 
 import (
-	_ "github.com/macaron-contrib/cache/memcache"
+	_ "github.com/go-macaron/cache/memcache"
 )
 
 func init() {

--- a/modules/setting/setting_redis.go
+++ b/modules/setting/setting_redis.go
@@ -7,8 +7,8 @@
 package setting
 
 import (
-	_ "github.com/macaron-contrib/cache/redis"
-	_ "github.com/macaron-contrib/session/redis"
+	_ "github.com/go-macaron/cache/redis"
+	_ "github.com/go-macaron/session/redis"
 )
 
 func init() {


### PR DESCRIPTION
Hello,
After re-compiling gogs with Redis from the master branch today, I wasn't able to run gogs. The error message was "panic: cache: unknown adapter 'redis'(forgot to import?)"
It's a minor issue with new go-macaron path.
Kenno