### PR TITLE
gogs: add import that lets gogs run as a stand-alone windows service

### DIFF
--- a/gogs.go
+++ b/gogs.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 
 	"github.com/codegangsta/cli"
+	_ "github.com/kardianos/minwinsvc"
 
 	"github.com/gogits/gogs/cmd"
 	"github.com/gogits/gogs/modules/setting"


### PR DESCRIPTION
Updates #630