### PR TITLE
Update repo.go

### DIFF
--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -330,5 +330,5 @@ func Download(ctx *middleware.Context) {
 		}
 	}
 
-	ctx.ServeFile(archivePath, ctx.Repo.Repository.Name+"-"+base.ShortSha(commit.ID.String())+ext)
+	ctx.ServeFile(archivePath, ctx.Repo.Repository.Name+"-"+refName+ext)
 }


### PR DESCRIPTION
Release download file name doesn't include tag number #2339
Download: Changed to use refName instead of commit.ID for downloaded file name