### PR TITLE
Open and close issue count always 0

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -702,6 +702,12 @@ type IssueStatsOptions struct {
 	IsPull      bool
 }
 
+func checkErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 // GetIssueStats returns issue statistic information by given conditions.
 func GetIssueStats(opts *IssueStatsOptions) *IssueStats {
 	stats := &IssueStats{}
@@ -726,9 +732,11 @@ func GetIssueStats(opts *IssueStatsOptions) *IssueStats {
 
 	switch opts.FilterMode {
 	case FM_ALL, FM_ASSIGN:
-		results, _ := x.Query(queryStr+baseCond, false)
+		results, err := x.Query(queryStr+baseCond, false)
+		checkErr(err)
 		stats.OpenCount = parseCountResult(results)
-		results, _ = x.Query(queryStr+baseCond, true)
+		results, err = x.Query(queryStr+baseCond, true)
+		checkErr(err)
 		stats.ClosedCount = parseCountResult(results)
 
 	case FM_CREATE:


### PR DESCRIPTION
(This pull request is not supposed to be merged, is just to show a issue).

I've noticed that the issue count is always 0 (at least with PostgreSQL, not sure about others).

![1](https://cloud.githubusercontent.com/assets/7011819/11319843/283afd98-906c-11e5-930f-f85422b9cfb1.png)

I did a bit of investigation and found that the PG driver is returning an error on these 2 queries:

```
PANIC: pq: operator does not exist: boolean = integer
```