### PR TITLE
Update s6 path in Dockerfile.rpi

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -19,4 +19,4 @@ RUN ./docker/build.sh
 VOLUME ["/data"]
 EXPOSE 22 3000
 ENTRYPOINT ["docker/start.sh"]
-CMD ["/usr/bin/s6-svscan", "/app/gogs/docker/s6/"]
+CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
The Dockerfile.rpi (Raspberry / ARM Version) pointed to the old path for the s6-vscan command. As a consequence, docker run without providing a custom command fails.

This pull request corrects the path by applying the change in the Dockerfile from https://github.com/gogits/gogs/commit/0cbf56855aad82ff49952132287a0112f308c728 to the Dockerfile.rpi as well

I successfully built a container from the corrected version of Dockerfile.rpi (based on V0.8.10)