### PR TITLE
OS X launchd script

### DIFF
--- a/scripts/launchd/io.gogs.web.plist
+++ b/scripts/launchd/io.gogs.web.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Label</key>
+		<string>io.gogs.web</string>
+		<!-- assumes Gogs is running under 'git' account -->
+		<!-- modify below to reflect your settings -->
+		<key>UserName</key>
+		<string>git</string>
+		<key>GroupName</key>
+		<string>git</string>
+		<key>ProgramArguments</key>
+		<array>
+			<!-- assumes Gogs is installed in /Users/git/gogs -->
+			<!-- modify below to reflect your settings -->
+			<string>/Users/git/gogs/gogs</string>
+			<string>web</string>
+		</array>
+		<key>RunAtLoad</key>
+		<true/>
+		<key>KeepAlive</key>
+		<true/>
+		<!-- assumes Gogs is installed in /Users/git/gogs -->
+		<!-- modify below to reflect your settings -->
+		<key>WorkingDirectory</key>
+		<string>/Users/git/gogs/</string>
+		<key>StandardOutPath</key>
+		<string>/Users/git/gogs/log/stdout.log</string>
+		<key>StandardErrorPath</key>
+		<string>/Users/git/gogs/log/stderr.log</string>
+		<!-- default 256 is too low for Gogs needs using parallel pipes -->
+		<key>SoftResourceLimits</key>
+		<dict>
+			<key>NumberOfFiles</key>
+			<integer>8192</integer>
+		</dict>
+	</dict>
+</plist>


### PR DESCRIPTION
Using this script:

1. Copy scripts/launchd/io.gogs.web.plist into `/Library/LaunchDaemons`

2. The script assumes Gogs is running under `gogs` user and group, modify `/Library/LaunchDaemons/io.gogs.web.plist` if you want to user different user.

3. The script assumes Gogs is installed in `/Users/git/gogs`, modify `/Library/LaunchDaemons/io.gogs.web.plist` if you installed Gogs in different location.

4. Once you are sure that running Gogs manually via `gogs web` works fine, run it as a launchd service with:

         sudo launchctl load -F /Library/LaunchDaemons/io.gogs.web.plist

From now on launchd will ensure Gogs is running, eg. when system is restarted.