### PR TITLE
move minimum key sizes to config

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -116,6 +116,16 @@ DISABLE_MINIMUM_KEY_SIZE_CHECK = false
 ; Enable captcha validation for registration
 ENABLE_CAPTCHA = true
 
+; used to filter keys which are too short
+[service.minimum_key_sizes]
+ED25519 = 256
+ECDSA   = 256
+NTRU    = 1087
+MCE     = 1702
+McE     = 1702
+RSA     = 1024
+DSA     = 1024
+
 [webhook]
 ; Hook task queue length
 QUEUE_LENGTH = 1000

--- a/models/publickey.go
+++ b/models/publickey.go
@@ -117,16 +117,6 @@ func (key *PublicKey) GetAuthorizedString() string {
 	return fmt.Sprintf(_TPL_PUBLICK_KEY, appPath, key.ID, setting.CustomConf, key.Content)
 }
 
-var minimumKeySizes = map[string]int{
-	"(ED25519)": 256,
-	"(ECDSA)":   256,
-	"(NTRU)":    1087,
-	"(MCE)":     1702,
-	"(McE)":     1702,
-	"(RSA)":     1024,
-	"(DSA)":     1024,
-}
-
 func extractTypeFromBase64Key(key string) (string, error) {
 	b, err := base64.StdEncoding.DecodeString(key)
 	if err != nil || len(b) < 4 {
@@ -251,8 +241,8 @@ func CheckPublicKeyString(content string) (_ string, err error) {
 		if keySize == 0 {
 			return "", errors.New("cannot get key size of the given key")
 		}
-		keyType := strings.TrimSpace(sshKeygenOutput[len(sshKeygenOutput)-1])
-		if minimumKeySize := minimumKeySizes[keyType]; minimumKeySize == 0 {
+		keyType := strings.Trim(sshKeygenOutput[len(sshKeygenOutput)-1], " ()")
+		if minimumKeySize := setting.Service.MinimumKeySizes[keyType]; minimumKeySize == 0 {
 			return "", errors.New("sorry, unrecognized public key type")
 		} else if keySize < minimumKeySize {
 			return "", fmt.Errorf("the minimum accepted size of a public key %s is %d", keyType, minimumKeySize)

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -434,6 +434,7 @@ var Service struct {
 	EnableReverseProxyAuth         bool
 	EnableReverseProxyAutoRegister bool
 	DisableMinimumKeySizeCheck     bool
+	MinimumKeySizes                map[string]int
 	EnableCaptcha                  bool
 }
 
@@ -449,6 +450,11 @@ func newService() {
 	Service.EnableReverseProxyAutoRegister = sec.Key("ENABLE_REVERSE_PROXY_AUTO_REGISTRATION").MustBool()
 	Service.DisableMinimumKeySizeCheck = sec.Key("DISABLE_MINIMUM_KEY_SIZE_CHECK").MustBool()
 	Service.EnableCaptcha = sec.Key("ENABLE_CAPTCHA").MustBool()
+
+	minimumKeySizes := Cfg.Section("service.minimum_key_sizes").Keys()
+	for _, key := range minimumKeySizes {
+		Service.MinimumKeySizes[key.Name()] = key.MustInt()
+	}
 }
 
 var logLevels = map[string]string{


### PR DESCRIPTION
This patch moves the, currently hard coded, minimum key sizes into the configuration file. This way it is possible to enforce company security standards in gogs. For example it is now possible to disable DSA support or enforce RSA keys with a higher minimum length.

This also makes it possible to easily support new key formats as the only place which has to be adjusted is the configuration file.