### PR TITLE
Add command to run the test suite in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ clean:
 
 clean-mac: clean
 	find . -name ".DS_Store" -print0 | xargs -0 rm
+
+test:
+	go test ./...


### PR DESCRIPTION
`make test` will run the test files for all the packages.

`modules/httplib` is failing. But, if we can fix it, it would be a good idea to configure the CI to run the tests.