### PR TITLE
Update docker `socat` link creation

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -13,7 +13,7 @@ for f in /data/gogs/data /data/gogs/conf /data/gogs/log /data/git /data/ssh; do
 done
 
 # Bind linked docker container to localhost socket using socat
-USED_PORT="80:443:22"
+USED_PORT="3000:22"
 while read NAME ADDR PORT; do
     if test -z "$NAME$ADDR$PORT"; then
         continue

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -13,12 +13,24 @@ for f in /data/gogs/data /data/gogs/conf /data/gogs/log /data/git /data/ssh; do
 done
 
 # Bind linked docker container to localhost socket using socat
-env | sed -En 's|(.*)_PORT_([0-9]*)_TCP=tcp://(.*):(.*)|\1_\2 socat -ls TCP4-LISTEN:\2,fork,reuseaddr TCP4:\3:\4|p' | \
-while read NAME CMD; do
-    mkdir -p /app/gogs/docker/s6/SOCAT_$NAME
-    echo -e "#!/bin/sh\nexec $CMD" > /app/gogs/docker/s6/SOCAT_$NAME/run
-    chmod +x /app/gogs/docker/s6/SOCAT_$NAME/run
-done
+USED_PORT="80:443:22"
+while read NAME ADDR PORT; do
+    if test -z "$NAME$ADDR$PORT"; then
+        continue
+    elif echo $USED_PORT | grep -E "(^|:)$PORT($|:)" > /dev/null; then
+        echo "init:socat | Can't bind linked container ${NAME} to localhost, port ${PORT} already in use" 1>&2
+    else
+        SERV_FOLDER=/app/gogs/docker/s6/SOCAT_${NAME}_${PORT}
+        mkdir -p ${SERV_FOLDER}
+        CMD="socat -ls TCP4-LISTEN:${PORT},fork,reuseaddr TCP4:${ADDR}:${PORT}"
+        echo -e "#!/bin/sh\nexec $CMD" > ${SERV_FOLDER}/run
+        chmod +x ${SERV_FOLDER}/run
+        USED_PORT="${USED_PORT}:${PORT}"
+        echo "init:socat | Linked container ${NAME} will be binded to localhost on port ${PORT}" 1>&2
+    fi
+done << EOT
+$(env | sed -En 's|(.*)_PORT_([0-9]+)_TCP=tcp://(.*):([0-9]+)|\1 \3 \4|p')
+EOT
 
 # Exec CMD or S6 by default if nothing present
 if [ $# -gt 0 ];then


### PR DESCRIPTION
- `start.sh` will now verify that the port is not already used by another service when creating an `socat` link
- Log when a `socat` service is created, or could not be created making debugging easier with linked containers
- Keep track of which port is already used, including goes & sshd port to prevent collision
- Resolve #1807