### PR TITLE
Admin should be able to see all organizations

### DIFF
--- a/modules/middleware/org.go
+++ b/modules/middleware/org.go
@@ -48,7 +48,12 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 		return
 	}
 
-	if ctx.IsSigned {
+	// Admin has super access.
+	if ctx.IsSigned && ctx.User.IsAdmin {
+		ctx.Org.IsOwner = true
+		ctx.Org.IsMember = true
+		ctx.Org.IsAdminTeam = true
+	} else if ctx.IsSigned {
 		ctx.Org.IsOwner = org.IsOwnedBy(ctx.User.Id)
 		if ctx.Org.IsOwner {
 			ctx.Org.IsMember = true
@@ -68,6 +73,7 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 		return
 	}
 	ctx.Data["IsOrganizationOwner"] = ctx.Org.IsOwner
+	ctx.Data["IsOrganizationMember"] = ctx.Org.IsMember
 
 	ctx.Org.OrgLink = setting.AppSubUrl + "/org/" + org.Name
 	ctx.Data["OrgLink"] = ctx.Org.OrgLink

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -316,7 +316,7 @@ func showOrgProfile(ctx *middleware.Context) {
 	org := ctx.Org.Organization
 	ctx.Data["Title"] = org.FullName
 
-	repos, err := models.GetRepositories(org.Id, ctx.IsSigned && org.IsOrgMember(ctx.User.Id))
+	repos, err := models.GetRepositories(org.Id, ctx.IsSigned && (ctx.User.IsAdmin || org.IsOrgMember(ctx.User.Id)))
 	if err != nil {
 		ctx.Handle(500, "GetRepositories", err)
 		return

--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -24,7 +24,6 @@
 
   <div class="ui container">
     <div class="ui grid">
-      {{$isMember := .Org.IsOrgMember $.SignedUser.Id}}
       <div class="ui eleven wide column">
         {{if .IsOrganizationOwner}}
         <div class="text right">
@@ -38,13 +37,14 @@
       <div class="ui five wide column">
         <h4 class="ui top attached header">
           <strong>{{.i18n.Tr "org.people"}}</strong>
-          {{if $isMember}}
+          {{if .IsOrganizationMember}}
           <div class="ui right">
             <a class="text grey" href="{{.OrgLink}}/members"><strong>{{.Org.NumMembers}}</strong><span class="octicon octicon-chevron-right"></span></a>
           </div>
           {{end}}
         </h4>
         <div class="ui attached segment members">
+          {{$isMember := .IsOrganizationMember}}
           {{range .Members}}
             {{if or $isMember (.IsPublicMember $.Org.Id)}}
             <a href="{{.HomeLink}}" title="{{.Name}}"><img class="ui avatar" src="{{.AvatarLink}}"></a>
@@ -57,7 +57,7 @@
         </div>
         {{end}}
 
-        {{if $isMember}}
+        {{if .IsOrganizationMember}}
         <div class="ui top attached header">
           <strong>{{.i18n.Tr "org.teams"}}</strong>
           <div class="ui right">


### PR DESCRIPTION
This is follow-up for 56c66ee486b4b8d544201662de62a23f36e6a069 allowing admin
to see private repositories, even when not being member of them.

Without this patch, admin is effectively unable to edit any organization, so is not really an admin.

(this is rebased to `develop` PR #2054)