### PR TITLE
Allow pre-receive hook customization

### DIFF
--- a/modules/git/hooks.go
+++ b/modules/git/hooks.go
@@ -27,6 +27,7 @@ var hookNames = []string{
 	"post-checkout",
 	"post-merge",
 	"pre-push",
+	"pre-receive",
 	// "update",
 	"post-receive",
 	"post-update",


### PR DESCRIPTION
This hook can be used for example to reject too large commits and it is
executed before "update" hook, used exclusively by Gogs to update its state.

https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks