### PR TITLE
various fixes in gogs dump command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -60,10 +60,18 @@ func runDump(ctx *cli.Context) {
 	}
 
 	workDir, _ := setting.WorkDir()
-	z.AddFile("gogs-repo.zip", path.Join(workDir, "gogs-repo.zip"))
-	z.AddFile("gogs-db.sql", path.Join(workDir, "gogs-db.sql"))
-	z.AddDir("custom", path.Join(workDir, "custom"))
-	z.AddDir("log", path.Join(workDir, "log"))
+	if err := z.AddFile("gogs-repo.zip", path.Join(workDir, "gogs-repo.zip")); err !=nil {
+		log.Fatalf("Fail to include gogs-repo.zip: %v", err)
+	}
+	if err := z.AddFile("gogs-db.sql", path.Join(workDir, "gogs-db.sql")); err !=nil {
+		log.Fatalf("Fail to include gogs-db.sql: %v", err)
+	}
+	if err := z.AddDir("custom", path.Join(workDir, "custom")); err !=nil {
+		log.Fatalf("Fail to include custom: %v", err)
+	}
+	if err := z.AddDir("log", path.Join(workDir, "log")); err !=nil {
+		log.Fatalf("Fail to include log: %v", err)
+	}
 	// FIXME: SSH key file.
 	if err = z.Close(); err != nil {
 		os.Remove(fileName)

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -68,17 +68,21 @@ func runDump(ctx *cli.Context) {
 		log.Fatalf("Fail to create %s: %v", fileName, err)
 	}
 
-	workDir, _ := setting.WorkDir()
 	if err := z.AddFile("gogs-repo.zip", reposDump); err !=nil {
 		log.Fatalf("Fail to include gogs-repo.zip: %v", err)
 	}
 	if err := z.AddFile("gogs-db.sql", dbDump); err !=nil {
 		log.Fatalf("Fail to include gogs-db.sql: %v", err)
 	}
-	if err := z.AddDir("custom", path.Join(workDir, "custom")); err !=nil {
-		log.Fatalf("Fail to include custom: %v", err)
+	customDir, err := os.Stat(setting.CustomPath)
+	if err == nil && customDir.IsDir() {
+		if err := z.AddDir("custom", setting.CustomPath); err !=nil {
+			log.Fatalf("Fail to include custom: %v", err)
+	    }
+	} else {
+		log.Printf("Custom dir %s doesn't exist, skipped", setting.CustomPath)
 	}
-	if err := z.AddDir("log", path.Join(workDir, "log")); err !=nil {
+	if err := z.AddDir("log", setting.LogRootPath); err !=nil {
 		log.Fatalf("Fail to include log: %v", err)
 	}
 	// FIXME: SSH key file.

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -93,5 +93,5 @@ func runDump(ctx *cli.Context) {
 
 	log.Printf("Removing tmp work dir: %s", TmpWorkDir)
 	os.RemoveAll(TmpWorkDir)
-	log.Println("Finish dumping!")
+	log.Printf("Finish dumping in file %s", fileName)
 }


### PR DESCRIPTION
fixes includes:

* adding error handling on the target dump creation
* using a temporary directory to create the db and repositories dumps
* using the proper setting.<dir> instead of setting.workDir() for log/ and custom/
* adding few logs for tmpdir handling
* adding the name of the generated archive in  the final log

It fixes some weird behaviors where if the log/ and custom/ are not in a path relative to the gogs binary directory and if the command is not run from this directory, **gogs dump** will fail silently and create an empty archive.