### PR TITLE
Fixed Webhook URL-length Issue #2465

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -285,7 +285,7 @@ type HookTask struct {
 	HookID          int64
 	UUID            string
 	Type            HookTaskType
-	URL             string
+	URL             string `xorm:"TEXT"`
 	api.Payloader   `xorm:"-"`
 	PayloadContent  string `xorm:"TEXT"`
 	ContentType     HookContentType


### PR DESCRIPTION
As title says, fixes #2465

```
git@debian-gogs:~/gogs-repositories$ echo "select length(url) from hook_task;" | mysql -uroot -p gogs
Enter password: 
length(url)
255
972
```