### PR TITLE
Hide other teams & repos from organization page

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -350,11 +350,14 @@ func runWeb(ctx *cli.Context) {
 			m.Get("/members/action/:action", org.MembersAction)
 
 			m.Get("/teams", org.Teams)
+		}, middleware.OrgAssignment(true))
+
+		m.Group("/:org", func() {
 			m.Get("/teams/:team", org.TeamMembers)
 			m.Get("/teams/:team/repositories", org.TeamRepositories)
 			m.Route("/teams/:team/action/:action", "GET,POST", org.TeamsAction)
 			m.Route("/teams/:team/action/repo/:action", "GET,POST", org.TeamsRepoAction)
-		}, middleware.OrgAssignment(true))
+		}, middleware.OrgAssignment(true, false, true))
 
 		m.Group("/:org", func() {
 			m.Get("/teams/new", org.NewTeam)

--- a/models/org.go
+++ b/models/org.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"strconv"
 
 	"github.com/go-xorm/xorm"
 )
@@ -1039,14 +1040,24 @@ func (org *User) getUserRepositories(userID int64) (err error) {
 		return fmt.Errorf("getUserRepositories: get teams: %v", err)
 	}
 
-	var teamIDs []int64
+	var teamIDs []string
 	for _, team := range teams {
-		teamIDs = append(teamIDs, team.ID)
+		teamIDs = append(teamIDs, strconv.FormatInt(team.ID, 10))
+	}
+	if len(teamIDs) == 0 {
+		// user has no team but "IN ()" is invalid SQL
+		teamIDs = append(teamIDs, "0")  // there is no repo with id=0
 	}
 
+	// Due to a bug in xorm using IN() together with OR() is impossible.
+	// As a workaround, we have to build the IN statement on our own, until this is fixed.
+	// https://github.com/go-xorm/xorm/issues/342
+
 	if err := x.Cols("`repository`.*").
-				In("`team_repo`.team_id", teamIDs).
 				Join("INNER", "`team_repo`", "`team_repo`.repo_id=`repository`.id").
+				Where("`repository`.owner_id=?", org.Id).
+				And("`repository`.is_private=?", false).
+				Or("`team_repo`.team_id=(?)", strings.Join(teamIDs, ",")).
 				GroupBy("`repository`.id").
 				Find(&org.Repos); err != nil {
 		return fmt.Errorf("getUserRepositories: get repositories: %v", err)

--- a/models/org.go
+++ b/models/org.go
@@ -1030,7 +1030,9 @@ func RemoveOrgRepo(orgID, repoID int64) error {
 	return removeOrgRepo(x, orgID, repoID)
 }
 
-func (org *User) getUserRepositories(userID int64) (err error) {
+// GetUserRepositories gets all repositories of an organization,
+// that the user with the given userID has access to.
+func (org *User) GetUserRepositories(userID int64) (err error) {
 	teams := make([]*Team, 0, 10)
 	if err := x.Cols("`team`.id").
 				Where("`team_user`.org_id=?", org.Id).
@@ -1068,13 +1070,9 @@ func (org *User) getUserRepositories(userID int64) (err error) {
 	return
 }
 
-// GetUserRepositories gets all repositories of an organization,
-// that the user with the given userID has access to.
-func (org *User) GetUserRepositories(userID int64) error {
-	return org.getUserRepositories(userID)
-}
-
-func (org *User) getUserTeams(userID int64) (err error) {
+// GetTeams returns all teams that belong to organization,
+// and that the user has joined.
+func (org *User) GetUserTeams(userID int64) (err error) {
 	if err := x.Cols("`team`.*").
 				Where("`team_user`.org_id=?", org.Id).
 				And("`team_user`.uid=?", userID).
@@ -1086,10 +1084,4 @@ func (org *User) getUserTeams(userID int64) (err error) {
 	org.NumTeams = len(org.Teams)
 
 	return
-}
-
-// GetTeams returns all teams that belong to organization,
-// and that the user has joined.
-func (org *User) GetUserTeams(userID int64) error {
-	return org.getUserTeams(userID)
 }

--- a/models/org.go
+++ b/models/org.go
@@ -1046,7 +1046,7 @@ func (org *User) getUserRepositories(userID int64) (err error) {
 	}
 	if len(teamIDs) == 0 {
 		// user has no team but "IN ()" is invalid SQL
-		teamIDs = append(teamIDs, "0")  // there is no repo with id=0
+		teamIDs = append(teamIDs, "-1")  // there is no repo with id=-1
 	}
 
 	// Due to a bug in xorm using IN() together with OR() is impossible.

--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -66,7 +66,7 @@ type Context struct {
 		IsOwner      bool
 		IsMember     bool
 		IsTeamMember bool // Is member of team.
-		IsAdminTeam  bool // In owner team or team that has admin permission level.
+		IsTeamAdmin  bool // In owner team or team that has admin permission level.
 		Organization *models.User
 		OrgLink      string
 

--- a/modules/middleware/context.go
+++ b/modules/middleware/context.go
@@ -65,6 +65,7 @@ type Context struct {
 	Org struct {
 		IsOwner      bool
 		IsMember     bool
+		IsTeamMember bool // Is member of team.
 		IsAdminTeam  bool // In owner team or team that has admin permission level.
 		Organization *models.User
 		OrgLink      string

--- a/modules/middleware/org.go
+++ b/modules/middleware/org.go
@@ -18,7 +18,7 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 		requireMember     bool
 		requireOwner      bool
 		requireTeamMember bool
-		requireAdminTeam  bool
+		requireTeamAdmin  bool
 	)
 	if len(args) >= 1 {
 		requireMember = args[0]
@@ -30,7 +30,7 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 		requireTeamMember = args[2]
 	}
 	if len(args) >= 4 {
-		requireAdminTeam = args[3]
+		requireTeamAdmin = args[3]
 	}
 
 	orgName := ctx.Params(":org")
@@ -59,13 +59,13 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 		ctx.Org.IsOwner = true
 		ctx.Org.IsMember = true
 		ctx.Org.IsTeamMember = true
-		ctx.Org.IsAdminTeam = true
+		ctx.Org.IsTeamAdmin = true
 	} else if ctx.IsSigned {
 		ctx.Org.IsOwner = org.IsOwnedBy(ctx.User.Id)
 		if ctx.Org.IsOwner {
 			ctx.Org.IsMember = true
 			ctx.Org.IsTeamMember = true
-			ctx.Org.IsAdminTeam = true
+			ctx.Org.IsTeamAdmin = true
 		} else {
 			if org.IsOrgMember(ctx.User.Id) {
 				ctx.Org.IsMember = true
@@ -118,9 +118,9 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 			return
 		}
 
-		ctx.Org.IsAdminTeam = ctx.Org.Team.IsOwnerTeam() || ctx.Org.Team.Authorize >= models.ACCESS_MODE_ADMIN
-		ctx.Data["IsAdminTeam"] = ctx.Org.IsAdminTeam
-		if requireAdminTeam && !ctx.Org.IsAdminTeam {
+		ctx.Org.IsTeamAdmin = ctx.Org.Team.IsOwnerTeam() || ctx.Org.Team.Authorize >= models.ACCESS_MODE_ADMIN
+		ctx.Data["IsTeamAdmin"] = ctx.Org.IsTeamAdmin
+		if requireTeamAdmin && !ctx.Org.IsTeamAdmin {
 			ctx.Handle(404, "OrgAssignment", err)
 			return
 		}

--- a/modules/middleware/org.go
+++ b/modules/middleware/org.go
@@ -88,9 +88,16 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 
 	// Team.
 	if ctx.Org.IsMember {
-		if err := org.GetUserTeams(ctx.User.Id); err != nil {
-			ctx.Handle(500, "GetUserTeams", err)
-			return
+		if ctx.Org.IsOwner {
+			if err := org.GetTeams(); err != nil {
+				ctx.Handle(500, "GetUserTeams", err)
+				return
+			}
+		} else {
+			if err := org.GetUserTeams(ctx.User.Id); err != nil {
+				ctx.Handle(500, "GetUserTeams", err)
+				return
+			}
 		}
 	}
 
@@ -98,6 +105,7 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 	if len(teamName) > 0 {
 		teamExists := false
 		for _, team := range org.Teams {
+
 			if strings.ToLower(team.Name) == strings.ToLower(teamName) {
 				teamExists = true
 				ctx.Org.Team = team
@@ -125,7 +133,6 @@ func HandleOrgAssignment(ctx *Context, args ...bool) {
 			return
 		}
 	}
-
 }
 
 func OrgAssignment(args ...bool) macaron.Handler {

--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -28,10 +28,7 @@ func Teams(ctx *middleware.Context) {
 	ctx.Data["Title"] = org.FullName
 	ctx.Data["PageIsOrgTeams"] = true
 
-	if err := org.GetTeams(); err != nil {
-		ctx.Handle(500, "GetTeams", err)
-		return
-	}
+	// org.Teams is already loaded by middleware
 	for _, t := range org.Teams {
 		if err := t.GetMembers(); err != nil {
 			ctx.Handle(500, "GetMembers", err)

--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -28,7 +28,6 @@ func Teams(ctx *middleware.Context) {
 	ctx.Data["Title"] = org.FullName
 	ctx.Data["PageIsOrgTeams"] = true
 
-	// org.Teams is already loaded by middleware
 	for _, t := range org.Teams {
 		if err := t.GetMembers(); err != nil {
 			ctx.Handle(500, "GetMembers", err)

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -335,7 +335,7 @@ func showOrgProfile(ctx *middleware.Context) {
 	}
 	ctx.Data["Members"] = org.Members
 
-	ctx.Data["Teams"] = org.Teams // already loaded by middleware
+	ctx.Data["Teams"] = org.Teams
 
 	ctx.HTML(200, ORG_HOME)
 }

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -183,11 +183,18 @@ func Issues(ctx *middleware.Context) {
 	isShowClosed := ctx.Query("state") == "closed"
 
 	// Get repositories.
-	repos, err := models.GetRepositories(ctxUser.Id, true)
-	if err != nil {
-		ctx.Handle(500, "GetRepositories", err)
-		return
+	if ctxUser.IsOrganization() {
+		if err := ctxUser.GetUserRepositories(ctx.User.Id); err != nil {
+			ctx.Handle(500, "GetRepositories", err)
+			return
+		}
+	} else {
+		if err := ctxUser.GetRepositories(); err != nil {
+			ctx.Handle(500, "GetRepositories", err)
+			return
+		}
 	}
+	repos := ctxUser.Repos
 
 	allCount := 0
 	repoIDs := make([]int64, 0, len(repos))

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -312,14 +312,22 @@ func showOrgProfile(ctx *middleware.Context) {
 	}
 
 	org := ctx.Org.Organization
-	userId := ctx.User.Id
 	ctx.Data["Title"] = org.FullName
 
-	if err := org.GetUserRepositories(userId); err != nil {
-		ctx.Handle(500, "GetUserRepositories", err)
-		return
+	if ctx.IsSigned {
+		if err := org.GetUserRepositories(ctx.User.Id); err != nil {
+			ctx.Handle(500, "GetUserRepositories", err)
+			return
+		}
+		ctx.Data["Repos"] = org.Repos
+	} else {
+		if repos, err := models.GetRepositories(org.Id, false); err != nil {
+			ctx.Handle(500, "GetRepositories", err)
+			return
+		} else {
+			ctx.Data["Repos"] = repos
+		}
 	}
-	ctx.Data["Repos"] = org.Repos
 
 	if err := org.GetMembers(); err != nil {
 		ctx.Handle(500, "GetMembers", err)

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -314,20 +314,19 @@ func showOrgProfile(ctx *middleware.Context) {
 	org := ctx.Org.Organization
 	ctx.Data["Title"] = org.FullName
 
-	repos, err := models.GetRepositories(org.Id, ctx.IsSigned && (ctx.User.IsAdmin || org.IsOrgMember(ctx.User.Id)))
-	if err != nil {
-		ctx.Handle(500, "GetRepositories", err)
+	if err := org.GetUserRepositories(ctx.User.Id); err != nil {
+		ctx.Handle(500, "GetUserRepositories", err)
 		return
 	}
-	ctx.Data["Repos"] = repos
+	ctx.Data["Repos"] = org.Repos
 
-	if err = org.GetMembers(); err != nil {
+	if err := org.GetMembers(); err != nil {
 		ctx.Handle(500, "GetMembers", err)
 		return
 	}
 	ctx.Data["Members"] = org.Members
 
-	if err = org.GetTeams(); err != nil {
+	if err := org.GetTeams(); err != nil {
 		ctx.Handle(500, "GetTeams", err)
 		return
 	}

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -328,12 +328,12 @@ func showOrgProfile(ctx *middleware.Context) {
 		}
 		ctx.Data["Repos"] = org.Repos
 	} else {
-		if repos, err := models.GetRepositories(org.Id, false); err != nil {
+		repos, err := models.GetRepositories(org.Id, false)
+		if err != nil {
 			ctx.Handle(500, "GetRepositories", err)
 			return
-		} else {
-			ctx.Data["Repos"] = repos
 		}
+		ctx.Data["Repos"] = repos
 	}
 
 	if err := org.GetMembers(); err != nil {

--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -312,9 +312,10 @@ func showOrgProfile(ctx *middleware.Context) {
 	}
 
 	org := ctx.Org.Organization
+	userId := ctx.User.Id
 	ctx.Data["Title"] = org.FullName
 
-	if err := org.GetUserRepositories(ctx.User.Id); err != nil {
+	if err := org.GetUserRepositories(userId); err != nil {
 		ctx.Handle(500, "GetUserRepositories", err)
 		return
 	}
@@ -326,11 +327,7 @@ func showOrgProfile(ctx *middleware.Context) {
 	}
 	ctx.Data["Members"] = org.Members
 
-	if err := org.GetTeams(); err != nil {
-		ctx.Handle(500, "GetTeams", err)
-		return
-	}
-	ctx.Data["Teams"] = org.Teams
+	ctx.Data["Teams"] = org.Teams // already loaded by middleware
 
 	ctx.HTML(200, ORG_HOME)
 }


### PR DESCRIPTION
Users should only be able to see repositories & teams they can access / they have joined. Right now, a user sees all repositories of an organization but when he clicks on it, a 404 page comes up. After merging this, users will only be able to see the teams & repos, they have access to. Just like on GitHub & Co. :-)

![screenshot from 2016-01-31 19-38-48](https://cloud.githubusercontent.com/assets/616991/12704042/48f8f440-c852-11e5-8468-a79f5d2d87bf.png)

Explanation of screenshot:
```
User left:
- is Owner of org2
- can see all repos
- can see all teams

User right:
- only in Team2
- can see public repos
- can see repos of Team2
- can see team Team2

Anyone:
- can see public repos
```