### PR TITLE
Change regex for /compare/

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -536,7 +536,7 @@ func runWeb(ctx *cli.Context) {
 			m.Get("/forks", repo.Forks)
 		}, middleware.RepoRef())
 
-		m.Get("/compare/:before([a-z0-9]{40})...:after([a-z0-9]{40})", repo.CompareDiff)
+		m.Get("/compare/:before(.*[^.])...:after(.*[^.])", repo.CompareDiff)
 	}, ignSignIn, middleware.RepoAssignment(true))
 
 	m.Group("/:username", func() {


### PR DESCRIPTION
For full reference about the git rules on branch names, see `man git check-ref-format`.

I've changed the regex to allow many more branches names in the url, including branch names that include a slash. I've not implemented all the rules as defined by `man git check-ref-format`, however I don't think this is required because git should error from the very moment it notices there's something odd in the branch name.