### PR TITLE
Making scroll always visible.

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -718,6 +718,7 @@
 body {
   font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif, '微软雅黑';
   background-color: #FAFAFA;
+  overflow-y: scroll;
 }
 img {
   border-radius: 3px;

--- a/public/less/_base.less
+++ b/public/less/_base.less
@@ -3,6 +3,7 @@
 body {
 	font-family: 'Helvetica Neue',Arial,Helvetica,sans-serif,'微软雅黑';
 	background-color: #FAFAFA;
+	overflow-y: scroll;
 }
 img {
 	border-radius: 3px;


### PR DESCRIPTION
Simple trick to prevent the page from "jumping" when navigating from/to a page not long enought to have the scroll.