### PR TITLE
Feature/markdown custom url scheme

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -41,6 +41,9 @@ ORG_PAGING_NUM = 50
 [markdown]
 ; Enable hard line break extension
 ENABLE_HARD_LINE_BREAK = false
+; List of custom URL-Schemes that are allowed as links when rendering Markdown
+; for example git,magnet
+CUSTOM_URL_SCHEMES =
 
 [server]
 PROTOCOL = http

--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -340,7 +340,7 @@ OUTER_LOOP:
 func RenderMarkdown(rawBytes []byte, urlPrefix string, metas map[string]string) []byte {
 	result := RenderRawMarkdown(rawBytes, urlPrefix)
 	result = PostProcessMarkdown(result, urlPrefix, metas)
-	result = BuildSanitizer().SanitizeBytes(result)
+	result = Sanitizer.SanitizeBytes(result)
 	return result
 }
 

--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -29,16 +29,10 @@ func isalnum(c byte) bool {
 	return (c >= '0' && c <= '9') || isletter(c)
 }
 
-var validLinks = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://")}
+var validLinksPattern = regexp.MustCompile(`^[a-z][\w-]+://`)
 
 func isLink(link []byte) bool {
-	for _, prefix := range validLinks {
-		if len(link) > len(prefix) && bytes.Equal(bytes.ToLower(link[:len(prefix)]), prefix) && isalnum(link[len(prefix)]) {
-			return true
-		}
-	}
-
-	return false
+	return validLinksPattern.Match(link)
 }
 
 func IsMarkdownFile(name string) bool {
@@ -346,7 +340,7 @@ OUTER_LOOP:
 func RenderMarkdown(rawBytes []byte, urlPrefix string, metas map[string]string) []byte {
 	result := RenderRawMarkdown(rawBytes, urlPrefix)
 	result = PostProcessMarkdown(result, urlPrefix, metas)
-	result = Sanitizer.SanitizeBytes(result)
+	result = BuildSanitizer().SanitizeBytes(result)
 	return result
 }
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -37,6 +37,7 @@ func BuildSanitizer() (p *bluemonday.Policy) {
 
 	p.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
 	p.AllowAttrs("checked", "disabled").OnElements("input")
+	p.AllowURLSchemes(setting.Markdown.CustomURLSchemes...)
 	return p
 }
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -31,17 +31,19 @@ import (
 	"github.com/gogits/gogs/modules/setting"
 )
 
-func BuildSanitizer() (p *bluemonday.Policy) {
-	p = bluemonday.UGCPolicy()
-	p.AllowAttrs("class").Matching(regexp.MustCompile(`[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&]*`)).OnElements("code")
+var Sanitizer = bluemonday.UGCPolicy()
 
-	p.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
-	p.AllowAttrs("checked", "disabled").OnElements("input")
-	p.AllowURLSchemes(setting.Markdown.CustomURLSchemes...)
-	return p
+func BuildSanitizer() {
+	// Normal markdown-stuff
+	Sanitizer.AllowAttrs("class").Matching(regexp.MustCompile(`[\p{L}\p{N}\s\-_',:\[\]!\./\\\(\)&]*`)).OnElements("code")
+
+	// Checkboxes
+	Sanitizer.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
+	Sanitizer.AllowAttrs("checked", "disabled").OnElements("input")
+
+	// Custom URL-Schemes
+	Sanitizer.AllowURLSchemes(setting.Markdown.CustomURLSchemes...)
 }
-
-var Sanitizer = BuildSanitizer()
 
 // EncodeMD5 encodes string to md5 hex value.
 func EncodeMD5(str string) string {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -117,6 +117,7 @@ var (
 	// Markdown sttings
 	Markdown struct {
 		EnableHardLineBreak bool
+		CustomURLSchemes    []string `ini:"CUSTOM_URL_SCHEMES"`
 	}
 
 	// Picture settings

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -105,7 +105,7 @@ func Safe(raw string) template.HTML {
 }
 
 func Str2html(raw string) template.HTML {
-	return template.HTML(base.BuildSanitizer().Sanitize(raw))
+	return template.HTML(base.Sanitizer.Sanitize(raw))
 }
 
 func Range(l int) []int {

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -105,7 +105,7 @@ func Safe(raw string) template.HTML {
 }
 
 func Str2html(raw string) template.HTML {
-	return template.HTML(base.Sanitizer.Sanitize(raw))
+	return template.HTML(base.BuildSanitizer().Sanitize(raw))
 }
 
 func Range(l int) []int {

--- a/routers/install.go
+++ b/routers/install.go
@@ -91,6 +91,9 @@ func GlobalInit() {
 		ssh.Listen(setting.SSHPort)
 		log.Info("SSH server started on :%v", setting.SSHPort)
 	}
+
+	// Build Sanitizer
+	base.BuildSanitizer()
 }
 
 func InstallInit(ctx *middleware.Context) {


### PR DESCRIPTION
~~This is a WIP-feature that needs rebasing after #2396 is merged~~

This adds the ability to define custom URL-Schemes (e.g. git,file,magnet) as acceptable links when rendering markdown

example `custom/conf/app.ini`:
```ini
[markdown]
CUSTOM_URL_SCHEMES = "git,file,magnet"
```

TODO:
- [x] implement it :laughing: 
- [x] wait for #2396 
- [x] add example to `conf/app.ini`