### PR TITLE
added docker-compose file with mariadb

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+gogs:
+  image: gogs/gogs:latest
+  links: 
+    - db
+  volumes:
+    - /var/gogs:/data
+  ports:
+    - "10080:3000"
+    - "10022:22"
+  environment:
+    DB_TYPE: mysql
+    HOST: db
+    NAME: gogs
+    USER: gogs
+    PASSWD: changeme
+db:
+  image: library/mariadb:latest
+  environment:
+    MYSQL_ROOT_PASSWORD: changeme
+    MYSQL_DATABASE: gogs
+    MYSQL_USER: gogs
+    MYSQL_PASSWORD: changeme


### PR DESCRIPTION
I have a basic docker-compose file but I have two problems that I am not sure if they are bugs with gogs or something I missed.

1. Even though I specify environment variables for the database the initial setup screen is still shown and the variables I provide are not filled in. It's easy to add the values but probably should be done automatically based on the environment
2. I link the containers but it does not appear the application looks in /etc/hosts file where the link is stored. I verified the right values were in /etc/hosts but I would still get an error trying to link the db by name (tried db docker_db docker_db_1 etc) It works if I use 127.0.0.1 or the ip address of the db container but not hostname.

This could also be extended to support other databases and/or data containers but I figured that would be overkill for someone just wanting to try out gogs. I wanted to provide sane defaults with slightly better performance than a sqlite db.

Ideally all environment variables could easily be substituted with ${VAR:-default} but [that is not supported in compose files](https://github.com/docker/compose/issues/1377)