### PR TITLE
Change user name in Pull Requests to avoid errors (fixes #2495)

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -525,6 +525,14 @@ func AddTestPullRequestTask(repoID int64, branch string) {
 	}
 }
 
+func ChangeUsernameInPullRequests(oldUserName, newUserName string) (error) {
+	pr := PullRequest{
+		HeadUserName : newUserName,
+	}
+	_, err := x.Cols("head_user_name").Where("head_user_name = ?", oldUserName).Update(pr)
+	return err
+}
+
 // checkAndUpdateStatus checks if pull request is possible to levaing checking status,
 // and set to be either conflict or mergeable.
 func (pr *PullRequest) checkAndUpdateStatus() {

--- a/models/user.go
+++ b/models/user.go
@@ -599,6 +599,11 @@ func ChangeUserName(u *User, newUserName string) (err error) {
 		return ErrUserAlreadyExist{newUserName}
 	}
 
+	err = ChangeUsernameInPullRequests(u.LowerName, newUserName)
+	if err != nil {
+		return err
+	}
+
 	return os.Rename(UserPath(u.LowerName), UserPath(newUserName))
 }
 


### PR DESCRIPTION
This PR fixes issue #2495.

Changing the name of a user breaks some links on the Pull Request pages.

- 500 Server Error on the "Files changed" tab (URL: `/:user/:repo/pulls/:id/files`)
- 404 Not Found on the "Commits" tab when you click a revision number of a commit

This PR replaces all occurrences of the old user name in the table `pull_request` with the new one.