### PR TITLE
Repo file list layout & misc fixes

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -77,7 +77,7 @@ func fail(userMessage, logMessage string, args ...interface{}) {
 
 	if len(logMessage) > 0 {
 		if !setting.ProdMode {
-			fmt.Fprintf(os.Stderr, logMessage, args...)
+			fmt.Fprintf(os.Stderr, logMessage+"\n", args...)
 		}
 		log.GitLogger.Fatal(3, logMessage, args...)
 		return

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -65,7 +65,10 @@ func handleServerConn(keyID string, chans <-chan ssh.NewChannel) {
 					cmdName := strings.TrimLeft(payload, "'()")
 					os.Setenv("SSH_ORIGINAL_COMMAND", cmdName)
 					log.Trace("Payload: %v", cmdName)
-					cmd := exec.Command(setting.AppPath, "serv", "key-"+keyID)
+
+					args := []string{"serv", "key-" + keyID, "--config=" + setting.CustomConf}
+					log.Trace("Arguments: %v", args)
+					cmd := exec.Command(setting.AppPath, args...)
 
 					stdout, err := cmd.StdoutPipe()
 					if err != nil {
@@ -153,6 +156,7 @@ func Listen(port int) {
 		if err != nil {
 			panic(fmt.Sprintf("Fail to generate private key: %v - %s", err, stderr))
 		}
+		log.Trace("New private key is generateed: %s", keyPath)
 	}
 
 	privateBytes, err := ioutil.ReadFile(keyPath)

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -5,7 +5,9 @@
   font-style: normal;
 }
 .octicon,
-.mega-octicon {
+.mega-octicon,
+.icon.octicon,
+.icon.mega-octicon {
   font: normal normal normal 16px/1 octicons;
   display: inline-block;
   text-decoration: none;

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1868,9 +1868,6 @@ footer .container .links > *:first-child {
   margin-bottom: -4px;
   width: 400px;
 }
-.repository.file.list #repo-files-table thead th .age {
-  margin-top: 2px;
-}
 .repository.file.list #repo-files-table thead .ui.avatar {
   margin-bottom: 5px;
 }
@@ -2242,25 +2239,6 @@ footer .container .links > *:first-child {
 .repository.commits .header .ui.right .search input {
   font-weight: normal;
   padding: 5px 10px;
-}
-.repository .commits.table {
-  font-size: 13px;
-}
-.repository .commits.table th:first-child,
-.repository .commits.table td:first-child {
-  padding-left: 15px;
-}
-.repository .commits.table td {
-  line-height: 15px;
-}
-.repository .commits.table .author {
-  min-width: 180px;
-}
-.repository .commits.table .message span {
-  max-width: 500px;
-}
-.repository .commits.table .date {
-  width: 120px;
 }
 .repository .diff-detail-box {
   margin: 15px 0;

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -916,6 +916,16 @@ pre.raw {
 .ui.status.buttons .octicon {
   margin-right: 4px;
 }
+.ui .sha.label {
+  font-family: Consolas, Menlo, Monaco, "Lucida Console", monospace;
+  font-size: 13px;
+  padding: 6px 10px 4px 10px;
+  font-weight: normal;
+  margin: 0 6px;
+}
+.ui .white.label {
+  background-color: white;
+}
 .overflow.menu .items {
   max-height: 300px;
   overflow-y: auto;
@@ -1865,20 +1875,10 @@ footer .container .links > *:first-child {
   margin-bottom: 5px;
 }
 .repository.file.list #repo-files-table tbody .icon {
-  margin-left: 5px;
-}
-.repository.file.list #repo-files-table tbody .name {
-  max-width: 120px;
-}
-.repository.file.list #repo-files-table tbody .message {
-  max-width: 300px;
-}
-.repository.file.list #repo-files-table tbody .age {
-  min-width: 150px;
+  margin-right: 5px;
 }
 .repository.file.list #repo-files-table tbody .text.truncate {
-  margin-bottom: -5px;
-  max-width: 100%;
+  max-width: 88%;
 }
 .repository.file.list #repo-files-table td {
   padding-top: 8px;
@@ -2261,12 +2261,6 @@ footer .container .links > *:first-child {
 }
 .repository .commits.table .date {
   width: 120px;
-}
-.repository .sha.label {
-  font-family: Consolas, Menlo, Monaco, "Lucida Console", monospace;
-  font-size: 14px;
-  padding: 6px 10px 4px 10px;
-  font-weight: normal;
 }
 .repository .diff-detail-box {
   margin: 15px 0;

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -20,8 +20,7 @@
     <thead>
       <tr>
         <th>{{.i18n.Tr "repo.commits.author"}}</th>
-        <th>SHA1</th>
-        <th>{{.i18n.Tr "repo.commits.message"}}</th>
+        <th class="message"><span class="ui sha white label">&nbsp;&nbsp;&nbsp;SHA1&nbsp;&nbsp;&nbsp;</span> {{.i18n.Tr "repo.commits.message"}}</th>
         <th>{{.i18n.Tr "repo.commits.date"}}</th>
       </tr>
     </thead>
@@ -36,8 +35,10 @@
           <img class="ui avatar image" src="{{AvatarLink .Author.Email}}" alt=""/>&nbsp;&nbsp;{{.Author.Name}}
           {{end}}
         </td>
-        <td class="sha"><a rel="nofollow" class="ui green sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}} ">{{SubStr .ID.String 0 10}} </a></td>
-        <td class="message"><span class="text truncate">{{RenderCommitMessage .Summary $.RepoLink}}</span></td>
+        <td class="message">
+          <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
+          <span class="text truncate">{{RenderCommitMessage .Summary $.RepoLink}}</span>
+        </td>
         <td class="date">{{TimeSince .Author.When $.Lang}}</td>
       </tr>
     {{end}}

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -19,9 +19,9 @@
   <table class="ui very basic striped commits table">
     <thead>
       <tr>
-        <th>{{.i18n.Tr "repo.commits.author"}}</th>
-        <th class="message"><span class="ui sha white label">&nbsp;&nbsp;&nbsp;SHA1&nbsp;&nbsp;&nbsp;</span> {{.i18n.Tr "repo.commits.message"}}</th>
-        <th>{{.i18n.Tr "repo.commits.date"}}</th>
+        <th class="four wide">{{.i18n.Tr "repo.commits.author"}}</th>
+        <th class="eight wide message"><span class="ui sha white label">&nbsp;&nbsp;&nbsp;SHA1&nbsp;&nbsp;&nbsp;</span> {{.i18n.Tr "repo.commits.message"}}</th>
+        <th class="four wide right aligned">{{.i18n.Tr "repo.commits.date"}}</th>
       </tr>
     </thead>
     <tbody>
@@ -39,7 +39,7 @@
           <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
           <span class="text truncate">{{RenderCommitMessage .Summary $.RepoLink}}</span>
         </td>
-        <td class="date">{{TimeSince .Author.When $.Lang}}</td>
+        <td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
       </tr>
     {{end}}
     </tbody>

--- a/templates/repo/sidebar.tmpl
+++ b/templates/repo/sidebar.tmpl
@@ -1,16 +1,16 @@
 {{if not .IsBareRepo}}
 <div class="ui {{if .IsRepositoryAdmin}}five{{else}}four{{end}} item menu">
   <a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
-    <i class="icon octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui blue label">{{.Repository.NumOpenIssues}}</span>
+    <i class="icon octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if eq 0 .Repository.NumOpenIssues}}gray{{else}}blue{{end}} label">{{.Repository.NumOpenIssues}}</span>
   </a>
   <a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
-    <i class="icon octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui blue label">{{.Repository.NumOpenPulls}}</span>
+    <i class="icon octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui {{if eq 0 .Repository.NumOpenPulls}}gray{{else}}blue{{end}} label">{{.Repository.NumOpenPulls}}</span>
   </a>
   <a class="{{if .PageIsCommits}}active{{end}} item" href="{{.RepoLink}}/commits/{{EscapePound .BranchName}}">
-    <i class="icon octicon octicon-history"></i> {{.i18n.Tr "repo.commits"}} <span class="ui blue label">{{.CommitsCount}}</span>
+    <i class="icon octicon octicon-history"></i> {{.i18n.Tr "repo.commits"}} <span class="ui {{if eq 0 .CommitsCount}}gray{{else}}blue{{end}} label">{{.CommitsCount}}</span>
   </a>
   <a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
-    <i class="icon octicon octicon-tag"></i> {{.i18n.Tr "repo.releases"}} <span class="ui blue label">{{.Repository.NumTags}}</span>
+    <i class="icon octicon octicon-tag"></i> {{.i18n.Tr "repo.releases"}} <span class="ui {{if eq 0 .Repository.NumTags}}gray{{else}}blue{{end}} label">{{.Repository.NumTags}}</span>
   </a>
   {{if .IsRepositoryAdmin}}
   <a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -1,28 +1,26 @@
 <table id="repo-files-table" class="ui table">
   <thead>
     <tr>
-      <th colspan="5" class="clear">
+      <th colspan="2">
         <span>
           {{if .LastCommitUser}}
           <img class="ui avatar image img-12" src="{{.LastCommitUser.AvatarLink}}" />
-          <a href="{{AppSubUrl}}/{{.LastCommitUser.Name}}"><strong>{{.LastCommit.Author.Name}}</strong></a>:
+          <a href="{{AppSubUrl}}/{{.LastCommitUser.Name}}"><strong>{{.LastCommit.Author.Name}}</strong></a>
           {{else}}
           <img class="ui avatar image img-12" src="{{AvatarLink .LastCommit.Author.Email}}" />
-          <strong>{{.LastCommit.Author.Name}}</strong>:
+          <strong>{{.LastCommit.Author.Name}}</strong>
           {{end}}
         </span>
-        <a class="text black" href="{{.RepoLink}}/commit/{{.LastCommit.ID}}" rel="nofollow">
-        <strong>{{ShortSha .LastCommit.ID.String}}</strong></a>
-        <span class="text truncate grey" id="last-commit-message">{{RenderCommitMessage .LastCommit.Summary .RepoLink}}</span>
-        <span class="ui right text grey age">{{TimeSince .LastCommit.Author.When $.Lang}}</span>
+        <a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.LastCommit.ID}}" rel="nofollow">{{ShortSha .LastCommit.ID.String}}</a>
+        <span class="text truncate grey">{{RenderCommitMessage .LastCommit.Summary .RepoLink}}</span>
       </th>
+      <th class="text grey right age four wide">{{TimeSince .LastCommit.Author.When $.Lang}}</th>
     </tr>
   </thead>
   <tbody>
     {{if .HasParentPath}}
     <tr class="has-parent">
-      <td><span class="octicon octicon-mail-reply"></span></td>
-      <td><a href="{{EscapePound .BranchLink}}{{.ParentPath}}">..</a></td>
+      <td colspan="3"><i class="icon octicon octicon-mail-reply"></i><a href="{{EscapePound .BranchLink}}{{.ParentPath}}">..</a></td>
     </tr>
     {{end}}
     {{range $item := .Files}}
@@ -30,10 +28,8 @@
       {{$commit := index $item 1}}
       <tr>
         {{if $entry.IsSubModule}}
-        <td>
+        <td class="four wide">
           <span class="icon octicon octicon-file-submodule"></span>
-        </td>
-        <td>
           {{if $commit.RefUrl}}
           <a href="{{$commit.RefUrl}}" class="text truncate">{{$entry.Name}}</a> @ <a href="{{$commit.RefUrl}}/commit/{{$commit.RefId}}">{{ShortSha $commit.RefId}}</a>
           {{else}}
@@ -41,20 +37,16 @@
           {{end}}
         </td>
         {{else}}
-        <td>
+        <td class="name four wide">
           <span class="icon octicon octicon-file-{{if or $entry.IsDir}}directory{{else}}text{{end}}"></span>
-        </td>
-        <td class="name">
           <a href="{{EscapePound $.BranchLink}}/{{EscapePound $.TreePath}}{{EscapePound $entry.Name}}" class="text truncate">{{$entry.Name}}</a>
         </td>
         {{end}}
-        <td class="sha">
-          <a rel="nofollow" class="ui green sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.ID}} ">{{SubStr $commit.ID.String 0 10}} </a>
-        </td>
-        <td class="message">
+        <td class="message collapsing eight wide">
+          <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.ID}}">{{ShortSha $commit.ID.String}}</a>
           <span class="text truncate">{{RenderCommitMessage $commit.Summary $.RepoLink}}</span>
         </td>
-        <td class="text grey right age">{{TimeSince $commit.Committer.When $.Lang}}</td>
+        <td class="text grey right age four wide">{{TimeSince $commit.Committer.When $.Lang}}</td>
       </tr>
     {{end}}
   </tbody>


### PR DESCRIPTION
This patch improves experience, making Octicons and repo file list look better. 

* Ensure Octicons are used with 16px font size
* UI: Mark top menu icons blue only when non-zero
* UI: Gray SHA1 next to message, file list collapse

I can understand that changing SHA1 label color to gray may be arguable, but I believe that this make the whole UI more balanced and less aggressive-looking. I believe that colorful labels should be reserved either for tags or issue types.

##### Before changes (current `devel`)

![repo-file-list-layout-before](https://cloud.githubusercontent.com/assets/103067/11478555/066f636a-978e-11e5-8a10-432341244ec4.png)

##### After changes

![repo-file-list-layout-after](https://cloud.githubusercontent.com/assets/103067/11478558/0ae3c238-978e-11e5-82dc-dfeb785f3d97.png)
