### PR TITLE
LOCAL_ROOT_URL for workers accessing web service 

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -109,7 +109,7 @@ func handleUpdateTask(uuid string, user *models.User, username, reponame string,
 	}
 
 	// Ask for running deliver hook and test pull request tasks.
-	reqURL := setting.AppUrl + username + "/" + reponame + "/tasks/trigger?branch=" +
+	reqURL := setting.LocalUrl + username + "/" + reponame + "/tasks/trigger?branch=" +
 		strings.TrimPrefix(task.RefName, "refs/heads/")
 	log.GitLogger.Trace("Trigger task: %s", reqURL)
 

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -46,6 +46,10 @@ DOMAIN = localhost
 ROOT_URL = %(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
 HTTP_ADDR =
 HTTP_PORT = 3000
+; Local (DMZ) URL for Gogs workers (such as SSH update) accessing web service.
+; In most cases you do not need to change the default value.
+; Alter it only if your SSH server node is not the same as HTTP node.
+LOCAL_ROOT_URL = http://localhost:%(HTTP_PORT)s/
 ; Disable SSH feature when not available
 DISABLE_SSH = false
 ; Whether use builtin SSH server or not.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -59,6 +59,7 @@ var (
 	Protocol           Scheme
 	Domain             string
 	HttpAddr, HttpPort string
+	LocalUrl           string
 	DisableSSH         bool
 	StartSSHServer     bool
 	SSHDomain          string
@@ -300,6 +301,7 @@ func NewContext() {
 	Domain = sec.Key("DOMAIN").MustString("localhost")
 	HttpAddr = sec.Key("HTTP_ADDR").MustString("0.0.0.0")
 	HttpPort = sec.Key("HTTP_PORT").MustString("3000")
+	LocalUrl = sec.Key("LOCAL_ROOT_URL").MustString("http://localhost:" + HttpPort + "/")
 	DisableSSH = sec.Key("DISABLE_SSH").MustBool()
 	if !DisableSSH {
 		StartSSHServer = sec.Key("START_SSH_SERVER").MustBool()


### PR DESCRIPTION
Local (DMZ) URL for gogs workers (such as ssh update) accessing web service. In
most cases you do not need to change default http://localhost:HTTP_PORT/. You
may need to alter it only if your ssh server node is not the same as http node,
eg. running behind proxy on different node than web server.

                     --- 80 public port -> 8080 -- web server node
                    /
    public proxy --<
                    \
                     --- 22 public port -> 10022 -- ssh server node

This option is not intended to be accessible via web GUI settings, since it is
unlikely someone needs to change it to somethings else than default
http://localhost:HTTP_PORT/ which should work for most of the cases.

But this should land into the documentation somewhere.