### PR TITLE
Fix #2431 - handle requests waiting for reply

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -91,6 +91,7 @@ func handleServerConn(keyID string, chans <-chan ssh.NewChannel) {
 						return
 					}
 
+					req.Reply(true, nil);
 					go io.Copy(input, ch)
 					io.Copy(ch, stdout)
 					io.Copy(ch.Stderr(), stderr)


### PR DESCRIPTION
According to the docs [1], the Reply method must be called for all
requests where WantReply is true. This fixes a hanging java ssh
implementation (jsch) which sets WantReply flag and waits for reply from
the server.

[1] https://godoc.org/golang.org/x/crypto/ssh#Request.Reply