### PR TITLE
LDAP parameters UI: bind_dn and bind_password are not required

### DIFF
--- a/templates/admin/auth/edit.tmpl
+++ b/templates/admin/auth/edit.tmpl
@@ -34,14 +34,14 @@
 								<input id="port" name="port" value="{{$cfg.Port}}"  placeholder="e.g. 636" required>
 							</div>
 							{{if .Source.IsLDAP}}
-								<div class="required field">
+								<div class="field">
 									<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
-									<input id="bind_dn" name="bind_dn" value="{{$cfg.BindDN}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com" required>
+									<input id="bind_dn" name="bind_dn" value="{{$cfg.BindDN}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
 								</div>
 								<input class="fake" type="password">
-								<div class="required field">
+								<div class="field">
 									<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
-									<input id="bind_password" name="bind_password" type="password" value="{{$cfg.BindPassword}}" required>
+									<input id="bind_password" name="bind_password" type="password" value="{{$cfg.BindPassword}}">
 									<p class="help text red">{{.i18n.Tr "admin.auths.bind_password_helper"}}</p>
 								</div>
 								<div class="required field">

--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -40,12 +40,12 @@
 								<label for="port">{{.i18n.Tr "admin.auths.port"}}</label>
 								<input id="port" name="port" value="{{.port}}"  placeholder="e.g. 636">
 							</div>
-							<div class="ldap required field {{if not (eq .type 2)}}hide{{end}}">
+							<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
 								<label for="bind_dn">{{.i18n.Tr "admin.auths.bind_dn"}}</label>
 								<input id="bind_dn" name="bind_dn" value="{{.bind_dn}}" placeholder="e.g. cn=Search,dc=mydomain,dc=com">
 							</div>
 							<input class="fake" type="password">
-							<div class="ldap required field {{if not (eq .type 2)}}hide{{end}}">
+							<div class="ldap field {{if not (eq .type 2)}}hide{{end}}">
 								<label for="bind_password">{{.i18n.Tr "admin.auths.bind_password"}}</label>
 								<input id="bind_password" name="bind_password" type="password" value="{{.bind_password}}">
 								<p class="help text red">{{.i18n.Tr "admin.auths.bind_password_helper"}}</p>


### PR DESCRIPTION
LDAP via BindDN bind_dn and bind_password parameters are optional. They may be left blank to perform an anonymous search.