### PR TITLE
Fixed the 'too many open files' error when starting gogs with systemd

### DIFF
--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -8,8 +8,12 @@ After=network.target
 #After=redis.service
 
 [Service]
-LimitMEMLOCK=infinity
-LimitNOFILE=65535
+# Modify these two values and uncomment them if you have
+# repos with lots of files and get an HTTP error 500 because
+# of that
+###
+#LimitMEMLOCK=infinity
+#LimitNOFILE=65535
 Type=simple
 User=git
 Group=git

--- a/scripts/systemd/gogs.service
+++ b/scripts/systemd/gogs.service
@@ -8,6 +8,8 @@ After=network.target
 #After=redis.service
 
 [Service]
+LimitMEMLOCK=infinity
+LimitNOFILE=65535
 Type=simple
 User=git
 Group=git


### PR DESCRIPTION
This commit addresses https://github.com/gogits/gogs/issues/1270. It seems that systemd has its own settings of max open file limits - i'm setting this limit to 65535 open files, which should succeed for most repositories. 