### PR TITLE
UI: Use more subtle grey SHA1 labels

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2243,6 +2243,9 @@ footer .container .links > *:first-child {
   font-size: 13px;
   padding: 6px 40px 4px 35px;
 }
+.repository #commits-table.ui.basic.striped.table tbody tr:nth-child(2n) {
+  background-color: rgba(0, 0, 0, 0.02) !important;
+}
 .repository .diff-detail-box {
   margin: 15px 0;
   line-height: 30px;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -602,6 +602,9 @@
 		    padding: 6px 40px 4px 35px;
 			}
 		}
+		&.ui.basic.striped.table tbody tr:nth-child(2n) {
+			background-color: rgba(0, 0, 0, .02)!important;
+		}
 	}
 
 	.diff-detail-box {

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -36,7 +36,7 @@
           {{end}}
         </td>
         <td class="message collapsing">
-          <a rel="nofollow" class="ui green sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
+          <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
           {{RenderCommitMessage .Summary $.RepoLink}}   
         </td>
         <td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -43,7 +43,7 @@
         </td>
         {{end}}
         <td class="message collapsing">
-          <a rel="nofollow" class="ui green sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.ID}}">{{ShortSha $commit.ID.String}}</a>
+          <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.ID}}">{{ShortSha $commit.ID.String}}</a>
           {{RenderCommitMessage $commit.Summary $.RepoLink}}
         </td>
         <td class="text grey right age">{{TimeSince $commit.Committer.When $.Lang}}</td>


### PR DESCRIPTION
Current green SHA1 labels are more pronounced than other UI elements attracting attention as if they were most important thing in the UI, while they are not as important, especially without real Git client.

Using grey SHA1 labels makes the UI more balanced, less aggressive and lets user to focus on other content elements.

##### Current

![current](https://cloud.githubusercontent.com/assets/103067/11561598/c9e2ff46-99c8-11e5-92bd-a917e8dabd1f.png)
![current](https://cloud.githubusercontent.com/assets/103067/11561918/db46c72a-99ca-11e5-95cc-3131c1dd5b09.png)

##### Proposed

![proposed](https://cloud.githubusercontent.com/assets/103067/11561602/cf4b8660-99c8-11e5-990c-42f589cc8355.png)
![proposed](https://cloud.githubusercontent.com/assets/103067/11561915/d81ef72a-99ca-11e5-84a8-b55f5ab00748.png)

NOTE: Neither GitHub or Bitbucket uses so heavy pronunciation as Gogs. (they are also not using SHAs on file list, that's why showing commit lists below)

##### Git

![github](https://cloud.githubusercontent.com/assets/103067/11561595/c495b8f8-99c8-11e5-94aa-0c67617c731c.png)

##### Bitbucket

![bitbucket](https://cloud.githubusercontent.com/assets/103067/11561605/d5c67518-99c8-11e5-879e-ecf6f87cc605.png)

This was previously proposed by #2068 and supported by @Depado.

## Discussion

I know there are supporters of current green SHA1 label look, and many users that are used to them. But they are also ppl that may find them distracting and actually repellent, that is why I humbly ask for concrete arguments behind having green labels and for keeping current design. Thank you.