### PR TITLE
Formatting and update copyrights

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -1,7 +1,7 @@
 // +build cert
 
 // Copyright 2009 The Go Authors. All rights reserved.
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/cert_stub.go
+++ b/cmd/cert_stub.go
@@ -1,7 +1,7 @@
 // +build !cert
 
 // Copyright 2009 The Go Authors. All rights reserved.
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 package cmd

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -68,21 +68,21 @@ func runDump(ctx *cli.Context) {
 		log.Fatalf("Fail to create %s: %v", fileName, err)
 	}
 
-	if err := z.AddFile("gogs-repo.zip", reposDump); err !=nil {
+	if err := z.AddFile("gogs-repo.zip", reposDump); err != nil {
 		log.Fatalf("Fail to include gogs-repo.zip: %v", err)
 	}
-	if err := z.AddFile("gogs-db.sql", dbDump); err !=nil {
+	if err := z.AddFile("gogs-db.sql", dbDump); err != nil {
 		log.Fatalf("Fail to include gogs-db.sql: %v", err)
 	}
 	customDir, err := os.Stat(setting.CustomPath)
 	if err == nil && customDir.IsDir() {
-		if err := z.AddDir("custom", setting.CustomPath); err !=nil {
+		if err := z.AddDir("custom", setting.CustomPath); err != nil {
 			log.Fatalf("Fail to include custom: %v", err)
-	    }
+		}
 	} else {
 		log.Printf("Custom dir %s doesn't exist, skipped", setting.CustomPath)
 	}
-	if err := z.AddDir("log", setting.LogRootPath); err !=nil {
+	if err := z.AddDir("log", setting.LogRootPath); err != nil {
 		log.Fatalf("Fail to include log: %v", err)
 	}
 	// FIXME: SSH key file.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -165,7 +165,7 @@ func newMacaron() *macaron.Macaron {
 	}))
 	m.Use(toolbox.Toolboxer(m, toolbox.Options{
 		HealthCheckFuncs: []*toolbox.HealthCheckFuncDesc{
-			&toolbox.HealthCheckFuncDesc{
+			{
 				Desc: "Database connection",
 				Func: models.Ping,
 			},

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/gogs.go
+++ b/gogs.go
@@ -1,6 +1,6 @@
 // +build go1.4
 
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/access.go
+++ b/models/access.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/action.go
+++ b/models/action.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/admin.go
+++ b/models/admin.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/cron/cron.go
+++ b/models/cron/cron.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/error.go
+++ b/models/error.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/git_diff_test.go
+++ b/models/git_diff_test.go
@@ -1,70 +1,70 @@
 package models
 
 import (
-  dmp "github.com/sergi/go-diff/diffmatchpatch"
-  "html/template"
-  "testing"
+	dmp "github.com/sergi/go-diff/diffmatchpatch"
+	"html/template"
+	"testing"
 )
 
 func assertEqual(t *testing.T, s1 string, s2 template.HTML) {
-  if s1 != string(s2) {
-    t.Errorf("%s should be equal %s", s2, s1)
-  }
+	if s1 != string(s2) {
+		t.Errorf("%s should be equal %s", s2, s1)
+	}
 }
 
 func assertLineEqual(t *testing.T, d1 *DiffLine, d2 *DiffLine) {
-  if d1 != d2 {
-    t.Errorf("%v should be equal %v", d1, d2)
-  }
+	if d1 != d2 {
+		t.Errorf("%v should be equal %v", d1, d2)
+	}
 }
 
 func TestDiffToHTML(t *testing.T) {
-  assertEqual(t, "foo <span class=\"added-code\">bar</span> biz", diffToHTML([]dmp.Diff{
-    dmp.Diff{dmp.DiffEqual, "foo "},
-    dmp.Diff{dmp.DiffInsert, "bar"},
-    dmp.Diff{dmp.DiffDelete, " baz"},
-    dmp.Diff{dmp.DiffEqual, " biz"},
-  }, DIFF_LINE_ADD))
+	assertEqual(t, "foo <span class=\"added-code\">bar</span> biz", diffToHTML([]dmp.Diff{
+		{dmp.DiffEqual, "foo "},
+		{dmp.DiffInsert, "bar"},
+		{dmp.DiffDelete, " baz"},
+		{dmp.DiffEqual, " biz"},
+	}, DIFF_LINE_ADD))
 
-  assertEqual(t, "foo <span class=\"removed-code\">bar</span> biz", diffToHTML([]dmp.Diff{
-    dmp.Diff{dmp.DiffEqual, "foo "},
-    dmp.Diff{dmp.DiffDelete, "bar"},
-    dmp.Diff{dmp.DiffInsert, " baz"},
-    dmp.Diff{dmp.DiffEqual, " biz"},
-  }, DIFF_LINE_DEL))
+	assertEqual(t, "foo <span class=\"removed-code\">bar</span> biz", diffToHTML([]dmp.Diff{
+		{dmp.DiffEqual, "foo "},
+		{dmp.DiffDelete, "bar"},
+		{dmp.DiffInsert, " baz"},
+		{dmp.DiffEqual, " biz"},
+	}, DIFF_LINE_DEL))
 }
 
 // test if GetLine is return the correct lines
 func TestGetLine(t *testing.T) {
-  ds := DiffSection{Lines: []*DiffLine{
-    &DiffLine{LeftIdx: 28,  RightIdx:   28, Type: DIFF_LINE_PLAIN},
-    &DiffLine{LeftIdx: 29,  RightIdx:   29, Type: DIFF_LINE_PLAIN},
-    &DiffLine{LeftIdx: 30,  RightIdx:   30, Type: DIFF_LINE_PLAIN},
-    &DiffLine{LeftIdx: 31,  RightIdx:    0, Type: DIFF_LINE_DEL},
-    &DiffLine{LeftIdx:  0,  RightIdx:   31, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx:  0,  RightIdx:   32, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx: 32,  RightIdx:   33, Type: DIFF_LINE_PLAIN},
-    &DiffLine{LeftIdx: 33,  RightIdx:    0, Type: DIFF_LINE_DEL},
-    &DiffLine{LeftIdx: 34,  RightIdx:    0, Type: DIFF_LINE_DEL},
-    &DiffLine{LeftIdx: 35,  RightIdx:    0, Type: DIFF_LINE_DEL},
-    &DiffLine{LeftIdx: 36,  RightIdx:    0, Type: DIFF_LINE_DEL},
-    &DiffLine{LeftIdx:  0,  RightIdx:   34, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx:  0,  RightIdx:   35, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx:  0,  RightIdx:   36, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx:  0,  RightIdx:   37, Type: DIFF_LINE_ADD},
-    &DiffLine{LeftIdx: 37,  RightIdx:   38, Type: DIFF_LINE_PLAIN},
-    &DiffLine{LeftIdx: 38,  RightIdx:   39, Type: DIFF_LINE_PLAIN},
-  }}
+	ds := DiffSection{Lines: []*DiffLine{
+		{LeftIdx: 28, RightIdx: 28, Type: DIFF_LINE_PLAIN},
+		{LeftIdx: 29, RightIdx: 29, Type: DIFF_LINE_PLAIN},
+		{LeftIdx: 30, RightIdx: 30, Type: DIFF_LINE_PLAIN},
+		{LeftIdx: 31, RightIdx: 0, Type: DIFF_LINE_DEL},
+		{LeftIdx: 0, RightIdx: 31, Type: DIFF_LINE_ADD},
+		{LeftIdx: 0, RightIdx: 32, Type: DIFF_LINE_ADD},
+		{LeftIdx: 32, RightIdx: 33, Type: DIFF_LINE_PLAIN},
+		{LeftIdx: 33, RightIdx: 0, Type: DIFF_LINE_DEL},
+		{LeftIdx: 34, RightIdx: 0, Type: DIFF_LINE_DEL},
+		{LeftIdx: 35, RightIdx: 0, Type: DIFF_LINE_DEL},
+		{LeftIdx: 36, RightIdx: 0, Type: DIFF_LINE_DEL},
+		{LeftIdx: 0, RightIdx: 34, Type: DIFF_LINE_ADD},
+		{LeftIdx: 0, RightIdx: 35, Type: DIFF_LINE_ADD},
+		{LeftIdx: 0, RightIdx: 36, Type: DIFF_LINE_ADD},
+		{LeftIdx: 0, RightIdx: 37, Type: DIFF_LINE_ADD},
+		{LeftIdx: 37, RightIdx: 38, Type: DIFF_LINE_PLAIN},
+		{LeftIdx: 38, RightIdx: 39, Type: DIFF_LINE_PLAIN},
+	}}
 
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 31), ds.Lines[4])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 31), ds.Lines[3])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 31), ds.Lines[4])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 31), ds.Lines[3])
 
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 33), ds.Lines[11])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 34), ds.Lines[12])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 35), ds.Lines[13])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 36), ds.Lines[14])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 34), ds.Lines[7])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 35), ds.Lines[8])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 36), ds.Lines[9])
-  assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 37), ds.Lines[10])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 33), ds.Lines[11])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 34), ds.Lines[12])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 35), ds.Lines[13])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 36), ds.Lines[14])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 34), ds.Lines[7])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 35), ds.Lines[8])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 36), ds.Lines[9])
+	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 37), ds.Lines[10])
 }

--- a/models/issue.go
+++ b/models/issue.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/login.go
+++ b/models/login.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/models.go
+++ b/models/models.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/models_sqlite.go
+++ b/models/models_sqlite.go
@@ -1,6 +1,6 @@
 // +build sqlite
 
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/models_tidb.go
+++ b/models/models_tidb.go
@@ -1,6 +1,6 @@
 // +build tidb go1.4.2
 
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/org.go
+++ b/models/org.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/pull.go
+++ b/models/pull.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/release.go
+++ b/models/release.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/token.go
+++ b/models/token.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/update.go
+++ b/models/update.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/user.go
+++ b/models/user.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/webhook_slack.go
+++ b/models/webhook_slack.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/models/wiki.go
+++ b/models/wiki.go
@@ -7,12 +7,12 @@ package models
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
-	"net/url"
 
 	"github.com/Unknwon/com"
 

--- a/modules/auth/admin.go
+++ b/modules/auth/admin.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/auth.go
+++ b/modules/auth/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/auth_form.go
+++ b/modules/auth/auth_form.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/org.go
+++ b/modules/auth/org.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/pam/pam.go
+++ b/modules/auth/pam/pam.go
@@ -1,6 +1,6 @@
 // +build pam
 
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/pam/pam_stub.go
+++ b/modules/auth/pam/pam_stub.go
@@ -1,6 +1,6 @@
 // +build !pam
 
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/auth/user_form.go
+++ b/modules/auth/user_form.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/avatar/avatar.go
+++ b/modules/avatar/avatar.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/avatar/avatar_test.go
+++ b/modules/avatar/avatar_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 package avatar_test

