### PR TITLE
Conditional StartTLS elevation based on UseSSL

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -202,6 +202,22 @@ func ldapDial(ls *Source) (*ldap.Conn, error) {
 			InsecureSkipVerify: ls.SkipVerify,
 		})
 	} else {
-		return ldap.Dial("tcp", fmt.Sprintf("%s:%d", ls.Host, ls.Port))
+		conn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ls.Host, ls.Port))
+		if err != nil {
+			return nil, err
+		}
+
+		if ls.SkipVerify {
+			return conn, nil
+		}
+
+		if err := conn.StartTLS(&tls.Config{
+			InsecureSkipVerify: false,
+		}); err != nil {
+			conn.Close()
+			return nil, err
+		}
+
+		return conn, nil
 	}
 }


### PR DESCRIPTION
StartTLS workaround similar to Openshift. Would fix #1666 and #1894.

I have been able to test this locally using `LDAP (simple auth)` authentication type. #2349 made the testing an absolute pain though.

Other changes:

* Migration to prevent breaking existing installations. UseSSL==true `ldap` authentications will jump to using `StartTLS` if no actions are taken to prevent it.
* Documentation updates
* UI field name updates 