### PR TITLE
Add go-source directive to repo pages

### DIFF
--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -347,6 +347,8 @@ func RepoAssignment(redirect bool, args ...bool) macaron.Handler {
 
 		if ctx.Query("go-get") == "1" {
 			ctx.Data["GoGetImport"] = fmt.Sprintf("%s/%s/%s", setting.Domain, u.Name, repo.Name)
+			ctx.Data["GoDocDirectory"] = fmt.Sprintf("%s%s/%s/src/master{/dir}", setting.AppUrl, repo.Owner.LowerName, repo.LowerName)
+			ctx.Data["GoDocFile"] = fmt.Sprintf("%s%s/%s/src/master{/dir}/{file}#L{line}", setting.AppUrl, repo.Owner.LowerName, repo.LowerName)
 		}
 
 		if ctx.IsSigned {

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -11,6 +11,7 @@
 	<meta name="_suburl" content="{{AppSubUrl}}" />
 	{{if .GoGetImport}}
 	<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">
+	<meta name="go-source" content="{{.GoGetImport}} _ {{.GoDocDirectory}} {{.GoDocFile}}">
 	{{end}}
 
 	<link rel="shortcut icon" href="{{AppSubUrl}}/img/favicon.png" />

--- a/templates/ng/base/head.tmpl
+++ b/templates/ng/base/head.tmpl
@@ -8,7 +8,10 @@
 		<meta name="keywords" content="go, git, self-hosted, gogs">
 		<meta name="referrer" content="no-referrer" />
 		<meta name="_csrf" content="{{.CsrfToken}}" />
-		{{if .GoGetImport}}<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">{{end}}
+		{{if .GoGetImport}}
+		<meta name="go-import" content="{{.GoGetImport}} git {{.CloneLink.HTTPS}}">
+		<meta name="go-source" content="{{.GoGetImport}} _ {{.GoDocDirectory}} {{.GoDocFile}}">
+		{{end}}
 
 		<link rel="shortcut icon" href="{{AppSubUrl}}/img/favicon.png" />
 


### PR DESCRIPTION
This makes Gogs repos work with godoc.org: https://github.com/golang/gddo/wiki/Source-Code-Links