### PR TITLE
enable basic TLS for mysql connection without server CA cert validation

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -123,12 +123,16 @@ func getEngine() (*xorm.Engine, error) {
 	cnnstr := ""
 	switch DbCfg.Type {
 	case "mysql":
+		tls := ""
+		if DbCfg.SSLMode == "skip-verify" {
+			tls = "&tls=skip-verify";
+		}
 		if DbCfg.Host[0] == '/' { // looks like a unix socket
 			cnnstr = fmt.Sprintf("%s:%s@unix(%s)/%s?charset=utf8&parseTime=true",
 				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name)
 		} else {
-			cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8&parseTime=true",
-				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name)
+			cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8&parseTime=true%s",
+				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name, tls)
 		}
 	case "postgres":
 		var host, port = "127.0.0.1", "5432"


### PR DESCRIPTION
warning: I am a total GO noob.
However I would love to see an options for the mysql driver to use TLS security - even if only without certificate verification. I found an option to enable it here: https://github.com/go-sql-driver/mysql#tls
and created a little patch reusing the SSLMode setting already used for Postgres. If set to "skip-verify" it should try to use TLS without verifying the remote CA cert.

Thanks