### PR TITLE
Fix status command in FreeBSD init script

### DIFF
--- a/scripts/init/freebsd/gogs
+++ b/scripts/init/freebsd/gogs
@@ -22,6 +22,7 @@ load_rc_config $name
 : ${gogs_directory:="/home/git"}
 
 command="${gogs_directory}/gogs web"
+procname="$(echo $command |cut -d' ' -f1)"
 
 pidfile="${gogs_directory}/${name}.pid"
 


### PR DESCRIPTION
If the init script is called with `status`, the rc.subr(8) routines check if
the first argument associated with the pid in the pidfile is equal to
`procname`. By default, `procname` is equal to the value of `command`. In our
case, `command` contains a space (i.e. has multiple arguments), so `procname`
can never be equal to the first argument of the command associated with the
pid.

Set `procname` to the first argument of `command` to fix the `status` command
of the init script.