### PR TITLE
[WIP] Added more supported link protocols for markdown

### DIFF
--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -29,7 +29,7 @@ func isalnum(c byte) bool {
 	return (c >= '0' && c <= '9') || isletter(c)
 }
 
-var validLinks = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://")}
+var validLinks = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://"), []byte("ssh://"), []byte("ts3server://"), []byte("git://"), []byte("irc://"), []byte("ircs://")}
 
 func isLink(link []byte) bool {
 	for _, prefix := range validLinks {


### PR DESCRIPTION
Added the ssh:// ts3server:// git:// irc:// ircs:// protocols for links in markdown files rendered

This will let you make links in markdown files rendered by gogs, like in the README.md files and such. I need this support for some git repos I am working on. I am sure other would find this useful as well.