### PR TITLE
Expand split-diff view to full page width, as in GitHub.

### DIFF
--- a/templates/repo/diff.tmpl
+++ b/templates/repo/diff.tmpl
@@ -1,7 +1,7 @@
 {{template "base/head" .}}
 <div class="repository diff">
 	{{template "repo/header" .}}
-	<div class="ui container">
+	<div class="{{if $.IsSplitStyle}}ui{{else}}ui container{{end}}">
 		{{if .IsDiffCompare }}
 			{{template "repo/commits_table" .}}
 		{{else}}


### PR DESCRIPTION
I noticed when using the new split-diff view (from #2296 -- very useful, thanks) that lines in the diffs often wrapped, even with 80-column source. GitHub expands the diff container to (almost) full-screen width when in split-view mode. This is a simple template tweak to get the same behavior in Gogs.

There may be a better way to do this (adding a nice margin, also expanding the header/tabs to full width, maybe making this a config option) but I spend my day in C++/non-webdev stuff and couldn't work out how to tweak the LESS or the template contexts to do that -- my apologies. I hope this is at least a starting point!