### PR TITLE
HOME fix into FreeBSD init script

### DIFF
--- a/scripts/init/freebsd/gogs
+++ b/scripts/init/freebsd/gogs
@@ -31,7 +31,7 @@ stop_cmd="${name}_stop"
 gogs_start() {
 	cd ${gogs_directory}
 	export USER=${gogs_user}
-	export HOME=${gogs_directory}
+	export HOME=/usr/home/${gogs_user}
 	/usr/sbin/daemon -f -u ${gogs_user} -p ${pidfile} $command
 }
 


### PR DESCRIPTION
The gogs_directory is not necessarily the same as the HOME directory.
WIthout this gogs ends up writing the authorized_keys file at  $gogs_directory/.ssh/authorized_keys which is not always the right place for it.