### PR TITLE
UI: Remove CSS rule making last-commit SHA bold

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1863,9 +1863,6 @@ footer .container .links > *:first-child {
   position: relative;
   width: 325%;
 }
-.repository.file.list #repo-files-table thead th .ui.sha.label {
-  font-weight: bold;
-}
 .repository.file.list #repo-files-table thead .ui.avatar {
   margin-bottom: 5px;
 }

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -152,10 +152,6 @@
 						position: relative;
 						width: 325%;
 					}
-
-					.ui.sha.label {
-					  font-weight: bold;
-					}
 				}
 				.ui.avatar {
 					margin-bottom: 5px;


### PR DESCRIPTION
This removes remains from old design, that was not cleaned by previous #2068 PR.

![before](https://cloud.githubusercontent.com/assets/103067/11560803/58230914-99c3-11e5-8af1-176eb378a3b0.png) **--->** ![after](https://cloud.githubusercontent.com/assets/103067/11560805/5c975630-99c3-11e5-99d7-605e196d7ae5.png)

