### PR TITLE
commit.RefUrl expects AppUrl argument

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -31,7 +31,7 @@
 					<td>
 						<span class="icon octicon octicon-file-submodule"></span>
 						{{if $commit.RefUrl AppUrl}}
-							<a href="{{$commit.RefUrl}}">{{$entry.Name}}</a> @ <a href="{{$commit.RefUrl}}/commit/{{$commit.RefId}}">{{ShortSha $commit.RefId}}</a>
+							<a href="{{$commit.RefUrl AppUrl}}">{{$entry.Name}}</a> @ <a href="{{$commit.RefUrl AppUrl}}/commit/{{$commit.RefId}}">{{ShortSha $commit.RefId}}</a>
 						{{else}}
 							{{$entry.Name}} @ {{ShortSha $commit.RefId}}
 						{{end}}


### PR DESCRIPTION
This is fixup for ea375c0dcca118c8ac3c48ba569b025836ad5ccf. The bug was not
visible because commit.RefUrl was always returning empty url due regression
described in https://github.com/gogits/git-module/pull/4