### PR TITLE
Show all orgs on user profile, except the private one's

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -253,6 +253,26 @@ func IsPublicMembership(orgId, uid int64) bool {
 	return has
 }
 
+func getPublicOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
+	orgs := make([]*User, 0, 10)
+	return orgs, sess.Where("`org_user`.uid=?", userID).And("`org_user`.is_public=?", true).
+		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").Find(&orgs)
+}
+
+// GetPublicOrgsByUserID returns a list of organizations that the given user ID
+// has joined publicly.
+func GetPublicOrgsByUserID(userID int64) ([]*User, error) {
+	sess := x.NewSession()
+	return getPublicOrgsByUserID(sess, userID)
+}
+
+// GetPublicOrgsByUserID returns a list of organizations that the given user ID
+// has joined publicly, ordered descending by the given condition.
+func GetPublicOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
+	sess := x.NewSession()
+	return getPublicOrgsByUserID(sess.Desc(desc), userID)
+}
+
 func getOwnedOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
 	orgs := make([]*User, 0, 10)
 	return orgs, sess.Where("`org_user`.uid=?", userID).And("`org_user`.is_owner=?", true).
@@ -266,7 +286,7 @@ func GetOwnedOrgsByUserID(userID int64) ([]*User, error) {
 }
 
 // GetOwnedOrganizationsByUserIDDesc returns a list of organizations are owned by
-// given user ID and descring order by given condition.
+// given user ID, ordered descending by the given condition.
 func GetOwnedOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
 	sess := x.NewSession()
 	return getOwnedOrgsByUserID(sess.Desc(desc), userID)

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -74,10 +74,10 @@ func Profile(ctx *middleware.Context) {
 	ctx.Data["Title"] = u.DisplayName()
 	ctx.Data["PageIsUserProfile"] = true
 	ctx.Data["Owner"] = u
-	
-	orgs, err := models.GetOwnedOrgsByUserIDDesc(u.Id, "updated")
+
+	orgs, err := models.GetPublicOrgsByUserIDDesc(u.Id, "updated")
 	if err != nil {
-		ctx.Handle(500, "GetOwnedOrgsByUserIDDesc", err)
+		ctx.Handle(500, "GetPublicOrgsByUserIDDesc", err)
 		return
 	}
 	ctx.Data["Orgs"] = orgs


### PR DESCRIPTION
Previously, the profile page of an user showed all organisations the user owned (regardless if public or not), which makes no sense. After merging this, the profile page will show all organisations the user has joined (not just the one's he owns), except the private (=not public) one's. Just like on GitHub :-)

![gogs-private-orgs-on-profile](https://cloud.githubusercontent.com/assets/616991/12698838/19c45cf0-c7a8-11e5-9013-bddc25a2e4bc.gif)