### PR TITLE
Makefile: Do not fail build on missing lessc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ NOW = $(shell date -u '+%Y%m%d%I%M%S')
 
 .PHONY: build pack release bindata clean
 
+.IGNORE: public/css/gogs.css
+
 build: $(GENERATED)
 	go install -ldflags '$(LDFLAGS)' -tags '$(TAGS)'
 	cp '$(GOPATH)/bin/gogs' .


### PR DESCRIPTION
This is achieved by adding public/css/gogs.css to special .IGNORE target, which
makes inability to generate/update gogs.css non-fatal and not stopping whole
build process. User is still notified about missing lessc command though, since
inability to update CSS may lead to potential problems:

    lessc public/less/gogs.less public/css/gogs.css
    make: lessc: No such file or directory
    make: [public/css/gogs.css] Error 1 (ignored)

More info at:

  https://www.gnu.org/software/make/manual/html_node/Special-Targets.html