### PR TITLE
fix #1957 - disable version display

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -334,3 +334,5 @@ it-IT = it
 
 [other]
 SHOW_FOOTER_BRANDING = false
+; Show version information about gogs and go in the footer
+SHOW_FOOTER_VERSION = true

--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -245,6 +245,7 @@ func Contexter() macaron.Handler {
 
 		ctx.Data["ShowRegistrationButton"] = setting.Service.ShowRegistrationButton
 		ctx.Data["ShowFooterBranding"] = setting.ShowFooterBranding
+		ctx.Data["ShowFooterVersion"] = setting.ShowFooterVersion
 
 		c.Map(ctx)
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -178,6 +178,7 @@ var (
 
 	// Other settings.
 	ShowFooterBranding bool
+	ShowFooterVersion  bool
 
 	// Global setting objects.
 	Cfg          *ini.File
@@ -425,6 +426,7 @@ func NewContext() {
 	dateLangs = Cfg.Section("i18n.datelang").KeysHash()
 
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
+	EnableShowVersion = Cfg.Section("other").Key("ENABLE_SHOW_VERSION").MustBool()
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -426,7 +426,7 @@ func NewContext() {
 	dateLangs = Cfg.Section("i18n.datelang").KeysHash()
 
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
-	EnableShowVersion = Cfg.Section("other").Key("ENABLE_SHOW_VERSION").MustBool()
+	ShowFooterVersion = Cfg.Section("other").Key("SHOW_FOOTER_VERSION").MustBool()
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -2,7 +2,7 @@
 	<footer>
 		<div class="ui container">
 			<div class="ui left">
-				© 2015 Gogs {{.i18n.Tr "version"}}: {{AppVer}} {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>
+				© 2015 Gogs {{ if .ShowFooterVersion }}{{.i18n.Tr "version"}}: {{AppVer}}{{ end }} {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>
 			</div>
 			<div class="ui right links">
 				{{if .ShowFooterBranding}}
@@ -20,7 +20,7 @@
 						</div>
         </div>
 				<a target="_blank" href="http://gogs.io">{{.i18n.Tr "website"}}</a>
-				<span class="version">{{GoVer}}</span>
+				{{ if .ShowFooterVersion }}<span class="version">{{GoVer}}</span>{{ end }}
 			</div>
 		</div>
 	</footer>

--- a/templates/ng/base/footer.tmpl
+++ b/templates/ng/base/footer.tmpl
@@ -1,7 +1,7 @@
 		</div>
 		<footer id="footer">
 		    <div class="container clear">
-		        <p class="left" id="footer-rights">© 2015 Gogs · {{.i18n.Tr "version"}}: {{AppVer}} · {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> ·
+		        <p class="left" id="footer-rights">© 2015 Gogs · {{ if .ShowFooterVersion }}{{.i18n.Tr "version"}}: {{AppVer}}{{ end }} · {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> ·
 		            {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong></p>
 
 		        <div class="right" id="footer-links">
@@ -21,7 +21,7 @@
 		                </div>
 		            </div>
 		            <a target="_blank" href="http://gogs.io">{{.i18n.Tr "website"}}</a>
-		            <span class="version">{{GoVer}}</span>
+		            {{ if .ShowVersionFooter }}<span class="version">{{GoVer}}</span>{{ end }}
 		        </div>
 		    </div>
 		</footer>


### PR DESCRIPTION
This allows the admin to disable the version information about gogs and
go in use in the footer.

This fixes #1957.