### PR TITLE
TextMate project file

### DIFF
--- a/.tm_properties
+++ b/.tm_properties
@@ -1,0 +1,41 @@
+# TextMate 2 project file
+#
+# Copyright 2015 The Gogs Authors. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
+
+# build with sqlite
+TM_MAKE_FLAGS = 'TAGS=sqlite'
+
+# exclude binary data from search
+binary                = '{gogs,*.{jpg,png,eot,ttf,woff,woff2,otf}}'
+excludeInFolderSearch = '{data,gogs-repositories*,modules/bindata,.git,*.min.css}'
+includeFiles          = '{.bra.toml,.dockerignore,.gitignore,.gopmfile,.pkgr.yml,.travis.yml}'
+
+# set language for translations based on file name suffix
+[ locale_*.ini ]
+FILE_LANGUAGE    = '${TM_FILEPATH/^.*locale_([a-z]+)-([A-Z]+).*$/$1_$2/}'
+windowTitle      = '$TM_FILEPATH — $FILE_LANGUAGE Translation'
+spellingLanguage = '$FILE_LANGUAGE'
+
+# tmpl files are html
+[ *.tmpl ]
+fileType = text.html
+
+# ini files are ini
+[ *.ini ]
+fileType = source.ini
+
+# use (hard) tabs in all files
+[ source.go; text.html ]
+softTabs       = false
+tabSize        = 2
+wrapColumn     = 0
+softWrap       = true
+showWrapColumn = false
+
+[ README.md ]
+spellingLanguage = 'en_US'
+
+[ README_ZH.md ]
+spellingLanguage = 'zh_CN'

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build: $(GENERATED)
 	go install -ldflags '$(LDFLAGS)' -tags '$(TAGS)'
 	cp '$(GOPATH)/bin/gogs' .
 
+run: build
+	./gogs web
+
 govet:
 	go tool vet -composites=false -methods=false -structtags=false .
 


### PR DESCRIPTION
TextMate 2 project properties file

1. Defining code style
2. Describing which files should not be searched (binaries)
3. Automatically sets the spelling language for translations

Also adds makefile "run" phony target required to be able to simply <kbd>⌘R</kbd> to run "gogs web" within TextMate 2.