### PR TITLE
Fix the JSON field names for MigrateRepoForm

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -37,8 +37,8 @@ type MigrateRepoForm struct {
 	AuthPassword string `json:"auth_password"`
 	Uid          int64  `json:"uid" binding:"Required"`
 	RepoName     string `json:"repo_name" binding:"Required;AlphaDashDot;MaxSize(100)"`
-	Private      bool   `json:"mirror"`
-	Mirror       bool   `json:"private"`
+	Mirror       bool   `json:"mirror"`
+	Private      bool   `json:"private"`
 	Description  string `json:"description" binding:"MaxSize(255)"`
 }
 


### PR DESCRIPTION
For some reason, the field names for Private and Mirror got swapped.
This causes private non-mirror migrations created through the API to end up public, and public mirrors to end up private.