### PR TITLE
Add default for NumFollowing field (fixes #2261)

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -91,7 +91,7 @@ type User struct {
 
 	// Counters
 	NumFollowers int
-	NumFollowing int `xorm:"NOT NULL"`
+	NumFollowing int `xorm:"NOT NULL DEFAULT 0"`
 	NumStars     int
 	NumRepos     int
 


### PR DESCRIPTION
We set the default value for the non-NULL field `NumFollowing` of the User model to 0, which stops an error when the ORM tries to sync.