### PR TITLE
Ignore invalid env for SSH Server (OSX fix)

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -53,7 +53,8 @@ func handleServerConn(keyID string, chans <-chan ssh.NewChannel) {
 				case "env":
 					args := strings.Split(strings.Replace(payload, "\x00", "", -1), "\v")
 					if len(args) != 2 {
-						return
+						log.Warn("Invalid env arguments: '%#v'", args)
+						continue
 					}
 					args[0] = strings.TrimLeft(args[0], "\x04")
 					_, _, err := com.ExecCmdBytes("env", args[0]+"="+args[1])


### PR DESCRIPTION
I was trying to use built-in ssh server from an OSX client and I couldn't push, it didn't even log an error. I added some debug code and found that it was unexpected ``env`` pushed.

```
2015/12/13 06:04:33 [I] [env]: payload LC_CTYPEUTF-8' replaced LC_CTYPEUTF-8' args: '[]string{"\bLC_CTYPE\x05UTF-8"}'
2015/12/13 06:04:33 [...s/modules/ssh/ssh.go:62 func·001()] [E] len(args) 1 != 2
```

I found the reason:

SSH: `SSH-2.0-OpenSSH_6.9`
OS: OSX El Capitan

`/etc/ssh/ssh_config` file from OSX (I guess, I didn't put that there myself):

```
 Host *
   SendEnv LANG LC_*
```

This pull request just log invalid env arguments instead of silently return.