### PR TITLE
Render commit msg as header + verbatim description

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -895,12 +895,21 @@ pre.raw {
 .ui .warning.segment {
   border-color: #F0C36D;
 }
-.ui .info.header {
-  background-color: #d9edf7 !important;
-  border-color: #85c5e5;
-}
 .ui .info.segment {
   border-color: #85c5e5;
+}
+.ui .info.segment.top {
+  background-color: #d9edf7 !important;
+}
+.ui .info.segment.top h3,
+.ui .info.segment.top h4 {
+  margin-top: 0;
+}
+.ui .info.segment.top h3:last-child {
+  margin-top: 4px;
+}
+.ui .info.segment.top > :last-child {
+  margin-bottom: 0;
 }
 .ui .normal.header {
   font-weight: normal;

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -196,12 +196,20 @@ pre {
 		}
 	}
 	.info {
-		&.header {
-			background-color: #d9edf7 !important;
-    	border-color: #85c5e5;
-		}
 		&.segment {
-    	border-color: #85c5e5;
+			border-color: #85c5e5;
+			&.top {
+				background-color: #d9edf7 !important;
+				h3, h4 {
+					margin-top: 0;
+				}
+				h3:last-child {
+					margin-top: 4px;
+				}
+				> :last-child {
+					margin-bottom: 0;
+				}
+			}
 		}
 	}
 

--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -37,7 +37,7 @@
         </td>
         <td class="message collapsing">
           <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSha .ID.String}}</a>
-          {{RenderCommitMessage .Summary $.RepoLink $.Repository.ComposeMetas}}   
+          {{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}
         </td>
         <td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
       </tr>

--- a/templates/repo/diff.tmpl
+++ b/templates/repo/diff.tmpl
@@ -5,14 +5,12 @@
     {{if .IsDiffCompare }}
     {{template "repo/commits_table" .}}
     {{else}}
-    <h4 class="ui top attached info header">
-      <div class="ui right">
-        <a class="ui blue tiny button" href="{{EscapePound .SourcePath}}">
-          {{.i18n.Tr "repo.diff.browse_source"}}
-        </a>
-      </div>
-      {{RenderCommitMessage .Commit.Message $.RepoLink $.Repository.ComposeMetas}}
-    </h4>
+    <div class="ui top attached info clearing segment">
+      <a class="ui floated right blue tiny button" href="{{EscapePound .SourcePath}}">
+        {{.i18n.Tr "repo.diff.browse_source"}}
+      </a>
+      {{RenderCommitMessage true .Commit.Message $.RepoLink $.Repository.ComposeMetas}}
+    </div>
     <div class="ui attached info segment">
       {{if .Author}}
       <img class="ui avatar image" src="{{.Author.AvatarLink}}" />

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -10,7 +10,7 @@
         <strong>{{.LastCommit.Author.Name}}</strong>
         {{end}}
         <a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.LastCommit.ID}}" rel="nofollow">{{ShortSha .LastCommit.ID.String}}</a>
-        <span class="grey">{{RenderCommitMessage .LastCommit.Summary .RepoLink $.Repository.ComposeMetas}}</span>
+        <span class="grey">{{RenderCommitMessage false .LastCommit.Summary .RepoLink $.Repository.ComposeMetas}}</span>
       </th>
       <th class="nine wide">
       </th>
@@ -44,7 +44,7 @@
         {{end}}
         <td class="message collapsing">
           <a rel="nofollow" class="ui sha label" href="{{AppSubUrl}}/{{$.Username}}/{{$.Reponame}}/commit/{{$commit.ID}}">{{ShortSha $commit.ID.String}}</a>
-          {{RenderCommitMessage $commit.Summary $.RepoLink $.Repository.ComposeMetas}}
+          {{RenderCommitMessage false $commit.Summary $.RepoLink $.Repository.ComposeMetas}}
         </td>
         <td class="text grey right age">{{TimeSince $commit.Committer.When $.Lang}}</td>
       </tr>


### PR DESCRIPTION
Most commit in Git are expected to follow standard of single header line,
followed by description paragraphs, separated by empty line from previous block.

Previously Gogs were treating everything as single header. Now we are trying to
render only first line as header, but following lines (description chunks) as a
verbatim.

#### Before (current `develop`)

![before](https://cloud.githubusercontent.com/assets/103067/11616352/ca261bd4-9c78-11e5-8112-5dffa00bd505.png)

#### After (this PR)

![after](https://cloud.githubusercontent.com/assets/103067/11616355/d217c69e-9c78-11e5-8bf8-fb68f7e809bd.png)
