### PR TITLE
Fix #1965 - the hyperlink and the display name of the branch

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -966,7 +966,7 @@ notices.delete_success = System notice has been deleted successfully.
 [action]
 create_repo = created repository <a href="%s">%s</a>
 rename_repo = renamed repository from <code>%[1]s</code> to <a href="%[2]s">%[3]s</a>
-commit_repo = pushed to <a href="%s/src/%s">%[2]s</a> at <a href="%[1]s">%[3]s</a>
+commit_repo = pushed to <a href="%[1]s/src/%[2]s">%[3]s</a> at <a href="%[1]s">%[4]s</a>
 create_issue = `opened issue <a href="%s/issues/%s">%s#%[2]s</a>`
 create_pull_request = `created pull request <a href="%s/pulls/%s">%s#%[2]s</a>`
 comment_issue = `commented on issue <a href="%s/issues/%s">%s#%[2]s</a>`

--- a/modules/git/utils.go
+++ b/modules/git/utils.go
@@ -36,7 +36,8 @@ func parsePrettyFormatLog(repo *Repository, logByts []byte) (*list.List, error) 
 
 func RefEndName(refStr string) string {
 	if strings.HasPrefix(refStr, "refs/heads/") {
-		return strings.TrimPrefix(refStr, "refs/heads/")
+		// trim the "refs/heads/"
+		return return refStr[11:]
 	}
 
 	index := strings.LastIndex(refStr, "/")

--- a/modules/git/utils.go
+++ b/modules/git/utils.go
@@ -35,6 +35,10 @@ func parsePrettyFormatLog(repo *Repository, logByts []byte) (*list.List, error) 
 }
 
 func RefEndName(refStr string) string {
+	if strings.HasPrefix(refStr, "refs/heads/") {
+		return strings.TrimPrefix(refStr, "refs/heads/")
+	}
+
 	index := strings.LastIndex(refStr, "/")
 	if index != -1 {
 		return refStr[index+1:]

--- a/modules/git/utils.go
+++ b/modules/git/utils.go
@@ -37,7 +37,7 @@ func parsePrettyFormatLog(repo *Repository, logByts []byte) (*list.List, error) 
 func RefEndName(refStr string) string {
 	if strings.HasPrefix(refStr, "refs/heads/") {
 		// trim the "refs/heads/"
-		return return refStr[11:]
+		return refStr[len("refs/heads/"):]
 	}
 
 	index := strings.LastIndex(refStr, "/")

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -13,7 +13,8 @@
           {{else if eq .GetOpType 2}}
           {{$.i18n.Tr "action.rename_repo" .GetContent .GetRepoLink .GetRepoPath | Str2html}}
           {{else if eq .GetOpType 5}}
-          {{$.i18n.Tr "action.commit_repo" .GetRepoLink .GetBranch .GetRepoPath | Str2html}}
+          {{ $branchLink := .GetBranch | EscapePound}}
+          {{$.i18n.Tr "action.commit_repo" .GetRepoLink $branchLink .GetBranch .GetRepoPath | Str2html}}
           {{else if eq .GetOpType 6}}
           {{ $index := index .GetIssueInfos 0}}
           {{$.i18n.Tr "action.create_issue" .GetRepoLink $index .GetRepoPath | Str2html}}


### PR DESCRIPTION
The hyperlink and the display name of the branch if the branch is in a folder or the branch name has '#'

I didn't commit modules/bindata/bindata.go, you need to re-generate and commit it.

Fix #1965

**Bug Example**

I setup a branch like the issue said at https://try.gogs.io/john.doe/project_x
And I had add your account to the collaborator, you can see what listed below on the dashboard afte you logined:

```
john.doe pushed to #1965 at john.doe/project_x

 ceb578ba4e Initial commit
 bfd5a61610 Initial commit
```