--- a/modules/base/base.go
+++ b/modules/base/base.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/base/markdown.go
+++ b/modules/base/markdown.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/bindata/bindata.go
+++ b/modules/bindata/bindata.go
@@ -224,11 +224,11 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"strings"
-	"os"
-	"time"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 func bindataRead(data []byte, name string) ([]byte, error) {
@@ -257,9 +257,9 @@ type asset struct {
 }
 
 type bindataFileInfo struct {
-	name string
-	size int64
-	mode os.FileMode
+	name    string
+	size    int64
+	mode    os.FileMode
 	modTime time.Time
 }
 
@@ -298,7 +298,7 @@ func confAppIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/app.ini", size: 10207, mode: os.FileMode(420), modTime: time.Unix(1450579175, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -318,7 +318,7 @@ func confGitignoreActionscript() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Actionscript", size: 300, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -338,7 +338,7 @@ func confGitignoreAda() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Ada", size: 51, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -358,7 +358,7 @@ func confGitignoreAgda() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Agda", size: 8, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -378,7 +378,7 @@ func confGitignoreAndroid() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Android", size: 394, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -398,7 +398,7 @@ func confGitignoreAnjuta() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Anjuta", size: 78, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -418,7 +418,7 @@ func confGitignoreAppengine() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/AppEngine", size: 58, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -438,7 +438,7 @@ func confGitignoreAppceleratortitanium() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/AppceleratorTitanium", size: 45, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -458,7 +458,7 @@ func confGitignoreArchlinuxpackages() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ArchLinuxPackages", size: 75, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -478,7 +478,7 @@ func confGitignoreArchives() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Archives", size: 295, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -498,7 +498,7 @@ func confGitignoreAutotools() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Autotools", size: 181, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -518,7 +518,7 @@ func confGitignoreBricxcc() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/BricxCC", size: 72, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -538,7 +538,7 @@ func confGitignoreC() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/C", size: 246, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -558,7 +558,7 @@ func confGitignoreCSharp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/C Sharp", size: 1521, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -578,7 +578,7 @@ func confGitignoreC2() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/C++", size: 242, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -598,7 +598,7 @@ func confGitignoreCfwheels() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CFWheels", size: 205, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -618,7 +618,7 @@ func confGitignoreCmake() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CMake", size: 89, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -638,7 +638,7 @@ func confGitignoreCuda() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CUDA", size: 38, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -658,7 +658,7 @@ func confGitignoreCvs() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CVS", size: 39, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -678,7 +678,7 @@ func confGitignoreCakephp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CakePHP", size: 136, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -698,7 +698,7 @@ func confGitignoreChefcookbook() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ChefCookbook", size: 77, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -718,7 +718,7 @@ func confGitignoreCloud9() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Cloud9", size: 45, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -738,7 +738,7 @@ func confGitignoreCodeigniter() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CodeIgniter", size: 106, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -758,7 +758,7 @@ func confGitignoreCodekit() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CodeKit", size: 54, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -778,7 +778,7 @@ func confGitignoreCommonlisp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CommonLisp", size: 26, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -798,7 +798,7 @@ func confGitignoreComposer() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Composer", size: 250, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -818,7 +818,7 @@ func confGitignoreConcrete5() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Concrete5", size: 42, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -838,7 +838,7 @@ func confGitignoreCoq() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Coq", size: 18, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -858,7 +858,7 @@ func confGitignoreCraftcms() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/CraftCMS", size: 120, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -878,7 +878,7 @@ func confGitignoreDm() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/DM", size: 29, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -898,7 +898,7 @@ func confGitignoreDart() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Dart", size: 234, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -918,7 +918,7 @@ func confGitignoreDarteditor() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/DartEditor", size: 19, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -938,7 +938,7 @@ func confGitignoreDelphi() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Delphi", size: 1347, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -958,7 +958,7 @@ func confGitignoreDreamweaver() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Dreamweaver", size: 47, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -978,7 +978,7 @@ func confGitignoreDrupal() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Drupal", size: 605, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -998,7 +998,7 @@ func confGitignoreEpiserver() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/EPiServer", size: 81, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1018,7 +1018,7 @@ func confGitignoreEagle() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Eagle", size: 401, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1038,7 +1038,7 @@ func confGitignoreEclipse() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Eclipse", size: 458, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1058,7 +1058,7 @@ func confGitignoreEiffelstudio() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/EiffelStudio", size: 35, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1078,7 +1078,7 @@ func confGitignoreElisp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Elisp", size: 36, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1098,7 +1098,7 @@ func confGitignoreElixir() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Elixir", size: 34, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1118,7 +1118,7 @@ func confGitignoreEmacs() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Emacs", size: 320, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1138,7 +1138,7 @@ func confGitignoreEnsime() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Ensime", size: 57, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1158,7 +1158,7 @@ func confGitignoreErlang() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Erlang", size: 95, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1178,7 +1178,7 @@ func confGitignoreEspresso() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Espresso", size: 9, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1198,7 +1198,7 @@ func confGitignoreExpressionengine() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ExpressionEngine", size: 342, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1218,7 +1218,7 @@ func confGitignoreExtjs() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ExtJs", size: 38, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1238,7 +1238,7 @@ func confGitignoreFancy() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Fancy", size: 12, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1258,7 +1258,7 @@ func confGitignoreFinale() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Finale", size: 184, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1278,7 +1278,7 @@ func confGitignoreFlexbuilder() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/FlexBuilder", size: 29, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1298,7 +1298,7 @@ func confGitignoreForcedotcom() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ForceDotCom", size: 57, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1318,7 +1318,7 @@ func confGitignoreFuelphp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/FuelPHP", size: 39, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1338,7 +1338,7 @@ func confGitignoreGwt() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/GWT", size: 395, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1358,7 +1358,7 @@ func confGitignoreGcov() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Gcov", size: 56, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1378,7 +1378,7 @@ func confGitignoreGitbook() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/GitBook", size: 353, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1398,7 +1398,7 @@ func confGitignoreGo() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Go", size: 266, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1418,7 +1418,7 @@ func confGitignoreGradle() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Gradle", size: 157, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1438,7 +1438,7 @@ func confGitignoreGrails() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Grails", size: 583, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1458,7 +1458,7 @@ func confGitignoreHaskell() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Haskell", size: 135, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1478,7 +1478,7 @@ func confGitignoreIgorpro() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/IGORPro", size: 121, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1498,7 +1498,7 @@ func confGitignoreIpythonnotebook() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/IPythonNotebook", size: 37, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1518,7 +1518,7 @@ func confGitignoreIdris() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Idris", size: 10, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1538,7 +1538,7 @@ func confGitignoreJdeveloper() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/JDeveloper", size: 255, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1558,7 +1558,7 @@ func confGitignoreJava() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Java", size: 189, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1578,7 +1578,7 @@ func confGitignoreJboss() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Jboss", size: 509, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1598,7 +1598,7 @@ func confGitignoreJekyll() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Jekyll", size: 37, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1618,7 +1618,7 @@ func confGitignoreJetbrains() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/JetBrains", size: 860, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1638,7 +1638,7 @@ func confGitignoreJoomla() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Joomla", size: 22387, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1658,7 +1658,7 @@ func confGitignoreKdevelop4() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/KDevelop4", size: 16, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1678,7 +1678,7 @@ func confGitignoreKate() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Kate", size: 34, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1698,7 +1698,7 @@ func confGitignoreKicad() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/KiCAD", size: 208, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1718,7 +1718,7 @@ func confGitignoreKohana() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Kohana", size: 39, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1738,7 +1738,7 @@ func confGitignoreLabview() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/LabVIEW", size: 142, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1758,7 +1758,7 @@ func confGitignoreLaravel() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Laravel", size: 49, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1778,7 +1778,7 @@ func confGitignoreLazarus() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Lazarus", size: 407, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1798,7 +1798,7 @@ func confGitignoreLeiningen() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Leiningen", size: 138, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1818,7 +1818,7 @@ func confGitignoreLemonstand() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/LemonStand", size: 348, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1838,7 +1838,7 @@ func confGitignoreLibreoffice() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/LibreOffice", size: 30, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1858,7 +1858,7 @@ func confGitignoreLilypond() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Lilypond", size: 33, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1878,7 +1878,7 @@ func confGitignoreLinux() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Linux", size: 118, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1898,7 +1898,7 @@ func confGitignoreLithium() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Lithium", size: 28, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1918,7 +1918,7 @@ func confGitignoreLua() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Lua", size: 324, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1938,7 +1938,7 @@ func confGitignoreLyx() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/LyX", size: 75, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1958,7 +1958,7 @@ func confGitignoreMagento() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Magento", size: 2599, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1978,7 +1978,7 @@ func confGitignoreMatlab() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Matlab", size: 360, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -1998,7 +1998,7 @@ func confGitignoreMaven() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Maven", size: 170, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2018,7 +2018,7 @@ func confGitignoreMercurial() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Mercurial", size: 50, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2038,7 +2038,7 @@ func confGitignoreMercury() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Mercury", size: 93, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2058,7 +2058,7 @@ func confGitignoreMetaprogrammingsystem() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/MetaProgrammingSystem", size: 391, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2078,7 +2078,7 @@ func confGitignoreMicrosoftoffice() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/MicrosoftOffice", size: 88, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2098,7 +2098,7 @@ func confGitignoreModelsim() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ModelSim", size: 282, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2118,7 +2118,7 @@ func confGitignoreMomentics() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Momentics", size: 76, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2138,7 +2138,7 @@ func confGitignoreMonodevelop() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/MonoDevelop", size: 93, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2158,7 +2158,7 @@ func confGitignoreNanoc() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Nanoc", size: 197, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2178,7 +2178,7 @@ func confGitignoreNetbeans() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/NetBeans", size: 96, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2198,7 +2198,7 @@ func confGitignoreNim() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Nim", size: 10, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2218,7 +2218,7 @@ func confGitignoreNinja() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Ninja", size: 23, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2238,7 +2238,7 @@ func confGitignoreNode() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Node", size: 529, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2258,7 +2258,7 @@ func confGitignoreNotepadpp() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/NotepadPP", size: 30, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2278,7 +2278,7 @@ func confGitignoreOcaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/OCaml", size: 178, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2298,7 +2298,7 @@ func confGitignoreOsx() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/OSX", size: 356, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2318,7 +2318,7 @@ func confGitignoreObjectiveC() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Objective-C", size: 837, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2338,7 +2338,7 @@ func confGitignoreOpa() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Opa", size: 90, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2358,7 +2358,7 @@ func confGitignoreOpencart() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/OpenCart", size: 115, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2378,7 +2378,7 @@ func confGitignoreOracleforms() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/OracleForms", size: 100, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2398,7 +2398,7 @@ func confGitignorePacker() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Packer", size: 55, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2418,7 +2418,7 @@ func confGitignorePerl() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Perl", size: 191, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2438,7 +2438,7 @@ func confGitignorePhalcon() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Phalcon", size: 29, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2458,7 +2458,7 @@ func confGitignorePlayframework() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/PlayFramework", size: 170, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2478,7 +2478,7 @@ func confGitignorePlone() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Plone", size: 137, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2498,7 +2498,7 @@ func confGitignorePrestashop() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Prestashop", size: 483, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2518,7 +2518,7 @@ func confGitignoreProcessing() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Processing", size: 120, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2538,7 +2538,7 @@ func confGitignorePython() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Python", size: 713, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2558,7 +2558,7 @@ func confGitignoreQooxdoo() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Qooxdoo", size: 58, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2578,7 +2578,7 @@ func confGitignoreQt() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Qt", size: 292, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2598,7 +2598,7 @@ func confGitignoreR() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/R", size: 255, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2618,7 +2618,7 @@ func confGitignoreRos() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ROS", size: 493, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2638,7 +2638,7 @@ func confGitignoreRails() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Rails", size: 707, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2658,7 +2658,7 @@ func confGitignoreRedcar() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Redcar", size: 8, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2678,7 +2678,7 @@ func confGitignoreRedis() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Redis", size: 51, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2698,7 +2698,7 @@ func confGitignoreRhodesrhomobile() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/RhodesRhomobile", size: 77, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2718,7 +2718,7 @@ func confGitignoreRuby() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Ruby", size: 607, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2738,7 +2738,7 @@ func confGitignoreRust() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Rust", size: 91, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2758,7 +2758,7 @@ func confGitignoreSbt() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SBT", size: 186, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2778,7 +2778,7 @@ func confGitignoreScons() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SCons", size: 90, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2798,7 +2798,7 @@ func confGitignoreSvn() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SVN", size: 6, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2818,7 +2818,7 @@ func confGitignoreSass() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Sass", size: 23, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2838,7 +2838,7 @@ func confGitignoreScala() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Scala", size: 185, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2858,7 +2858,7 @@ func confGitignoreScrivener() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Scrivener", size: 140, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2878,7 +2878,7 @@ func confGitignoreSdcc() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Sdcc", size: 55, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2898,7 +2898,7 @@ func confGitignoreSeamgen() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SeamGen", size: 961, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2918,7 +2918,7 @@ func confGitignoreSketchup() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SketchUp", size: 6, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2938,7 +2938,7 @@ func confGitignoreSlickedit() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SlickEdit", size: 323, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2958,7 +2958,7 @@ func confGitignoreStella() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Stella", size: 207, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2978,7 +2978,7 @@ func confGitignoreSublimetext() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SublimeText", size: 354, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -2998,7 +2998,7 @@ func confGitignoreSugarcrm() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SugarCRM", size: 734, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3018,7 +3018,7 @@ func confGitignoreSwift() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Swift", size: 837, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3038,7 +3038,7 @@ func confGitignoreSymfony() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Symfony", size: 531, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3058,7 +3058,7 @@ func confGitignoreSymphonycms() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SymphonyCMS", size: 90, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3078,7 +3078,7 @@ func confGitignoreSynopsysvcs() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/SynopsysVCS", size: 971, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3098,7 +3098,7 @@ func confGitignoreTags() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Tags", size: 177, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3118,7 +3118,7 @@ func confGitignoreTex() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/TeX", size: 1328, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3138,7 +3138,7 @@ func confGitignoreTextmate() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/TextMate", size: 28, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3158,7 +3158,7 @@ func confGitignoreTextpattern() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Textpattern", size: 177, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3178,7 +3178,7 @@ func confGitignoreTortoisegit() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/TortoiseGit", size: 38, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3198,7 +3198,7 @@ func confGitignoreTurbogears2() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/TurboGears2", size: 202, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3218,7 +3218,7 @@ func confGitignoreTypo3() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Typo3", size: 466, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3238,7 +3238,7 @@ func confGitignoreUmbraco() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Umbraco", size: 536, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3258,7 +3258,7 @@ func confGitignoreUnity() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Unity", size: 267, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3278,7 +3278,7 @@ func confGitignoreVvvv() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/VVVV", size: 57, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3298,7 +3298,7 @@ func confGitignoreVagrant() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Vagrant", size: 10, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3318,7 +3318,7 @@ func confGitignoreVim() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Vim", size: 66, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3338,7 +3338,7 @@ func confGitignoreVirtualenv() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/VirtualEnv", size: 151, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3358,7 +3358,7 @@ func confGitignoreVisualstudio() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/VisualStudio", size: 3412, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3378,7 +3378,7 @@ func confGitignoreVisualstudiocode() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/VisualStudioCode", size: 11, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3398,7 +3398,7 @@ func confGitignoreWaf() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Waf", size: 87, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3418,7 +3418,7 @@ func confGitignoreWebmethods() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/WebMethods", size: 424, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3438,7 +3438,7 @@ func confGitignoreWindows() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Windows", size: 211, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3458,7 +3458,7 @@ func confGitignoreWordpress() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/WordPress", size: 297, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3478,7 +3478,7 @@ func confGitignoreXcode() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Xcode", size: 361, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3498,7 +3498,7 @@ func confGitignoreXilinxise() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/XilinxISE", size: 566, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3518,7 +3518,7 @@ func confGitignoreXojo() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Xojo", size: 160, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3538,7 +3538,7 @@ func confGitignoreYeoman() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Yeoman", size: 52, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3558,7 +3558,7 @@ func confGitignoreYii() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Yii", size: 120, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3578,7 +3578,7 @@ func confGitignoreZendframework() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/ZendFramework", size: 217, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3598,7 +3598,7 @@ func confGitignoreZephir() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/gitignore/Zephir", size: 387, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3618,7 +3618,7 @@ func confLicenseAbstylesLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Abstyles License", size: 730, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3638,7 +3638,7 @@ func confLicenseAcademicFreeLicenseV11() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Academic Free License v1.1", size: 4660, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3658,7 +3658,7 @@ func confLicenseAcademicFreeLicenseV12() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Academic Free License v1.2", size: 4949, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3678,7 +3678,7 @@ func confLicenseAcademicFreeLicenseV20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Academic Free License v2.0", size: 8937, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3698,7 +3698,7 @@ func confLicenseAcademicFreeLicenseV21() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Academic Free License v2.1", size: 8922, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3718,7 +3718,7 @@ func confLicenseAcademicFreeLicenseV30() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Academic Free License v3.0", size: 10306, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3738,7 +3738,7 @@ func confLicenseAfferoGeneralPublicLicenseV10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Affero General Public License v1.0", size: 15837, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3758,7 +3758,7 @@ func confLicenseApacheLicense10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Apache License 1.0", size: 2475, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3778,7 +3778,7 @@ func confLicenseApacheLicense11() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Apache License 1.1", size: 2508, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3798,7 +3798,7 @@ func confLicenseApacheLicense20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Apache License 2.0", size: 10261, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3818,7 +3818,7 @@ func confLicenseArtisticLicense10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Artistic License 1.0", size: 4789, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3838,7 +3838,7 @@ func confLicenseArtisticLicense20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Artistic License 2.0", size: 8661, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3858,7 +3858,7 @@ func confLicenseBsd2ClauseLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/BSD 2-clause License", size: 1286, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3878,7 +3878,7 @@ func confLicenseBsd3ClauseLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/BSD 3-clause License", size: 1480, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3898,7 +3898,7 @@ func confLicenseBsd4ClauseLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/BSD 4-clause License", size: 1624, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3918,7 +3918,7 @@ func confLicenseCreativeCommonsCc010Universal() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Creative Commons CC0 1.0 Universal", size: 6894, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3938,7 +3938,7 @@ func confLicenseEclipsePublicLicense10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Eclipse Public License 1.0", size: 11248, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3958,7 +3958,7 @@ func confLicenseEducationalCommunityLicenseV10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Educational Community License v1.0", size: 2394, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3978,7 +3978,7 @@ func confLicenseEducationalCommunityLicenseV20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Educational Community License v2.0", size: 11085, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -3998,7 +3998,7 @@ func confLicenseGnuAfferoGeneralPublicLicenseV30() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Affero General Public License v3.0", size: 33818, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4018,7 +4018,7 @@ func confLicenseGnuFreeDocumentationLicenseV11() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Free Documentation License v1.1", size: 17912, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4038,7 +4038,7 @@ func confLicenseGnuFreeDocumentationLicenseV12() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Free Documentation License v1.2", size: 20209, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4058,7 +4058,7 @@ func confLicenseGnuFreeDocumentationLicenseV13() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Free Documentation License v1.3", size: 22732, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4078,7 +4078,7 @@ func confLicenseGnuGeneralPublicLicenseV10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU General Public License v1.0", size: 12165, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4098,7 +4098,7 @@ func confLicenseGnuGeneralPublicLicenseV20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU General Public License v2.0", size: 17277, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4118,7 +4118,7 @@ func confLicenseGnuGeneralPublicLicenseV30() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU General Public License v3.0", size: 34570, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4138,7 +4138,7 @@ func confLicenseGnuLesserGeneralPublicLicenseV21() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Lesser General Public License v2.1", size: 25885, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4158,7 +4158,7 @@ func confLicenseGnuLesserGeneralPublicLicenseV30() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Lesser General Public License v3.0", size: 7355, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4178,7 +4178,7 @@ func confLicenseGnuLibraryGeneralPublicLicenseV20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/GNU Library General Public License v2.0", size: 24758, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4198,7 +4198,7 @@ func confLicenseIscLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/ISC license", size: 823, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4218,7 +4218,7 @@ func confLicenseMitLicense() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/MIT License", size: 1077, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4238,7 +4238,7 @@ func confLicenseMozillaPublicLicense10() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Mozilla Public License 1.0", size: 18026, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4258,7 +4258,7 @@ func confLicenseMozillaPublicLicense11() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Mozilla Public License 1.1", size: 23361, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4278,7 +4278,7 @@ func confLicenseMozillaPublicLicense20() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/license/Mozilla Public License 2.0", size: 14827, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4298,7 +4298,7 @@ func confLocaleLocale_bgBgIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_bg-BG.ini", size: 74289, mode: os.FileMode(493), modTime: time.Unix(1452479330, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4318,7 +4318,7 @@ func confLocaleLocale_deDeIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_de-DE.ini", size: 51412, mode: os.FileMode(493), modTime: time.Unix(1452479332, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4338,7 +4338,7 @@ func confLocaleLocale_enUsIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_en-US.ini", size: 48409, mode: os.FileMode(420), modTime: time.Unix(1452230531, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4358,7 +4358,7 @@ func confLocaleLocale_esEsIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_es-ES.ini", size: 52579, mode: os.FileMode(493), modTime: time.Unix(1452479330, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4378,7 +4378,7 @@ func confLocaleLocale_frFrIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_fr-FR.ini", size: 52387, mode: os.FileMode(493), modTime: time.Unix(1452479330, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4398,7 +4398,7 @@ func confLocaleLocale_itItIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_it-IT.ini", size: 49974, mode: os.FileMode(493), modTime: time.Unix(1452479336, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4418,7 +4418,7 @@ func confLocaleLocale_jaJpIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_ja-JP.ini", size: 57701, mode: os.FileMode(493), modTime: time.Unix(1452479336, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4438,7 +4438,7 @@ func confLocaleLocale_lvLvIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_lv-LV.ini", size: 52627, mode: os.FileMode(493), modTime: time.Unix(1452479340, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4458,7 +4458,7 @@ func confLocaleLocale_nlNlIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_nl-NL.ini", size: 48931, mode: os.FileMode(493), modTime: time.Unix(1452479338, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4478,7 +4478,7 @@ func confLocaleLocale_plPlIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_pl-PL.ini", size: 50492, mode: os.FileMode(493), modTime: time.Unix(1452479338, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4498,7 +4498,7 @@ func confLocaleLocale_ptBrIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_pt-BR.ini", size: 50937, mode: os.FileMode(493), modTime: time.Unix(1452479340, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4518,7 +4518,7 @@ func confLocaleLocale_ruRuIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_ru-RU.ini", size: 74767, mode: os.FileMode(493), modTime: time.Unix(1452479338, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4538,7 +4538,7 @@ func confLocaleLocale_zhCnIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_zh-CN.ini", size: 46353, mode: os.FileMode(493), modTime: time.Unix(1452479338, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4558,7 +4558,7 @@ func confLocaleLocale_zhHkIni() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/locale/locale_zh-HK.ini", size: 46365, mode: os.FileMode(493), modTime: time.Unix(1452479338, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4578,7 +4578,7 @@ func confReadmeDefault() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "conf/readme/Default", size: 23, mode: os.FileMode(420), modTime: time.Unix(1441006036, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -4601,7 +4601,7 @@ func Asset(name string) ([]byte, error) {
 // It simplifies safe initialization of global variables.
 func MustAsset(name string) []byte {
 	a, err := Asset(name)
-	if (err != nil) {
+	if err != nil {
 		panic("asset: Asset(" + name + "): " + err.Error())
 	}
 
@@ -4634,221 +4634,221 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"conf/app.ini": confAppIni,
-	"conf/gitignore/Actionscript": confGitignoreActionscript,
-	"conf/gitignore/Ada": confGitignoreAda,
-	"conf/gitignore/Agda": confGitignoreAgda,
-	"conf/gitignore/Android": confGitignoreAndroid,
-	"conf/gitignore/Anjuta": confGitignoreAnjuta,
-	"conf/gitignore/AppEngine": confGitignoreAppengine,
-	"conf/gitignore/AppceleratorTitanium": confGitignoreAppceleratortitanium,
-	"conf/gitignore/ArchLinuxPackages": confGitignoreArchlinuxpackages,
-	"conf/gitignore/Archives": confGitignoreArchives,
-	"conf/gitignore/Autotools": confGitignoreAutotools,
-	"conf/gitignore/BricxCC": confGitignoreBricxcc,
-	"conf/gitignore/C": confGitignoreC,
-	"conf/gitignore/C Sharp": confGitignoreCSharp,
-	"conf/gitignore/C++": confGitignoreC2,
-	"conf/gitignore/CFWheels": confGitignoreCfwheels,
-	"conf/gitignore/CMake": confGitignoreCmake,
-	"conf/gitignore/CUDA": confGitignoreCuda,
-	"conf/gitignore/CVS": confGitignoreCvs,
-	"conf/gitignore/CakePHP": confGitignoreCakephp,
-	"conf/gitignore/ChefCookbook": confGitignoreChefcookbook,
-	"conf/gitignore/Cloud9": confGitignoreCloud9,
-	"conf/gitignore/CodeIgniter": confGitignoreCodeigniter,
-	"conf/gitignore/CodeKit": confGitignoreCodekit,
-	"conf/gitignore/CommonLisp": confGitignoreCommonlisp,
-	"conf/gitignore/Composer": confGitignoreComposer,
-	"conf/gitignore/Concrete5": confGitignoreConcrete5,
-	"conf/gitignore/Coq": confGitignoreCoq,
-	"conf/gitignore/CraftCMS": confGitignoreCraftcms,
-	"conf/gitignore/DM": confGitignoreDm,
-	"conf/gitignore/Dart": confGitignoreDart,
-	"conf/gitignore/DartEditor": confGitignoreDarteditor,
-	"conf/gitignore/Delphi": confGitignoreDelphi,
-	"conf/gitignore/Dreamweaver": confGitignoreDreamweaver,
-	"conf/gitignore/Drupal": confGitignoreDrupal,
-	"conf/gitignore/EPiServer": confGitignoreEpiserver,
-	"conf/gitignore/Eagle": confGitignoreEagle,
-	"conf/gitignore/Eclipse": confGitignoreEclipse,
-	"conf/gitignore/EiffelStudio": confGitignoreEiffelstudio,
-	"conf/gitignore/Elisp": confGitignoreElisp,
-	"conf/gitignore/Elixir": confGitignoreElixir,
-	"conf/gitignore/Emacs": confGitignoreEmacs,
-	"conf/gitignore/Ensime": confGitignoreEnsime,
-	"conf/gitignore/Erlang": confGitignoreErlang,
-	"conf/gitignore/Espresso": confGitignoreEspresso,
-	"conf/gitignore/ExpressionEngine": confGitignoreExpressionengine,
-	"conf/gitignore/ExtJs": confGitignoreExtjs,
-	"conf/gitignore/Fancy": confGitignoreFancy,
-	"conf/gitignore/Finale": confGitignoreFinale,
-	"conf/gitignore/FlexBuilder": confGitignoreFlexbuilder,
-	"conf/gitignore/ForceDotCom": confGitignoreForcedotcom,
-	"conf/gitignore/FuelPHP": confGitignoreFuelphp,
-	"conf/gitignore/GWT": confGitignoreGwt,
-	"conf/gitignore/Gcov": confGitignoreGcov,
-	"conf/gitignore/GitBook": confGitignoreGitbook,
-	"conf/gitignore/Go": confGitignoreGo,
-	"conf/gitignore/Gradle": confGitignoreGradle,
-	"conf/gitignore/Grails": confGitignoreGrails,
-	"conf/gitignore/Haskell": confGitignoreHaskell,
-	"conf/gitignore/IGORPro": confGitignoreIgorpro,
-	"conf/gitignore/IPythonNotebook": confGitignoreIpythonnotebook,
-	"conf/gitignore/Idris": confGitignoreIdris,
-	"conf/gitignore/JDeveloper": confGitignoreJdeveloper,
-	"conf/gitignore/Java": confGitignoreJava,
-	"conf/gitignore/Jboss": confGitignoreJboss,
-	"conf/gitignore/Jekyll": confGitignoreJekyll,
-	"conf/gitignore/JetBrains": confGitignoreJetbrains,
-	"conf/gitignore/Joomla": confGitignoreJoomla,
-	"conf/gitignore/KDevelop4": confGitignoreKdevelop4,
-	"conf/gitignore/Kate": confGitignoreKate,
-	"conf/gitignore/KiCAD": confGitignoreKicad,
-	"conf/gitignore/Kohana": confGitignoreKohana,
-	"conf/gitignore/LabVIEW": confGitignoreLabview,
-	"conf/gitignore/Laravel": confGitignoreLaravel,
-	"conf/gitignore/Lazarus": confGitignoreLazarus,
-	"conf/gitignore/Leiningen": confGitignoreLeiningen,
-	"conf/gitignore/LemonStand": confGitignoreLemonstand,
-	"conf/gitignore/LibreOffice": confGitignoreLibreoffice,
-	"conf/gitignore/Lilypond": confGitignoreLilypond,
-	"conf/gitignore/Linux": confGitignoreLinux,
-	"conf/gitignore/Lithium": confGitignoreLithium,
-	"conf/gitignore/Lua": confGitignoreLua,
-	"conf/gitignore/LyX": confGitignoreLyx,
-	"conf/gitignore/Magento": confGitignoreMagento,
-	"conf/gitignore/Matlab": confGitignoreMatlab,
-	"conf/gitignore/Maven": confGitignoreMaven,
-	"conf/gitignore/Mercurial": confGitignoreMercurial,
-	"conf/gitignore/Mercury": confGitignoreMercury,
-	"conf/gitignore/MetaProgrammingSystem": confGitignoreMetaprogrammingsystem,
-	"conf/gitignore/MicrosoftOffice": confGitignoreMicrosoftoffice,
-	"conf/gitignore/ModelSim": confGitignoreModelsim,
-	"conf/gitignore/Momentics": confGitignoreMomentics,
-	"conf/gitignore/MonoDevelop": confGitignoreMonodevelop,
-	"conf/gitignore/Nanoc": confGitignoreNanoc,
-	"conf/gitignore/NetBeans": confGitignoreNetbeans,
-	"conf/gitignore/Nim": confGitignoreNim,
-	"conf/gitignore/Ninja": confGitignoreNinja,
-	"conf/gitignore/Node": confGitignoreNode,
-	"conf/gitignore/NotepadPP": confGitignoreNotepadpp,
-	"conf/gitignore/OCaml": confGitignoreOcaml,
-	"conf/gitignore/OSX": confGitignoreOsx,
-	"conf/gitignore/Objective-C": confGitignoreObjectiveC,
-	"conf/gitignore/Opa": confGitignoreOpa,
-	"conf/gitignore/OpenCart": confGitignoreOpencart,
-	"conf/gitignore/OracleForms": confGitignoreOracleforms,
-	"conf/gitignore/Packer": confGitignorePacker,
-	"conf/gitignore/Perl": confGitignorePerl,
-	"conf/gitignore/Phalcon": confGitignorePhalcon,
-	"conf/gitignore/PlayFramework": confGitignorePlayframework,
-	"conf/gitignore/Plone": confGitignorePlone,
-	"conf/gitignore/Prestashop": confGitignorePrestashop,
-	"conf/gitignore/Processing": confGitignoreProcessing,
-	"conf/gitignore/Python": confGitignorePython,
-	"conf/gitignore/Qooxdoo": confGitignoreQooxdoo,
-	"conf/gitignore/Qt": confGitignoreQt,
-	"conf/gitignore/R": confGitignoreR,
-	"conf/gitignore/ROS": confGitignoreRos,
-	"conf/gitignore/Rails": confGitignoreRails,
-	"conf/gitignore/Redcar": confGitignoreRedcar,
-	"conf/gitignore/Redis": confGitignoreRedis,
-	"conf/gitignore/RhodesRhomobile": confGitignoreRhodesrhomobile,
-	"conf/gitignore/Ruby": confGitignoreRuby,
-	"conf/gitignore/Rust": confGitignoreRust,
-	"conf/gitignore/SBT": confGitignoreSbt,
-	"conf/gitignore/SCons": confGitignoreScons,
-	"conf/gitignore/SVN": confGitignoreSvn,
-	"conf/gitignore/Sass": confGitignoreSass,
-	"conf/gitignore/Scala": confGitignoreScala,
-	"conf/gitignore/Scrivener": confGitignoreScrivener,
-	"conf/gitignore/Sdcc": confGitignoreSdcc,
-	"conf/gitignore/SeamGen": confGitignoreSeamgen,
-	"conf/gitignore/SketchUp": confGitignoreSketchup,
-	"conf/gitignore/SlickEdit": confGitignoreSlickedit,
-	"conf/gitignore/Stella": confGitignoreStella,
-	"conf/gitignore/SublimeText": confGitignoreSublimetext,
-	"conf/gitignore/SugarCRM": confGitignoreSugarcrm,
-	"conf/gitignore/Swift": confGitignoreSwift,
-	"conf/gitignore/Symfony": confGitignoreSymfony,
-	"conf/gitignore/SymphonyCMS": confGitignoreSymphonycms,
-	"conf/gitignore/SynopsysVCS": confGitignoreSynopsysvcs,
-	"conf/gitignore/Tags": confGitignoreTags,
-	"conf/gitignore/TeX": confGitignoreTex,
-	"conf/gitignore/TextMate": confGitignoreTextmate,
-	"conf/gitignore/Textpattern": confGitignoreTextpattern,
-	"conf/gitignore/TortoiseGit": confGitignoreTortoisegit,
-	"conf/gitignore/TurboGears2": confGitignoreTurbogears2,
-	"conf/gitignore/Typo3": confGitignoreTypo3,
-	"conf/gitignore/Umbraco": confGitignoreUmbraco,
-	"conf/gitignore/Unity": confGitignoreUnity,
-	"conf/gitignore/VVVV": confGitignoreVvvv,
-	"conf/gitignore/Vagrant": confGitignoreVagrant,
-	"conf/gitignore/Vim": confGitignoreVim,
-	"conf/gitignore/VirtualEnv": confGitignoreVirtualenv,
-	"conf/gitignore/VisualStudio": confGitignoreVisualstudio,
-	"conf/gitignore/VisualStudioCode": confGitignoreVisualstudiocode,
-	"conf/gitignore/Waf": confGitignoreWaf,
-	"conf/gitignore/WebMethods": confGitignoreWebmethods,
-	"conf/gitignore/Windows": confGitignoreWindows,
-	"conf/gitignore/WordPress": confGitignoreWordpress,
-	"conf/gitignore/Xcode": confGitignoreXcode,
-	"conf/gitignore/XilinxISE": confGitignoreXilinxise,
-	"conf/gitignore/Xojo": confGitignoreXojo,
-	"conf/gitignore/Yeoman": confGitignoreYeoman,
-	"conf/gitignore/Yii": confGitignoreYii,
-	"conf/gitignore/ZendFramework": confGitignoreZendframework,
-	"conf/gitignore/Zephir": confGitignoreZephir,
-	"conf/license/Abstyles License": confLicenseAbstylesLicense,
-	"conf/license/Academic Free License v1.1": confLicenseAcademicFreeLicenseV11,
-	"conf/license/Academic Free License v1.2": confLicenseAcademicFreeLicenseV12,
-	"conf/license/Academic Free License v2.0": confLicenseAcademicFreeLicenseV20,
-	"conf/license/Academic Free License v2.1": confLicenseAcademicFreeLicenseV21,
-	"conf/license/Academic Free License v3.0": confLicenseAcademicFreeLicenseV30,
-	"conf/license/Affero General Public License v1.0": confLicenseAfferoGeneralPublicLicenseV10,
-	"conf/license/Apache License 1.0": confLicenseApacheLicense10,
-	"conf/license/Apache License 1.1": confLicenseApacheLicense11,
-	"conf/license/Apache License 2.0": confLicenseApacheLicense20,
-	"conf/license/Artistic License 1.0": confLicenseArtisticLicense10,
-	"conf/license/Artistic License 2.0": confLicenseArtisticLicense20,
-	"conf/license/BSD 2-clause License": confLicenseBsd2ClauseLicense,
-	"conf/license/BSD 3-clause License": confLicenseBsd3ClauseLicense,
-	"conf/license/BSD 4-clause License": confLicenseBsd4ClauseLicense,
-	"conf/license/Creative Commons CC0 1.0 Universal": confLicenseCreativeCommonsCc010Universal,
-	"conf/license/Eclipse Public License 1.0": confLicenseEclipsePublicLicense10,
-	"conf/license/Educational Community License v1.0": confLicenseEducationalCommunityLicenseV10,
-	"conf/license/Educational Community License v2.0": confLicenseEducationalCommunityLicenseV20,
-	"conf/license/GNU Affero General Public License v3.0": confLicenseGnuAfferoGeneralPublicLicenseV30,
-	"conf/license/GNU Free Documentation License v1.1": confLicenseGnuFreeDocumentationLicenseV11,
-	"conf/license/GNU Free Documentation License v1.2": confLicenseGnuFreeDocumentationLicenseV12,
-	"conf/license/GNU Free Documentation License v1.3": confLicenseGnuFreeDocumentationLicenseV13,
-	"conf/license/GNU General Public License v1.0": confLicenseGnuGeneralPublicLicenseV10,
-	"conf/license/GNU General Public License v2.0": confLicenseGnuGeneralPublicLicenseV20,
-	"conf/license/GNU General Public License v3.0": confLicenseGnuGeneralPublicLicenseV30,
-	"conf/license/GNU Lesser General Public License v2.1": confLicenseGnuLesserGeneralPublicLicenseV21,
-	"conf/license/GNU Lesser General Public License v3.0": confLicenseGnuLesserGeneralPublicLicenseV30,
+	"conf/app.ini":                                         confAppIni,
+	"conf/gitignore/Actionscript":                          confGitignoreActionscript,
+	"conf/gitignore/Ada":                                   confGitignoreAda,
+	"conf/gitignore/Agda":                                  confGitignoreAgda,
+	"conf/gitignore/Android":                               confGitignoreAndroid,
+	"conf/gitignore/Anjuta":                                confGitignoreAnjuta,
+	"conf/gitignore/AppEngine":                             confGitignoreAppengine,
+	"conf/gitignore/AppceleratorTitanium":                  confGitignoreAppceleratortitanium,
+	"conf/gitignore/ArchLinuxPackages":                     confGitignoreArchlinuxpackages,
+	"conf/gitignore/Archives":                              confGitignoreArchives,
+	"conf/gitignore/Autotools":                             confGitignoreAutotools,
+	"conf/gitignore/BricxCC":                               confGitignoreBricxcc,
+	"conf/gitignore/C":                                     confGitignoreC,
+	"conf/gitignore/C Sharp":                               confGitignoreCSharp,
+	"conf/gitignore/C++":                                   confGitignoreC2,
+	"conf/gitignore/CFWheels":                              confGitignoreCfwheels,
+	"conf/gitignore/CMake":                                 confGitignoreCmake,
+	"conf/gitignore/CUDA":                                  confGitignoreCuda,
+	"conf/gitignore/CVS":                                   confGitignoreCvs,
+	"conf/gitignore/CakePHP":                               confGitignoreCakephp,
+	"conf/gitignore/ChefCookbook":                          confGitignoreChefcookbook,
+	"conf/gitignore/Cloud9":                                confGitignoreCloud9,
+	"conf/gitignore/CodeIgniter":                           confGitignoreCodeigniter,
+	"conf/gitignore/CodeKit":                               confGitignoreCodekit,
+	"conf/gitignore/CommonLisp":                            confGitignoreCommonlisp,
+	"conf/gitignore/Composer":                              confGitignoreComposer,
+	"conf/gitignore/Concrete5":                             confGitignoreConcrete5,
+	"conf/gitignore/Coq":                                   confGitignoreCoq,
+	"conf/gitignore/CraftCMS":                              confGitignoreCraftcms,
+	"conf/gitignore/DM":                                    confGitignoreDm,
+	"conf/gitignore/Dart":                                  confGitignoreDart,
+	"conf/gitignore/DartEditor":                            confGitignoreDarteditor,
+	"conf/gitignore/Delphi":                                confGitignoreDelphi,
+	"conf/gitignore/Dreamweaver":                           confGitignoreDreamweaver,
+	"conf/gitignore/Drupal":                                confGitignoreDrupal,
+	"conf/gitignore/EPiServer":                             confGitignoreEpiserver,
+	"conf/gitignore/Eagle":                                 confGitignoreEagle,
+	"conf/gitignore/Eclipse":                               confGitignoreEclipse,
+	"conf/gitignore/EiffelStudio":                          confGitignoreEiffelstudio,
+	"conf/gitignore/Elisp":                                 confGitignoreElisp,
+	"conf/gitignore/Elixir":                                confGitignoreElixir,
+	"conf/gitignore/Emacs":                                 confGitignoreEmacs,
+	"conf/gitignore/Ensime":                                confGitignoreEnsime,
+	"conf/gitignore/Erlang":                                confGitignoreErlang,
+	"conf/gitignore/Espresso":                              confGitignoreEspresso,
+	"conf/gitignore/ExpressionEngine":                      confGitignoreExpressionengine,
+	"conf/gitignore/ExtJs":                                 confGitignoreExtjs,
+	"conf/gitignore/Fancy":                                 confGitignoreFancy,
+	"conf/gitignore/Finale":                                confGitignoreFinale,
+	"conf/gitignore/FlexBuilder":                           confGitignoreFlexbuilder,
+	"conf/gitignore/ForceDotCom":                           confGitignoreForcedotcom,
+	"conf/gitignore/FuelPHP":                               confGitignoreFuelphp,
+	"conf/gitignore/GWT":                                   confGitignoreGwt,
+	"conf/gitignore/Gcov":                                  confGitignoreGcov,
+	"conf/gitignore/GitBook":                               confGitignoreGitbook,
+	"conf/gitignore/Go":                                    confGitignoreGo,
+	"conf/gitignore/Gradle":                                confGitignoreGradle,
+	"conf/gitignore/Grails":                                confGitignoreGrails,
+	"conf/gitignore/Haskell":                               confGitignoreHaskell,
+	"conf/gitignore/IGORPro":                               confGitignoreIgorpro,
+	"conf/gitignore/IPythonNotebook":                       confGitignoreIpythonnotebook,
+	"conf/gitignore/Idris":                                 confGitignoreIdris,
+	"conf/gitignore/JDeveloper":                            confGitignoreJdeveloper,
+	"conf/gitignore/Java":                                  confGitignoreJava,
+	"conf/gitignore/Jboss":                                 confGitignoreJboss,
+	"conf/gitignore/Jekyll":                                confGitignoreJekyll,
+	"conf/gitignore/JetBrains":                             confGitignoreJetbrains,
+	"conf/gitignore/Joomla":                                confGitignoreJoomla,
+	"conf/gitignore/KDevelop4":                             confGitignoreKdevelop4,
+	"conf/gitignore/Kate":                                  confGitignoreKate,
+	"conf/gitignore/KiCAD":                                 confGitignoreKicad,
+	"conf/gitignore/Kohana":                                confGitignoreKohana,
+	"conf/gitignore/LabVIEW":                               confGitignoreLabview,
+	"conf/gitignore/Laravel":                               confGitignoreLaravel,
+	"conf/gitignore/Lazarus":                               confGitignoreLazarus,
+	"conf/gitignore/Leiningen":                             confGitignoreLeiningen,
+	"conf/gitignore/LemonStand":                            confGitignoreLemonstand,
+	"conf/gitignore/LibreOffice":                           confGitignoreLibreoffice,
+	"conf/gitignore/Lilypond":                              confGitignoreLilypond,
+	"conf/gitignore/Linux":                                 confGitignoreLinux,
+	"conf/gitignore/Lithium":                               confGitignoreLithium,
+	"conf/gitignore/Lua":                                   confGitignoreLua,
+	"conf/gitignore/LyX":                                   confGitignoreLyx,
+	"conf/gitignore/Magento":                               confGitignoreMagento,
+	"conf/gitignore/Matlab":                                confGitignoreMatlab,
+	"conf/gitignore/Maven":                                 confGitignoreMaven,
+	"conf/gitignore/Mercurial":                             confGitignoreMercurial,
+	"conf/gitignore/Mercury":                               confGitignoreMercury,
+	"conf/gitignore/MetaProgrammingSystem":                 confGitignoreMetaprogrammingsystem,
+	"conf/gitignore/MicrosoftOffice":                       confGitignoreMicrosoftoffice,
+	"conf/gitignore/ModelSim":                              confGitignoreModelsim,
+	"conf/gitignore/Momentics":                             confGitignoreMomentics,
+	"conf/gitignore/MonoDevelop":                           confGitignoreMonodevelop,
+	"conf/gitignore/Nanoc":                                 confGitignoreNanoc,
+	"conf/gitignore/NetBeans":                              confGitignoreNetbeans,
+	"conf/gitignore/Nim":                                   confGitignoreNim,
+	"conf/gitignore/Ninja":                                 confGitignoreNinja,
+	"conf/gitignore/Node":                                  confGitignoreNode,
+	"conf/gitignore/NotepadPP":                             confGitignoreNotepadpp,
+	"conf/gitignore/OCaml":                                 confGitignoreOcaml,
+	"conf/gitignore/OSX":                                   confGitignoreOsx,
+	"conf/gitignore/Objective-C":                           confGitignoreObjectiveC,
+	"conf/gitignore/Opa":                                   confGitignoreOpa,
+	"conf/gitignore/OpenCart":                              confGitignoreOpencart,
+	"conf/gitignore/OracleForms":                           confGitignoreOracleforms,
+	"conf/gitignore/Packer":                                confGitignorePacker,
+	"conf/gitignore/Perl":                                  confGitignorePerl,
+	"conf/gitignore/Phalcon":                               confGitignorePhalcon,
+	"conf/gitignore/PlayFramework":                         confGitignorePlayframework,
+	"conf/gitignore/Plone":                                 confGitignorePlone,
+	"conf/gitignore/Prestashop":                            confGitignorePrestashop,
+	"conf/gitignore/Processing":                            confGitignoreProcessing,
+	"conf/gitignore/Python":                                confGitignorePython,
+	"conf/gitignore/Qooxdoo":                               confGitignoreQooxdoo,
+	"conf/gitignore/Qt":                                    confGitignoreQt,
+	"conf/gitignore/R":                                     confGitignoreR,
+	"conf/gitignore/ROS":                                   confGitignoreRos,
+	"conf/gitignore/Rails":                                 confGitignoreRails,
+	"conf/gitignore/Redcar":                                confGitignoreRedcar,
+	"conf/gitignore/Redis":                                 confGitignoreRedis,
+	"conf/gitignore/RhodesRhomobile":                       confGitignoreRhodesrhomobile,
+	"conf/gitignore/Ruby":                                  confGitignoreRuby,
+	"conf/gitignore/Rust":                                  confGitignoreRust,
+	"conf/gitignore/SBT":                                   confGitignoreSbt,
+	"conf/gitignore/SCons":                                 confGitignoreScons,
+	"conf/gitignore/SVN":                                   confGitignoreSvn,
+	"conf/gitignore/Sass":                                  confGitignoreSass,
+	"conf/gitignore/Scala":                                 confGitignoreScala,
+	"conf/gitignore/Scrivener":                             confGitignoreScrivener,
+	"conf/gitignore/Sdcc":                                  confGitignoreSdcc,
+	"conf/gitignore/SeamGen":                               confGitignoreSeamgen,
+	"conf/gitignore/SketchUp":                              confGitignoreSketchup,
+	"conf/gitignore/SlickEdit":                             confGitignoreSlickedit,
+	"conf/gitignore/Stella":                                confGitignoreStella,
+	"conf/gitignore/SublimeText":                           confGitignoreSublimetext,
+	"conf/gitignore/SugarCRM":                              confGitignoreSugarcrm,
+	"conf/gitignore/Swift":                                 confGitignoreSwift,
+	"conf/gitignore/Symfony":                               confGitignoreSymfony,
+	"conf/gitignore/SymphonyCMS":                           confGitignoreSymphonycms,
+	"conf/gitignore/SynopsysVCS":                           confGitignoreSynopsysvcs,
+	"conf/gitignore/Tags":                                  confGitignoreTags,
+	"conf/gitignore/TeX":                                   confGitignoreTex,
+	"conf/gitignore/TextMate":                              confGitignoreTextmate,
+	"conf/gitignore/Textpattern":                           confGitignoreTextpattern,
+	"conf/gitignore/TortoiseGit":                           confGitignoreTortoisegit,
+	"conf/gitignore/TurboGears2":                           confGitignoreTurbogears2,
+	"conf/gitignore/Typo3":                                 confGitignoreTypo3,
+	"conf/gitignore/Umbraco":                               confGitignoreUmbraco,
+	"conf/gitignore/Unity":                                 confGitignoreUnity,
+	"conf/gitignore/VVVV":                                  confGitignoreVvvv,
+	"conf/gitignore/Vagrant":                               confGitignoreVagrant,
+	"conf/gitignore/Vim":                                   confGitignoreVim,
+	"conf/gitignore/VirtualEnv":                            confGitignoreVirtualenv,
+	"conf/gitignore/VisualStudio":                          confGitignoreVisualstudio,
+	"conf/gitignore/VisualStudioCode":                      confGitignoreVisualstudiocode,
+	"conf/gitignore/Waf":                                   confGitignoreWaf,
+	"conf/gitignore/WebMethods":                            confGitignoreWebmethods,
+	"conf/gitignore/Windows":                               confGitignoreWindows,
+	"conf/gitignore/WordPress":                             confGitignoreWordpress,
+	"conf/gitignore/Xcode":                                 confGitignoreXcode,
+	"conf/gitignore/XilinxISE":                             confGitignoreXilinxise,
+	"conf/gitignore/Xojo":                                  confGitignoreXojo,
+	"conf/gitignore/Yeoman":                                confGitignoreYeoman,
+	"conf/gitignore/Yii":                                   confGitignoreYii,
+	"conf/gitignore/ZendFramework":                         confGitignoreZendframework,
+	"conf/gitignore/Zephir":                                confGitignoreZephir,
+	"conf/license/Abstyles License":                        confLicenseAbstylesLicense,
+	"conf/license/Academic Free License v1.1":              confLicenseAcademicFreeLicenseV11,
+	"conf/license/Academic Free License v1.2":              confLicenseAcademicFreeLicenseV12,
+	"conf/license/Academic Free License v2.0":              confLicenseAcademicFreeLicenseV20,
+	"conf/license/Academic Free License v2.1":              confLicenseAcademicFreeLicenseV21,
+	"conf/license/Academic Free License v3.0":              confLicenseAcademicFreeLicenseV30,
+	"conf/license/Affero General Public License v1.0":      confLicenseAfferoGeneralPublicLicenseV10,
+	"conf/license/Apache License 1.0":                      confLicenseApacheLicense10,
+	"conf/license/Apache License 1.1":                      confLicenseApacheLicense11,
+	"conf/license/Apache License 2.0":                      confLicenseApacheLicense20,
+	"conf/license/Artistic License 1.0":                    confLicenseArtisticLicense10,
+	"conf/license/Artistic License 2.0":                    confLicenseArtisticLicense20,
+	"conf/license/BSD 2-clause License":                    confLicenseBsd2ClauseLicense,
+	"conf/license/BSD 3-clause License":                    confLicenseBsd3ClauseLicense,
+	"conf/license/BSD 4-clause License":                    confLicenseBsd4ClauseLicense,
+	"conf/license/Creative Commons CC0 1.0 Universal":      confLicenseCreativeCommonsCc010Universal,
+	"conf/license/Eclipse Public License 1.0":              confLicenseEclipsePublicLicense10,
+	"conf/license/Educational Community License v1.0":      confLicenseEducationalCommunityLicenseV10,
+	"conf/license/Educational Community License v2.0":      confLicenseEducationalCommunityLicenseV20,
+	"conf/license/GNU Affero General Public License v3.0":  confLicenseGnuAfferoGeneralPublicLicenseV30,
+	"conf/license/GNU Free Documentation License v1.1":     confLicenseGnuFreeDocumentationLicenseV11,
+	"conf/license/GNU Free Documentation License v1.2":     confLicenseGnuFreeDocumentationLicenseV12,
+	"conf/license/GNU Free Documentation License v1.3":     confLicenseGnuFreeDocumentationLicenseV13,
+	"conf/license/GNU General Public License v1.0":         confLicenseGnuGeneralPublicLicenseV10,
+	"conf/license/GNU General Public License v2.0":         confLicenseGnuGeneralPublicLicenseV20,
+	"conf/license/GNU General Public License v3.0":         confLicenseGnuGeneralPublicLicenseV30,
+	"conf/license/GNU Lesser General Public License v2.1":  confLicenseGnuLesserGeneralPublicLicenseV21,
+	"conf/license/GNU Lesser General Public License v3.0":  confLicenseGnuLesserGeneralPublicLicenseV30,
 	"conf/license/GNU Library General Public License v2.0": confLicenseGnuLibraryGeneralPublicLicenseV20,
-	"conf/license/ISC license": confLicenseIscLicense,
-	"conf/license/MIT License": confLicenseMitLicense,
-	"conf/license/Mozilla Public License 1.0": confLicenseMozillaPublicLicense10,
-	"conf/license/Mozilla Public License 1.1": confLicenseMozillaPublicLicense11,
-	"conf/license/Mozilla Public License 2.0": confLicenseMozillaPublicLicense20,
-	"conf/locale/locale_bg-BG.ini": confLocaleLocale_bgBgIni,
-	"conf/locale/locale_de-DE.ini": confLocaleLocale_deDeIni,
-	"conf/locale/locale_en-US.ini": confLocaleLocale_enUsIni,
-	"conf/locale/locale_es-ES.ini": confLocaleLocale_esEsIni,
-	"conf/locale/locale_fr-FR.ini": confLocaleLocale_frFrIni,
-	"conf/locale/locale_it-IT.ini": confLocaleLocale_itItIni,
-	"conf/locale/locale_ja-JP.ini": confLocaleLocale_jaJpIni,
-	"conf/locale/locale_lv-LV.ini": confLocaleLocale_lvLvIni,
-	"conf/locale/locale_nl-NL.ini": confLocaleLocale_nlNlIni,
-	"conf/locale/locale_pl-PL.ini": confLocaleLocale_plPlIni,
-	"conf/locale/locale_pt-BR.ini": confLocaleLocale_ptBrIni,
-	"conf/locale/locale_ru-RU.ini": confLocaleLocale_ruRuIni,
-	"conf/locale/locale_zh-CN.ini": confLocaleLocale_zhCnIni,
-	"conf/locale/locale_zh-HK.ini": confLocaleLocale_zhHkIni,
-	"conf/readme/Default": confReadmeDefault,
+	"conf/license/ISC license":                             confLicenseIscLicense,
+	"conf/license/MIT License":                             confLicenseMitLicense,
+	"conf/license/Mozilla Public License 1.0":              confLicenseMozillaPublicLicense10,
+	"conf/license/Mozilla Public License 1.1":              confLicenseMozillaPublicLicense11,
+	"conf/license/Mozilla Public License 2.0":              confLicenseMozillaPublicLicense20,
+	"conf/locale/locale_bg-BG.ini":                         confLocaleLocale_bgBgIni,
+	"conf/locale/locale_de-DE.ini":                         confLocaleLocale_deDeIni,
+	"conf/locale/locale_en-US.ini":                         confLocaleLocale_enUsIni,
+	"conf/locale/locale_es-ES.ini":                         confLocaleLocale_esEsIni,
+	"conf/locale/locale_fr-FR.ini":                         confLocaleLocale_frFrIni,
+	"conf/locale/locale_it-IT.ini":                         confLocaleLocale_itItIni,
+	"conf/locale/locale_ja-JP.ini":                         confLocaleLocale_jaJpIni,
+	"conf/locale/locale_lv-LV.ini":                         confLocaleLocale_lvLvIni,
+	"conf/locale/locale_nl-NL.ini":                         confLocaleLocale_nlNlIni,
+	"conf/locale/locale_pl-PL.ini":                         confLocaleLocale_plPlIni,
+	"conf/locale/locale_pt-BR.ini":                         confLocaleLocale_ptBrIni,
+	"conf/locale/locale_ru-RU.ini":                         confLocaleLocale_ruRuIni,
+	"conf/locale/locale_zh-CN.ini":                         confLocaleLocale_zhCnIni,
+	"conf/locale/locale_zh-HK.ini":                         confLocaleLocale_zhHkIni,
+	"conf/readme/Default":                                  confReadmeDefault,
 }
 
 // AssetDir returns the file names below a certain
@@ -4887,496 +4887,281 @@ func AssetDir(name string) ([]string, error) {
 }
 
 type bintree struct {
-	Func func() (*asset, error)
+	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"conf": &bintree{nil, map[string]*bintree{
-		"app.ini": &bintree{confAppIni, map[string]*bintree{
+	"conf": {nil, map[string]*bintree{
+		"app.ini": {confAppIni, map[string]*bintree{}},
+		"gitignore": {nil, map[string]*bintree{
+			"Actionscript":          {confGitignoreActionscript, map[string]*bintree{}},
+			"Ada":                   {confGitignoreAda, map[string]*bintree{}},
+			"Agda":                  {confGitignoreAgda, map[string]*bintree{}},
+			"Android":               {confGitignoreAndroid, map[string]*bintree{}},
+			"Anjuta":                {confGitignoreAnjuta, map[string]*bintree{}},
+			"AppEngine":             {confGitignoreAppengine, map[string]*bintree{}},
+			"AppceleratorTitanium":  {confGitignoreAppceleratortitanium, map[string]*bintree{}},
+			"ArchLinuxPackages":     {confGitignoreArchlinuxpackages, map[string]*bintree{}},
+			"Archives":              {confGitignoreArchives, map[string]*bintree{}},
+			"Autotools":             {confGitignoreAutotools, map[string]*bintree{}},
+			"BricxCC":               {confGitignoreBricxcc, map[string]*bintree{}},
+			"C":                     {confGitignoreC, map[string]*bintree{}},
+			"C Sharp":               {confGitignoreCSharp, map[string]*bintree{}},
+			"C++":                   {confGitignoreC2, map[string]*bintree{}},
+			"CFWheels":              {confGitignoreCfwheels, map[string]*bintree{}},
+			"CMake":                 {confGitignoreCmake, map[string]*bintree{}},
+			"CUDA":                  {confGitignoreCuda, map[string]*bintree{}},
+			"CVS":                   {confGitignoreCvs, map[string]*bintree{}},
+			"CakePHP":               {confGitignoreCakephp, map[string]*bintree{}},
+			"ChefCookbook":          {confGitignoreChefcookbook, map[string]*bintree{}},
+			"Cloud9":                {confGitignoreCloud9, map[string]*bintree{}},
+			"CodeIgniter":           {confGitignoreCodeigniter, map[string]*bintree{}},
+			"CodeKit":               {confGitignoreCodekit, map[string]*bintree{}},
+			"CommonLisp":            {confGitignoreCommonlisp, map[string]*bintree{}},
+			"Composer":              {confGitignoreComposer, map[string]*bintree{}},
+			"Concrete5":             {confGitignoreConcrete5, map[string]*bintree{}},
+			"Coq":                   {confGitignoreCoq, map[string]*bintree{}},
+			"CraftCMS":              {confGitignoreCraftcms, map[string]*bintree{}},
+			"DM":                    {confGitignoreDm, map[string]*bintree{}},
+			"Dart":                  {confGitignoreDart, map[string]*bintree{}},
+			"DartEditor":            {confGitignoreDarteditor, map[string]*bintree{}},
+			"Delphi":                {confGitignoreDelphi, map[string]*bintree{}},
+			"Dreamweaver":           {confGitignoreDreamweaver, map[string]*bintree{}},
+			"Drupal":                {confGitignoreDrupal, map[string]*bintree{}},
+			"EPiServer":             {confGitignoreEpiserver, map[string]*bintree{}},
+			"Eagle":                 {confGitignoreEagle, map[string]*bintree{}},
+			"Eclipse":               {confGitignoreEclipse, map[string]*bintree{}},
+			"EiffelStudio":          {confGitignoreEiffelstudio, map[string]*bintree{}},
+			"Elisp":                 {confGitignoreElisp, map[string]*bintree{}},
+			"Elixir":                {confGitignoreElixir, map[string]*bintree{}},
+			"Emacs":                 {confGitignoreEmacs, map[string]*bintree{}},
+			"Ensime":                {confGitignoreEnsime, map[string]*bintree{}},
+			"Erlang":                {confGitignoreErlang, map[string]*bintree{}},
+			"Espresso":              {confGitignoreEspresso, map[string]*bintree{}},
+			"ExpressionEngine":      {confGitignoreExpressionengine, map[string]*bintree{}},
+			"ExtJs":                 {confGitignoreExtjs, map[string]*bintree{}},
+			"Fancy":                 {confGitignoreFancy, map[string]*bintree{}},
+			"Finale":                {confGitignoreFinale, map[string]*bintree{}},
+			"FlexBuilder":           {confGitignoreFlexbuilder, map[string]*bintree{}},
+			"ForceDotCom":           {confGitignoreForcedotcom, map[string]*bintree{}},
+			"FuelPHP":               {confGitignoreFuelphp, map[string]*bintree{}},
+			"GWT":                   {confGitignoreGwt, map[string]*bintree{}},
+			"Gcov":                  {confGitignoreGcov, map[string]*bintree{}},
+			"GitBook":               {confGitignoreGitbook, map[string]*bintree{}},
+			"Go":                    {confGitignoreGo, map[string]*bintree{}},
+			"Gradle":                {confGitignoreGradle, map[string]*bintree{}},
+			"Grails":                {confGitignoreGrails, map[string]*bintree{}},
+			"Haskell":               {confGitignoreHaskell, map[string]*bintree{}},
+			"IGORPro":               {confGitignoreIgorpro, map[string]*bintree{}},
+			"IPythonNotebook":       {confGitignoreIpythonnotebook, map[string]*bintree{}},
+			"Idris":                 {confGitignoreIdris, map[string]*bintree{}},
+			"JDeveloper":            {confGitignoreJdeveloper, map[string]*bintree{}},
+			"Java":                  {confGitignoreJava, map[string]*bintree{}},
+			"Jboss":                 {confGitignoreJboss, map[string]*bintree{}},
+			"Jekyll":                {confGitignoreJekyll, map[string]*bintree{}},
+			"JetBrains":             {confGitignoreJetbrains, map[string]*bintree{}},
+			"Joomla":                {confGitignoreJoomla, map[string]*bintree{}},
+			"KDevelop4":             {confGitignoreKdevelop4, map[string]*bintree{}},
+			"Kate":                  {confGitignoreKate, map[string]*bintree{}},
+			"KiCAD":                 {confGitignoreKicad, map[string]*bintree{}},
+			"Kohana":                {confGitignoreKohana, map[string]*bintree{}},
+			"LabVIEW":               {confGitignoreLabview, map[string]*bintree{}},
+			"Laravel":               {confGitignoreLaravel, map[string]*bintree{}},
+			"Lazarus":               {confGitignoreLazarus, map[string]*bintree{}},
+			"Leiningen":             {confGitignoreLeiningen, map[string]*bintree{}},
+			"LemonStand":            {confGitignoreLemonstand, map[string]*bintree{}},
+			"LibreOffice":           {confGitignoreLibreoffice, map[string]*bintree{}},
+			"Lilypond":              {confGitignoreLilypond, map[string]*bintree{}},
+			"Linux":                 {confGitignoreLinux, map[string]*bintree{}},
+			"Lithium":               {confGitignoreLithium, map[string]*bintree{}},
+			"Lua":                   {confGitignoreLua, map[string]*bintree{}},
+			"LyX":                   {confGitignoreLyx, map[string]*bintree{}},
+			"Magento":               {confGitignoreMagento, map[string]*bintree{}},
+			"Matlab":                {confGitignoreMatlab, map[string]*bintree{}},
+			"Maven":                 {confGitignoreMaven, map[string]*bintree{}},
+			"Mercurial":             {confGitignoreMercurial, map[string]*bintree{}},
+			"Mercury":               {confGitignoreMercury, map[string]*bintree{}},
+			"MetaProgrammingSystem": {confGitignoreMetaprogrammingsystem, map[string]*bintree{}},
+			"MicrosoftOffice":       {confGitignoreMicrosoftoffice, map[string]*bintree{}},
+			"ModelSim":              {confGitignoreModelsim, map[string]*bintree{}},
+			"Momentics":             {confGitignoreMomentics, map[string]*bintree{}},
+			"MonoDevelop":           {confGitignoreMonodevelop, map[string]*bintree{}},
+			"Nanoc":                 {confGitignoreNanoc, map[string]*bintree{}},
+			"NetBeans":              {confGitignoreNetbeans, map[string]*bintree{}},
+			"Nim":                   {confGitignoreNim, map[string]*bintree{}},
+			"Ninja":                 {confGitignoreNinja, map[string]*bintree{}},
+			"Node":                  {confGitignoreNode, map[string]*bintree{}},
+			"NotepadPP":             {confGitignoreNotepadpp, map[string]*bintree{}},
+			"OCaml":                 {confGitignoreOcaml, map[string]*bintree{}},
+			"OSX":                   {confGitignoreOsx, map[string]*bintree{}},
+			"Objective-C":           {confGitignoreObjectiveC, map[string]*bintree{}},
+			"Opa":                   {confGitignoreOpa, map[string]*bintree{}},
+			"OpenCart":              {confGitignoreOpencart, map[string]*bintree{}},
+			"OracleForms":           {confGitignoreOracleforms, map[string]*bintree{}},
+			"Packer":                {confGitignorePacker, map[string]*bintree{}},
+			"Perl":                  {confGitignorePerl, map[string]*bintree{}},
+			"Phalcon":               {confGitignorePhalcon, map[string]*bintree{}},
+			"PlayFramework":         {confGitignorePlayframework, map[string]*bintree{}},
+			"Plone":                 {confGitignorePlone, map[string]*bintree{}},
+			"Prestashop":            {confGitignorePrestashop, map[string]*bintree{}},
+			"Processing":            {confGitignoreProcessing, map[string]*bintree{}},
+			"Python":                {confGitignorePython, map[string]*bintree{}},
+			"Qooxdoo":               {confGitignoreQooxdoo, map[string]*bintree{}},
+			"Qt":                    {confGitignoreQt, map[string]*bintree{}},
+			"R":                     {confGitignoreR, map[string]*bintree{}},
+			"ROS":                   {confGitignoreRos, map[string]*bintree{}},
+			"Rails":                 {confGitignoreRails, map[string]*bintree{}},
+			"Redcar":                {confGitignoreRedcar, map[string]*bintree{}},
+			"Redis":                 {confGitignoreRedis, map[string]*bintree{}},
+			"RhodesRhomobile":       {confGitignoreRhodesrhomobile, map[string]*bintree{}},
+			"Ruby":                  {confGitignoreRuby, map[string]*bintree{}},
+			"Rust":                  {confGitignoreRust, map[string]*bintree{}},
+			"SBT":                   {confGitignoreSbt, map[string]*bintree{}},
+			"SCons":                 {confGitignoreScons, map[string]*bintree{}},
+			"SVN":                   {confGitignoreSvn, map[string]*bintree{}},
+			"Sass":                  {confGitignoreSass, map[string]*bintree{}},
+			"Scala":                 {confGitignoreScala, map[string]*bintree{}},
+			"Scrivener":             {confGitignoreScrivener, map[string]*bintree{}},
+			"Sdcc":                  {confGitignoreSdcc, map[string]*bintree{}},
+			"SeamGen":               {confGitignoreSeamgen, map[string]*bintree{}},
+			"SketchUp":              {confGitignoreSketchup, map[string]*bintree{}},
+			"SlickEdit":             {confGitignoreSlickedit, map[string]*bintree{}},
+			"Stella":                {confGitignoreStella, map[string]*bintree{}},
+			"SublimeText":           {confGitignoreSublimetext, map[string]*bintree{}},
+			"SugarCRM":              {confGitignoreSugarcrm, map[string]*bintree{}},
+			"Swift":                 {confGitignoreSwift, map[string]*bintree{}},
+			"Symfony":               {confGitignoreSymfony, map[string]*bintree{}},
+			"SymphonyCMS":           {confGitignoreSymphonycms, map[string]*bintree{}},
+			"SynopsysVCS":           {confGitignoreSynopsysvcs, map[string]*bintree{}},
+			"Tags":                  {confGitignoreTags, map[string]*bintree{}},
+			"TeX":                   {confGitignoreTex, map[string]*bintree{}},
+			"TextMate":              {confGitignoreTextmate, map[string]*bintree{}},
+			"Textpattern":           {confGitignoreTextpattern, map[string]*bintree{}},
+			"TortoiseGit":           {confGitignoreTortoisegit, map[string]*bintree{}},
+			"TurboGears2":           {confGitignoreTurbogears2, map[string]*bintree{}},
+			"Typo3":                 {confGitignoreTypo3, map[string]*bintree{}},
+			"Umbraco":               {confGitignoreUmbraco, map[string]*bintree{}},
+			"Unity":                 {confGitignoreUnity, map[string]*bintree{}},
+			"VVVV":                  {confGitignoreVvvv, map[string]*bintree{}},
+			"Vagrant":               {confGitignoreVagrant, map[string]*bintree{}},
+			"Vim":                   {confGitignoreVim, map[string]*bintree{}},
+			"VirtualEnv":            {confGitignoreVirtualenv, map[string]*bintree{}},
+			"VisualStudio":          {confGitignoreVisualstudio, map[string]*bintree{}},
+			"VisualStudioCode":      {confGitignoreVisualstudiocode, map[string]*bintree{}},
+			"Waf":                   {confGitignoreWaf, map[string]*bintree{}},
+			"WebMethods":            {confGitignoreWebmethods, map[string]*bintree{}},
+			"Windows":               {confGitignoreWindows, map[string]*bintree{}},
+			"WordPress":             {confGitignoreWordpress, map[string]*bintree{}},
+			"Xcode":                 {confGitignoreXcode, map[string]*bintree{}},
+			"XilinxISE":             {confGitignoreXilinxise, map[string]*bintree{}},
+			"Xojo":                  {confGitignoreXojo, map[string]*bintree{}},
+			"Yeoman":                {confGitignoreYeoman, map[string]*bintree{}},
+			"Yii":                   {confGitignoreYii, map[string]*bintree{}},
+			"ZendFramework":         {confGitignoreZendframework, map[string]*bintree{}},
+			"Zephir":                {confGitignoreZephir, map[string]*bintree{}},
 		}},
-		"gitignore": &bintree{nil, map[string]*bintree{
-			"Actionscript": &bintree{confGitignoreActionscript, map[string]*bintree{
-			}},
-			"Ada": &bintree{confGitignoreAda, map[string]*bintree{
-			}},
-			"Agda": &bintree{confGitignoreAgda, map[string]*bintree{
-			}},
-			"Android": &bintree{confGitignoreAndroid, map[string]*bintree{
-			}},
-			"Anjuta": &bintree{confGitignoreAnjuta, map[string]*bintree{
-			}},
-			"AppEngine": &bintree{confGitignoreAppengine, map[string]*bintree{
-			}},
-			"AppceleratorTitanium": &bintree{confGitignoreAppceleratortitanium, map[string]*bintree{
-			}},
-			"ArchLinuxPackages": &bintree{confGitignoreArchlinuxpackages, map[string]*bintree{
-			}},
-			"Archives": &bintree{confGitignoreArchives, map[string]*bintree{
-			}},
-			"Autotools": &bintree{confGitignoreAutotools, map[string]*bintree{
-			}},
-			"BricxCC": &bintree{confGitignoreBricxcc, map[string]*bintree{
-			}},
-			"C": &bintree{confGitignoreC, map[string]*bintree{
-			}},
-			"C Sharp": &bintree{confGitignoreCSharp, map[string]*bintree{
-			}},
-			"C++": &bintree{confGitignoreC2, map[string]*bintree{
-			}},
-			"CFWheels": &bintree{confGitignoreCfwheels, map[string]*bintree{
-			}},
-			"CMake": &bintree{confGitignoreCmake, map[string]*bintree{
-			}},
-			"CUDA": &bintree{confGitignoreCuda, map[string]*bintree{
-			}},
-			"CVS": &bintree{confGitignoreCvs, map[string]*bintree{
-			}},
-			"CakePHP": &bintree{confGitignoreCakephp, map[string]*bintree{
-			}},
-			"ChefCookbook": &bintree{confGitignoreChefcookbook, map[string]*bintree{
-			}},
-			"Cloud9": &bintree{confGitignoreCloud9, map[string]*bintree{
-			}},
-			"CodeIgniter": &bintree{confGitignoreCodeigniter, map[string]*bintree{
-			}},
-			"CodeKit": &bintree{confGitignoreCodekit, map[string]*bintree{
-			}},
-			"CommonLisp": &bintree{confGitignoreCommonlisp, map[string]*bintree{
-			}},
-			"Composer": &bintree{confGitignoreComposer, map[string]*bintree{
-			}},
-			"Concrete5": &bintree{confGitignoreConcrete5, map[string]*bintree{
-			}},
-			"Coq": &bintree{confGitignoreCoq, map[string]*bintree{
-			}},
-			"CraftCMS": &bintree{confGitignoreCraftcms, map[string]*bintree{
-			}},
-			"DM": &bintree{confGitignoreDm, map[string]*bintree{
-			}},
-			"Dart": &bintree{confGitignoreDart, map[string]*bintree{
-			}},
-			"DartEditor": &bintree{confGitignoreDarteditor, map[string]*bintree{
-			}},
-			"Delphi": &bintree{confGitignoreDelphi, map[string]*bintree{
-			}},
-			"Dreamweaver": &bintree{confGitignoreDreamweaver, map[string]*bintree{
-			}},
-			"Drupal": &bintree{confGitignoreDrupal, map[string]*bintree{
-			}},
-			"EPiServer": &bintree{confGitignoreEpiserver, map[string]*bintree{
-			}},
-			"Eagle": &bintree{confGitignoreEagle, map[string]*bintree{
-			}},
-			"Eclipse": &bintree{confGitignoreEclipse, map[string]*bintree{
-			}},
-			"EiffelStudio": &bintree{confGitignoreEiffelstudio, map[string]*bintree{
-			}},
-			"Elisp": &bintree{confGitignoreElisp, map[string]*bintree{
-			}},
-			"Elixir": &bintree{confGitignoreElixir, map[string]*bintree{
-			}},
-			"Emacs": &bintree{confGitignoreEmacs, map[string]*bintree{
-			}},
-			"Ensime": &bintree{confGitignoreEnsime, map[string]*bintree{
-			}},
-			"Erlang": &bintree{confGitignoreErlang, map[string]*bintree{
-			}},
-			"Espresso": &bintree{confGitignoreEspresso, map[string]*bintree{
-			}},
-			"ExpressionEngine": &bintree{confGitignoreExpressionengine, map[string]*bintree{
-			}},
-			"ExtJs": &bintree{confGitignoreExtjs, map[string]*bintree{
-			}},
-			"Fancy": &bintree{confGitignoreFancy, map[string]*bintree{
-			}},
-			"Finale": &bintree{confGitignoreFinale, map[string]*bintree{
-			}},
-			"FlexBuilder": &bintree{confGitignoreFlexbuilder, map[string]*bintree{
-			}},
-			"ForceDotCom": &bintree{confGitignoreForcedotcom, map[string]*bintree{
-			}},
-			"FuelPHP": &bintree{confGitignoreFuelphp, map[string]*bintree{
-			}},
-			"GWT": &bintree{confGitignoreGwt, map[string]*bintree{
-			}},
-			"Gcov": &bintree{confGitignoreGcov, map[string]*bintree{
-			}},
-			"GitBook": &bintree{confGitignoreGitbook, map[string]*bintree{
-			}},
-			"Go": &bintree{confGitignoreGo, map[string]*bintree{
-			}},
-			"Gradle": &bintree{confGitignoreGradle, map[string]*bintree{
-			}},
-			"Grails": &bintree{confGitignoreGrails, map[string]*bintree{
-			}},
-			"Haskell": &bintree{confGitignoreHaskell, map[string]*bintree{
-			}},
-			"IGORPro": &bintree{confGitignoreIgorpro, map[string]*bintree{
-			}},
-			"IPythonNotebook": &bintree{confGitignoreIpythonnotebook, map[string]*bintree{
-			}},
-			"Idris": &bintree{confGitignoreIdris, map[string]*bintree{
-			}},
-			"JDeveloper": &bintree{confGitignoreJdeveloper, map[string]*bintree{
-			}},
-			"Java": &bintree{confGitignoreJava, map[string]*bintree{
-			}},
-			"Jboss": &bintree{confGitignoreJboss, map[string]*bintree{
-			}},
-			"Jekyll": &bintree{confGitignoreJekyll, map[string]*bintree{
-			}},
-			"JetBrains": &bintree{confGitignoreJetbrains, map[string]*bintree{
-			}},
-			"Joomla": &bintree{confGitignoreJoomla, map[string]*bintree{
-			}},
-			"KDevelop4": &bintree{confGitignoreKdevelop4, map[string]*bintree{
-			}},
-			"Kate": &bintree{confGitignoreKate, map[string]*bintree{
-			}},
-			"KiCAD": &bintree{confGitignoreKicad, map[string]*bintree{
-			}},
-			"Kohana": &bintree{confGitignoreKohana, map[string]*bintree{
-			}},
-			"LabVIEW": &bintree{confGitignoreLabview, map[string]*bintree{
-			}},
-			"Laravel": &bintree{confGitignoreLaravel, map[string]*bintree{
-			}},
-			"Lazarus": &bintree{confGitignoreLazarus, map[string]*bintree{
-			}},
-			"Leiningen": &bintree{confGitignoreLeiningen, map[string]*bintree{
-			}},
-			"LemonStand": &bintree{confGitignoreLemonstand, map[string]*bintree{
-			}},
-			"LibreOffice": &bintree{confGitignoreLibreoffice, map[string]*bintree{
-			}},
-			"Lilypond": &bintree{confGitignoreLilypond, map[string]*bintree{
-			}},
-			"Linux": &bintree{confGitignoreLinux, map[string]*bintree{
-			}},
-			"Lithium": &bintree{confGitignoreLithium, map[string]*bintree{
-			}},
-			"Lua": &bintree{confGitignoreLua, map[string]*bintree{
-			}},
-			"LyX": &bintree{confGitignoreLyx, map[string]*bintree{
-			}},
-			"Magento": &bintree{confGitignoreMagento, map[string]*bintree{
-			}},
-			"Matlab": &bintree{confGitignoreMatlab, map[string]*bintree{
-			}},
-			"Maven": &bintree{confGitignoreMaven, map[string]*bintree{
-			}},
-			"Mercurial": &bintree{confGitignoreMercurial, map[string]*bintree{
-			}},
-			"Mercury": &bintree{confGitignoreMercury, map[string]*bintree{
-			}},
-			"MetaProgrammingSystem": &bintree{confGitignoreMetaprogrammingsystem, map[string]*bintree{
-			}},
-			"MicrosoftOffice": &bintree{confGitignoreMicrosoftoffice, map[string]*bintree{
-			}},
-			"ModelSim": &bintree{confGitignoreModelsim, map[string]*bintree{
-			}},
-			"Momentics": &bintree{confGitignoreMomentics, map[string]*bintree{
-			}},
-			"MonoDevelop": &bintree{confGitignoreMonodevelop, map[string]*bintree{
-			}},
-			"Nanoc": &bintree{confGitignoreNanoc, map[string]*bintree{
-			}},
-			"NetBeans": &bintree{confGitignoreNetbeans, map[string]*bintree{
-			}},
-			"Nim": &bintree{confGitignoreNim, map[string]*bintree{
-			}},
-			"Ninja": &bintree{confGitignoreNinja, map[string]*bintree{
-			}},
-			"Node": &bintree{confGitignoreNode, map[string]*bintree{
-			}},
-			"NotepadPP": &bintree{confGitignoreNotepadpp, map[string]*bintree{
-			}},
-			"OCaml": &bintree{confGitignoreOcaml, map[string]*bintree{
-			}},
-			"OSX": &bintree{confGitignoreOsx, map[string]*bintree{
-			}},
-			"Objective-C": &bintree{confGitignoreObjectiveC, map[string]*bintree{
-			}},
-			"Opa": &bintree{confGitignoreOpa, map[string]*bintree{
-			}},
-			"OpenCart": &bintree{confGitignoreOpencart, map[string]*bintree{
-			}},
-			"OracleForms": &bintree{confGitignoreOracleforms, map[string]*bintree{
-			}},
-			"Packer": &bintree{confGitignorePacker, map[string]*bintree{
-			}},
-			"Perl": &bintree{confGitignorePerl, map[string]*bintree{
-			}},
-			"Phalcon": &bintree{confGitignorePhalcon, map[string]*bintree{
-			}},
-			"PlayFramework": &bintree{confGitignorePlayframework, map[string]*bintree{
-			}},
-			"Plone": &bintree{confGitignorePlone, map[string]*bintree{
-			}},
-			"Prestashop": &bintree{confGitignorePrestashop, map[string]*bintree{
-			}},
-			"Processing": &bintree{confGitignoreProcessing, map[string]*bintree{
-			}},
-			"Python": &bintree{confGitignorePython, map[string]*bintree{
-			}},
-			"Qooxdoo": &bintree{confGitignoreQooxdoo, map[string]*bintree{
-			}},
-			"Qt": &bintree{confGitignoreQt, map[string]*bintree{
-			}},
-			"R": &bintree{confGitignoreR, map[string]*bintree{
-			}},
-			"ROS": &bintree{confGitignoreRos, map[string]*bintree{
-			}},
-			"Rails": &bintree{confGitignoreRails, map[string]*bintree{
-			}},
-			"Redcar": &bintree{confGitignoreRedcar, map[string]*bintree{
-			}},
-			"Redis": &bintree{confGitignoreRedis, map[string]*bintree{
-			}},
-			"RhodesRhomobile": &bintree{confGitignoreRhodesrhomobile, map[string]*bintree{
-			}},
-			"Ruby": &bintree{confGitignoreRuby, map[string]*bintree{
-			}},
-			"Rust": &bintree{confGitignoreRust, map[string]*bintree{
-			}},
-			"SBT": &bintree{confGitignoreSbt, map[string]*bintree{
-			}},
-			"SCons": &bintree{confGitignoreScons, map[string]*bintree{
-			}},
-			"SVN": &bintree{confGitignoreSvn, map[string]*bintree{
-			}},
-			"Sass": &bintree{confGitignoreSass, map[string]*bintree{
-			}},
-			"Scala": &bintree{confGitignoreScala, map[string]*bintree{
-			}},
-			"Scrivener": &bintree{confGitignoreScrivener, map[string]*bintree{
-			}},
-			"Sdcc": &bintree{confGitignoreSdcc, map[string]*bintree{
-			}},
-			"SeamGen": &bintree{confGitignoreSeamgen, map[string]*bintree{
-			}},
-			"SketchUp": &bintree{confGitignoreSketchup, map[string]*bintree{
-			}},
-			"SlickEdit": &bintree{confGitignoreSlickedit, map[string]*bintree{
-			}},
-			"Stella": &bintree{confGitignoreStella, map[string]*bintree{
-			}},
-			"SublimeText": &bintree{confGitignoreSublimetext, map[string]*bintree{
-			}},
-			"SugarCRM": &bintree{confGitignoreSugarcrm, map[string]*bintree{
-			}},
-			"Swift": &bintree{confGitignoreSwift, map[string]*bintree{
-			}},
-			"Symfony": &bintree{confGitignoreSymfony, map[string]*bintree{
-			}},
-			"SymphonyCMS": &bintree{confGitignoreSymphonycms, map[string]*bintree{
-			}},
-			"SynopsysVCS": &bintree{confGitignoreSynopsysvcs, map[string]*bintree{
-			}},
-			"Tags": &bintree{confGitignoreTags, map[string]*bintree{
-			}},
-			"TeX": &bintree{confGitignoreTex, map[string]*bintree{
-			}},
-			"TextMate": &bintree{confGitignoreTextmate, map[string]*bintree{
-			}},
-			"Textpattern": &bintree{confGitignoreTextpattern, map[string]*bintree{
-			}},
-			"TortoiseGit": &bintree{confGitignoreTortoisegit, map[string]*bintree{
-			}},
-			"TurboGears2": &bintree{confGitignoreTurbogears2, map[string]*bintree{
-			}},
-			"Typo3": &bintree{confGitignoreTypo3, map[string]*bintree{
-			}},
-			"Umbraco": &bintree{confGitignoreUmbraco, map[string]*bintree{
-			}},
-			"Unity": &bintree{confGitignoreUnity, map[string]*bintree{
-			}},
-			"VVVV": &bintree{confGitignoreVvvv, map[string]*bintree{
-			}},
-			"Vagrant": &bintree{confGitignoreVagrant, map[string]*bintree{
-			}},
-			"Vim": &bintree{confGitignoreVim, map[string]*bintree{
-			}},
-			"VirtualEnv": &bintree{confGitignoreVirtualenv, map[string]*bintree{
-			}},
-			"VisualStudio": &bintree{confGitignoreVisualstudio, map[string]*bintree{
-			}},
-			"VisualStudioCode": &bintree{confGitignoreVisualstudiocode, map[string]*bintree{
-			}},
-			"Waf": &bintree{confGitignoreWaf, map[string]*bintree{
-			}},
-			"WebMethods": &bintree{confGitignoreWebmethods, map[string]*bintree{
-			}},
-			"Windows": &bintree{confGitignoreWindows, map[string]*bintree{
-			}},
-			"WordPress": &bintree{confGitignoreWordpress, map[string]*bintree{
-			}},
-			"Xcode": &bintree{confGitignoreXcode, map[string]*bintree{
-			}},
-			"XilinxISE": &bintree{confGitignoreXilinxise, map[string]*bintree{
-			}},
-			"Xojo": &bintree{confGitignoreXojo, map[string]*bintree{
-			}},
-			"Yeoman": &bintree{confGitignoreYeoman, map[string]*bintree{
-			}},
-			"Yii": &bintree{confGitignoreYii, map[string]*bintree{
-			}},
-			"ZendFramework": &bintree{confGitignoreZendframework, map[string]*bintree{
-			}},
-			"Zephir": &bintree{confGitignoreZephir, map[string]*bintree{
-			}},
+		"license": {nil, map[string]*bintree{
+			"Abstyles License":                        {confLicenseAbstylesLicense, map[string]*bintree{}},
+			"Academic Free License v1.1":              {confLicenseAcademicFreeLicenseV11, map[string]*bintree{}},
+			"Academic Free License v1.2":              {confLicenseAcademicFreeLicenseV12, map[string]*bintree{}},
+			"Academic Free License v2.0":              {confLicenseAcademicFreeLicenseV20, map[string]*bintree{}},
+			"Academic Free License v2.1":              {confLicenseAcademicFreeLicenseV21, map[string]*bintree{}},
+			"Academic Free License v3.0":              {confLicenseAcademicFreeLicenseV30, map[string]*bintree{}},
+			"Affero General Public License v1.0":      {confLicenseAfferoGeneralPublicLicenseV10, map[string]*bintree{}},
+			"Apache License 1.0":                      {confLicenseApacheLicense10, map[string]*bintree{}},
+			"Apache License 1.1":                      {confLicenseApacheLicense11, map[string]*bintree{}},
+			"Apache License 2.0":                      {confLicenseApacheLicense20, map[string]*bintree{}},
+			"Artistic License 1.0":                    {confLicenseArtisticLicense10, map[string]*bintree{}},
+			"Artistic License 2.0":                    {confLicenseArtisticLicense20, map[string]*bintree{}},
+			"BSD 2-clause License":                    {confLicenseBsd2ClauseLicense, map[string]*bintree{}},
+			"BSD 3-clause License":                    {confLicenseBsd3ClauseLicense, map[string]*bintree{}},
+			"BSD 4-clause License":                    {confLicenseBsd4ClauseLicense, map[string]*bintree{}},
+			"Creative Commons CC0 1.0 Universal":      {confLicenseCreativeCommonsCc010Universal, map[string]*bintree{}},
+			"Eclipse Public License 1.0":              {confLicenseEclipsePublicLicense10, map[string]*bintree{}},
+			"Educational Community License v1.0":      {confLicenseEducationalCommunityLicenseV10, map[string]*bintree{}},
+			"Educational Community License v2.0":      {confLicenseEducationalCommunityLicenseV20, map[string]*bintree{}},
+			"GNU Affero General Public License v3.0":  {confLicenseGnuAfferoGeneralPublicLicenseV30, map[string]*bintree{}},
+			"GNU Free Documentation License v1.1":     {confLicenseGnuFreeDocumentationLicenseV11, map[string]*bintree{}},
+			"GNU Free Documentation License v1.2":     {confLicenseGnuFreeDocumentationLicenseV12, map[string]*bintree{}},
+			"GNU Free Documentation License v1.3":     {confLicenseGnuFreeDocumentationLicenseV13, map[string]*bintree{}},
+			"GNU General Public License v1.0":         {confLicenseGnuGeneralPublicLicenseV10, map[string]*bintree{}},
+			"GNU General Public License v2.0":         {confLicenseGnuGeneralPublicLicenseV20, map[string]*bintree{}},
+			"GNU General Public License v3.0":         {confLicenseGnuGeneralPublicLicenseV30, map[string]*bintree{}},
+			"GNU Lesser General Public License v2.1":  {confLicenseGnuLesserGeneralPublicLicenseV21, map[string]*bintree{}},
+			"GNU Lesser General Public License v3.0":  {confLicenseGnuLesserGeneralPublicLicenseV30, map[string]*bintree{}},
+			"GNU Library General Public License v2.0": {confLicenseGnuLibraryGeneralPublicLicenseV20, map[string]*bintree{}},
+			"ISC license":                             {confLicenseIscLicense, map[string]*bintree{}},
+			"MIT License":                             {confLicenseMitLicense, map[string]*bintree{}},
+			"Mozilla Public License 1.0":              {confLicenseMozillaPublicLicense10, map[string]*bintree{}},
+			"Mozilla Public License 1.1":              {confLicenseMozillaPublicLicense11, map[string]*bintree{}},
+			"Mozilla Public License 2.0":              {confLicenseMozillaPublicLicense20, map[string]*bintree{}},
 		}},
-		"license": &bintree{nil, map[string]*bintree{
-			"Abstyles License": &bintree{confLicenseAbstylesLicense, map[string]*bintree{
-			}},
-			"Academic Free License v1.1": &bintree{confLicenseAcademicFreeLicenseV11, map[string]*bintree{
-			}},
-			"Academic Free License v1.2": &bintree{confLicenseAcademicFreeLicenseV12, map[string]*bintree{
-			}},
-			"Academic Free License v2.0": &bintree{confLicenseAcademicFreeLicenseV20, map[string]*bintree{
-			}},
-			"Academic Free License v2.1": &bintree{confLicenseAcademicFreeLicenseV21, map[string]*bintree{
-			}},
-			"Academic Free License v3.0": &bintree{confLicenseAcademicFreeLicenseV30, map[string]*bintree{
-			}},
-			"Affero General Public License v1.0": &bintree{confLicenseAfferoGeneralPublicLicenseV10, map[string]*bintree{
-			}},
-			"Apache License 1.0": &bintree{confLicenseApacheLicense10, map[string]*bintree{
-			}},
-			"Apache License 1.1": &bintree{confLicenseApacheLicense11, map[string]*bintree{
-			}},
-			"Apache License 2.0": &bintree{confLicenseApacheLicense20, map[string]*bintree{
-			}},
-			"Artistic License 1.0": &bintree{confLicenseArtisticLicense10, map[string]*bintree{
-			}},
-			"Artistic License 2.0": &bintree{confLicenseArtisticLicense20, map[string]*bintree{
-			}},
-			"BSD 2-clause License": &bintree{confLicenseBsd2ClauseLicense, map[string]*bintree{
-			}},
-			"BSD 3-clause License": &bintree{confLicenseBsd3ClauseLicense, map[string]*bintree{
-			}},
-			"BSD 4-clause License": &bintree{confLicenseBsd4ClauseLicense, map[string]*bintree{
-			}},
-			"Creative Commons CC0 1.0 Universal": &bintree{confLicenseCreativeCommonsCc010Universal, map[string]*bintree{
-			}},
-			"Eclipse Public License 1.0": &bintree{confLicenseEclipsePublicLicense10, map[string]*bintree{
-			}},
-			"Educational Community License v1.0": &bintree{confLicenseEducationalCommunityLicenseV10, map[string]*bintree{
-			}},
-			"Educational Community License v2.0": &bintree{confLicenseEducationalCommunityLicenseV20, map[string]*bintree{
-			}},
-			"GNU Affero General Public License v3.0": &bintree{confLicenseGnuAfferoGeneralPublicLicenseV30, map[string]*bintree{
-			}},
-			"GNU Free Documentation License v1.1": &bintree{confLicenseGnuFreeDocumentationLicenseV11, map[string]*bintree{
-			}},
-			"GNU Free Documentation License v1.2": &bintree{confLicenseGnuFreeDocumentationLicenseV12, map[string]*bintree{
-			}},
-			"GNU Free Documentation License v1.3": &bintree{confLicenseGnuFreeDocumentationLicenseV13, map[string]*bintree{
-			}},
-			"GNU General Public License v1.0": &bintree{confLicenseGnuGeneralPublicLicenseV10, map[string]*bintree{
-			}},
-			"GNU General Public License v2.0": &bintree{confLicenseGnuGeneralPublicLicenseV20, map[string]*bintree{
-			}},
-			"GNU General Public License v3.0": &bintree{confLicenseGnuGeneralPublicLicenseV30, map[string]*bintree{
-			}},
-			"GNU Lesser General Public License v2.1": &bintree{confLicenseGnuLesserGeneralPublicLicenseV21, map[string]*bintree{
-			}},
-			"GNU Lesser General Public License v3.0": &bintree{confLicenseGnuLesserGeneralPublicLicenseV30, map[string]*bintree{
-			}},
-			"GNU Library General Public License v2.0": &bintree{confLicenseGnuLibraryGeneralPublicLicenseV20, map[string]*bintree{
-			}},
-			"ISC license": &bintree{confLicenseIscLicense, map[string]*bintree{
-			}},
-			"MIT License": &bintree{confLicenseMitLicense, map[string]*bintree{
-			}},
-			"Mozilla Public License 1.0": &bintree{confLicenseMozillaPublicLicense10, map[string]*bintree{
-			}},
-			"Mozilla Public License 1.1": &bintree{confLicenseMozillaPublicLicense11, map[string]*bintree{
-			}},
-			"Mozilla Public License 2.0": &bintree{confLicenseMozillaPublicLicense20, map[string]*bintree{
-			}},
+		"locale": {nil, map[string]*bintree{
+			"locale_bg-BG.ini": {confLocaleLocale_bgBgIni, map[string]*bintree{}},
+			"locale_de-DE.ini": {confLocaleLocale_deDeIni, map[string]*bintree{}},
+			"locale_en-US.ini": {confLocaleLocale_enUsIni, map[string]*bintree{}},
+			"locale_es-ES.ini": {confLocaleLocale_esEsIni, map[string]*bintree{}},
+			"locale_fr-FR.ini": {confLocaleLocale_frFrIni, map[string]*bintree{}},
+			"locale_it-IT.ini": {confLocaleLocale_itItIni, map[string]*bintree{}},
+			"locale_ja-JP.ini": {confLocaleLocale_jaJpIni, map[string]*bintree{}},
+			"locale_lv-LV.ini": {confLocaleLocale_lvLvIni, map[string]*bintree{}},
+			"locale_nl-NL.ini": {confLocaleLocale_nlNlIni, map[string]*bintree{}},
+			"locale_pl-PL.ini": {confLocaleLocale_plPlIni, map[string]*bintree{}},
+			"locale_pt-BR.ini": {confLocaleLocale_ptBrIni, map[string]*bintree{}},
+			"locale_ru-RU.ini": {confLocaleLocale_ruRuIni, map[string]*bintree{}},
+			"locale_zh-CN.ini": {confLocaleLocale_zhCnIni, map[string]*bintree{}},
+			"locale_zh-HK.ini": {confLocaleLocale_zhHkIni, map[string]*bintree{}},
 		}},
-		"locale": &bintree{nil, map[string]*bintree{
-			"locale_bg-BG.ini": &bintree{confLocaleLocale_bgBgIni, map[string]*bintree{
-			}},
-			"locale_de-DE.ini": &bintree{confLocaleLocale_deDeIni, map[string]*bintree{
-			}},
-			"locale_en-US.ini": &bintree{confLocaleLocale_enUsIni, map[string]*bintree{
-			}},
-			"locale_es-ES.ini": &bintree{confLocaleLocale_esEsIni, map[string]*bintree{
-			}},
-			"locale_fr-FR.ini": &bintree{confLocaleLocale_frFrIni, map[string]*bintree{
-			}},
-			"locale_it-IT.ini": &bintree{confLocaleLocale_itItIni, map[string]*bintree{
-			}},
-			"locale_ja-JP.ini": &bintree{confLocaleLocale_jaJpIni, map[string]*bintree{
-			}},
-			"locale_lv-LV.ini": &bintree{confLocaleLocale_lvLvIni, map[string]*bintree{
-			}},
-			"locale_nl-NL.ini": &bintree{confLocaleLocale_nlNlIni, map[string]*bintree{
-			}},
-			"locale_pl-PL.ini": &bintree{confLocaleLocale_plPlIni, map[string]*bintree{
-			}},
-			"locale_pt-BR.ini": &bintree{confLocaleLocale_ptBrIni, map[string]*bintree{
-			}},
-			"locale_ru-RU.ini": &bintree{confLocaleLocale_ruRuIni, map[string]*bintree{
-			}},
-			"locale_zh-CN.ini": &bintree{confLocaleLocale_zhCnIni, map[string]*bintree{
-			}},
-			"locale_zh-HK.ini": &bintree{confLocaleLocale_zhHkIni, map[string]*bintree{
-			}},
-		}},
-		"readme": &bintree{nil, map[string]*bintree{
-			"Default": &bintree{confReadmeDefault, map[string]*bintree{
-			}},
+		"readme": {nil, map[string]*bintree{
+			"Default": {confReadmeDefault, map[string]*bintree{}},
 		}},
 	}},
 }}
 
 // RestoreAsset restores an asset under the given directory
 func RestoreAsset(dir, name string) error {
-        data, err := Asset(name)
-        if err != nil {
-                return err
-        }
-        info, err := AssetInfo(name)
-        if err != nil {
-                return err
-        }
-        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
-        if err != nil {
-                return err
-        }
-        err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
-        if err != nil {
-                return err
-        }
-        err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
-        if err != nil {
-                return err
-        }
-        return nil
+	data, err := Asset(name)
+	if err != nil {
+		return err
+	}
+	info, err := AssetInfo(name)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // RestoreAssets restores an asset under the given directory recursively
 func RestoreAssets(dir, name string) error {
-        children, err := AssetDir(name)
-        // File
-        if err != nil {
-                return RestoreAsset(dir, name)
-        }
-        // Dir
-        for _, child := range children {
-                err = RestoreAssets(dir, filepath.Join(name, child))
-                if err != nil {
-                        return err
-                }
-        }
-        return nil
+	children, err := AssetDir(name)
+	// File
+	if err != nil {
+		return RestoreAsset(dir, name)
+	}
+	// Dir
+	for _, child := range children {
+		err = RestoreAssets(dir, filepath.Join(name, child))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func _filePath(dir, name string) string {
-        cannonicalName := strings.Replace(name, "\\", "/", -1)
-        return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/modules/cron/cron.go
+++ b/modules/cron/cron.go
@@ -1,5 +1,5 @@
 // Copyright 2012 Rob Figueiredo. All rights reserved.
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/httplib/httplib.go
+++ b/modules/httplib/httplib.go
@@ -1,5 +1,5 @@
 // Copyright 2013 The Beego Authors. All rights reserved.
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/httplib/httplib_test.go
+++ b/modules/httplib/httplib_test.go
@@ -1,5 +1,5 @@
 // Copyright 2013 The Beego Authors. All rights reserved.
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/conn.go
+++ b/modules/log/conn.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/console.go
+++ b/modules/log/console.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/database.go
+++ b/modules/log/database.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/log/smtp.go
+++ b/modules/log/smtp.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/mailer/mail.go
+++ b/modules/mailer/mail.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/mailer/mailer.go
+++ b/modules/mailer/mailer.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/middleware/auth.go
+++ b/modules/middleware/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/middleware/org.go
+++ b/modules/middleware/org.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/process/manager.go
+++ b/modules/process/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/setting/miniwinsvc.go
+++ b/modules/setting/miniwinsvc.go
@@ -1,6 +1,6 @@
 // +build miniwinsvc
 
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/template/highlight.go
+++ b/modules/template/highlight.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/modules/user/user.go
+++ b/modules/user/user.go
@@ -5,7 +5,7 @@
 package user
 
 import (
-       "os"
+	"os"
 )
 
 func CurrentUsername() string {

--- a/modules/user/user.go
+++ b/modules/user/user.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/auths.go
+++ b/routers/admin/auths.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/notice.go
+++ b/routers/admin/notice.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/orgs.go
+++ b/routers/admin/orgs.go
@@ -28,15 +28,15 @@ func Organizations(ctx *middleware.Context) {
 		page = 1
 	}
 	ctx.Data["Page"] = paginater.New(int(total), setting.AdminOrgPagingNum, page, 5)
- 
-    orgs, err := models.Organizations(page, setting.AdminOrgPagingNum)
-	
+
+	orgs, err := models.Organizations(page, setting.AdminOrgPagingNum)
+
 	if err != nil {
 		ctx.Handle(500, "Organizations", err)
 		return
 	}
-	
- 	ctx.Data["Orgs"] = orgs
+
+	ctx.Data["Orgs"] = orgs
 	ctx.Data["Total"] = total
 
 	ctx.HTML(200, ORGS)

--- a/routers/admin/orgs.go
+++ b/routers/admin/orgs.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/repos.go
+++ b/routers/admin/repos.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/admin/users.go
+++ b/routers/admin/users.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/admin/orgs.go
+++ b/routers/api/v1/admin/orgs.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/admin/repos.go
+++ b/routers/api/v1/admin/repos.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/admin/users.go
+++ b/routers/api/v1/admin/users.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/convert/convert.go
+++ b/routers/api/v1/convert/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/misc/markdown.go
+++ b/routers/api/v1/misc/markdown.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/org/org.go
+++ b/routers/api/v1/org/org.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/repo/hooks.go
+++ b/routers/api/v1/repo/hooks.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/repo/keys.go
+++ b/routers/api/v1/repo/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/user/email.go
+++ b/routers/api/v1/user/email.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/user/followers.go
+++ b/routers/api/v1/user/followers.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/user/keys.go
+++ b/routers/api/v1/user/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/dev/template.go
+++ b/routers/dev/template.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/home.go
+++ b/routers/home.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/install.go
+++ b/routers/install.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/org/members.go
+++ b/routers/org/members.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/org/org.go
+++ b/routers/org/org.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/org/setting.go
+++ b/routers/org/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/branch.go
+++ b/routers/repo/branch.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/http.go
+++ b/routers/repo/http.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -199,7 +199,7 @@ func Home(ctx *middleware.Context) {
 
 	if len(treename) > 0 {
 		treenames = strings.Split(treename, "/")
-		for i, _ := range treenames {
+		for i := range treenames {
 			Paths = append(Paths, strings.Join(treenames[0:i+1], "/"))
 		}
 

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/repo/wiki.go
+++ b/routers/repo/wiki.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -74,7 +74,7 @@ func Profile(ctx *middleware.Context) {
 	ctx.Data["Title"] = u.DisplayName()
 	ctx.Data["PageIsUserProfile"] = true
 	ctx.Data["Owner"] = u
-	
+
 	orgs, err := models.GetOwnedOrgsByUserIDDesc(u.Id, "updated")
 	if err != nil {
 		ctx.Handle(500, "GetOwnedOrgsByUserIDDesc", err)

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2016 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Fix formatting using ```gofmt -s -w .``` and update copyright notices.