### PR TITLE
Remove RSA1 keys as only SSH version 2 is used

### DIFF
--- a/docker/s6/openssh/setup
+++ b/docker/s6/openssh/setup
@@ -1,10 +1,6 @@
 #!/bin/sh
 
 # Check if host keys are present, else create them
-if ! test -f /data/ssh/ssh_host_key; then
-    ssh-keygen -q -f /data/ssh/ssh_host_key -N '' -t rsa1
-fi
-
 if ! test -f /data/ssh/ssh_host_rsa_key; then
     ssh-keygen -q -f /data/ssh/ssh_host_rsa_key -N '' -t rsa
 fi

--- a/docker/sshd_config
+++ b/docker/sshd_config
@@ -4,7 +4,6 @@ ListenAddress 0.0.0.0
 ListenAddress ::
 Protocol 2
 LogLevel INFO
-HostKey /data/ssh/ssh_host_key
 HostKey /data/ssh/ssh_host_rsa_key
 HostKey /data/ssh/ssh_host_dsa_key
 HostKey /data/ssh/ssh_host_ecdsa_key


### PR DESCRIPTION
Since OpenSSH is configured for using protocol version 2, it's worthless the generation and use of RSA1 keys.

Building a Docker container using rpi version, OpenSSH 7.1 is used and due to a bug on this version RSA1 keys generation is broken and you'll get errors:

`Saving key "/data/ssh/ssh_host_key" failed: unknown or unsupported key type`
`Could not load host key: /data/ssh/ssh_host_key` 

Anyway, cloning via SSH seems to work fine.

Building a Docker container with normal version, OpenSSH 6.8 is used and there are no errors.