### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The goal of this project is to make the easiest, fastest, and most painless way 
 
 ## Overview
 
-- Please see the [Documentation](http://gogs.io/docs/intro/) for project design, known issues, and change log.
+- Please see the [Documentation](http://gogs.io/docs/intro) for project design, known issues, and change log.
 - See the [Trello Board](https://trello.com/b/uxAoeLUl/gogs-go-git-service) to follow the develop team.
 - Want to try it before doing anything else? Do it [online](https://try.gogs.io/gogs/gogs) or go down to the **Installation -> Install from binary** section!
 - Having trouble? Get help with [Troubleshooting](http://gogs.io/docs/intro/troubleshooting.html).


### PR DESCRIPTION
The link http://gogs.io/docs/intro/ produces a 404 error and is used in the README updated it to http://gogs.io/docs/intro which correctly links to the introductory documentation.

I opened issue #1855

This pull request is to the appropriate branch. Sorry about that.