### PR TITLE
Update Docker container with Alpine 3.3 & Fix RPi2 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER jp@roemer.im
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.6/gosu-amd64 /usr/sbin/gosu
 RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
- && echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories \
  && apk -U --no-progress upgrade \
  && apk -U --no-progress add ca-certificates bash git linux-pam s6@edge curl openssh socat \
  && chmod +x /usr/sbin/gosu

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -3,8 +3,8 @@ MAINTAINER jp@roemer.im, raxetul@gmail.com
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.6/gosu-armhf /usr/sbin/gosu
-RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
- && echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories \
+RUN echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \
+ && echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
  && apk -U --no-progress upgrade \
  && apk -U --no-progress add ca-certificates bash git linux-pam s6@edge curl openssh socat \
  && chmod +x /usr/sbin/gosu

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,9 +1,10 @@
-FROM sander85/rpi-alpine:latest
+FROM hypriot/rpi-alpine-scratch:v3.2
 MAINTAINER jp@roemer.im, raxetul@gmail.com
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.6/gosu-armhf /usr/sbin/gosu
-RUN echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \
+RUN echo "http://dl-4.alpinelinux.org/alpine/v3.3/main/"      | tee /etc/apk/repositories    \
+ && echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \
  && echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
  && apk -U --no-progress upgrade \
  && apk -U --no-progress add ca-certificates bash git linux-pam s6@edge curl openssh socat \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,7 +7,7 @@ export GOPATH=/tmp/go
 export PATH=${PATH}:${GOPATH}/bin
 
 # Install build deps
-apk -U --no-progress add --virtual build-deps linux-pam-dev go@community gcc musl-dev
+apk -U --no-progress add --virtual build-deps linux-pam-dev go gcc musl-dev
 
 # Init go environment to build Gogs
 mkdir -p ${GOPATH}/src/github.com/gogits/


### PR DESCRIPTION
This PR consist of small changes to both `Dockerfile`, `Dockerfile.rpi` & `docker/build.sh` which consist pretty much of an update of the container base system and a fix from a previously introduced bug.

#### Changes
- `Dockerfile`:
  * Base image is now alpine:3.3 making the community repository availlable to stable release (pinning will not be needed to update go to its latest version)

- `docker/build.sh`:
  * A bug was introduced in #2475 by using a virtual package to manage build-depencies as repository pinning was not compatible with it. This bug made apk fetch the mainstream version of `go` in `x86` build which was 1.4.2 instead of 1.5.3. It was also preventing the `RPi` container to build as `go` was not present in the `main` repository.
   * Going from `alpine:3.2` to `alpine:3.3` fixes this problem as the `community` repository is now part of the base system

- `Dockerfile.rpi`:
  * Changed base image from `sander85/rpi-alpine:latest` to `hypriot/rpi-alpine-scratch:v3.2` as the build script for this image is availlable to all making the maintenance easier.
  * As this image is not the latet version of alpine, I made the container update itself to this latest version `3.3` to have a consistant version accross all container

#### Testing & Known Issues
Thanks to @ivanmarban, we've been able to test that all those changes are working properly on standard system with extensive testing on the `Rapsberry Pi 2 (armv7)` platform with just a bad news. The current `docker/build.sh` script is unable to run properly on `Raspberry Pi 1 (armv6)` thus making it impossible to build the container on this platform due to an incompatibility of the go binaries provided by the Alpine Linux community with this platform.