### PR TITLE
Use icon repo-forked instead of repo-lock for private, forked repos

### DIFF
--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -3,10 +3,10 @@
 		<div class="item">
 			<div class="ui header">
 				<a class="name" href="{{AppSubUrl}}/{{if .Owner}}{{.Owner.Name}}{{else if $.Org}}{{$.Org.Name}}{{else}}{{$.Owner.Name}}{{end}}/{{.Name}}">{{if $.PageIsExplore}}{{.Owner.Name}} / {{end}}{{.Name}}</a>
-				{{if .IsFork}}
-					<span><i class="icon octicon octicon-repo-forked"></i></span>
-				{{else if .IsPrivate}}
+				{{if .IsPrivate}}
 					<span class="text gold"><i class="icon octicon octicon-lock"></i></span>
+				{{else if .IsFork}}
+					<span><i class="icon octicon octicon-repo-forked"></i></span>
 				{{else if .IsMirror}}
 					<span><i class="icon octicon octicon-repo-clone"></i></span>
 				{{end}}

--- a/templates/explore/repo_list.tmpl
+++ b/templates/explore/repo_list.tmpl
@@ -3,10 +3,10 @@
 		<div class="item">
 			<div class="ui header">
 				<a class="name" href="{{AppSubUrl}}/{{if .Owner}}{{.Owner.Name}}{{else if $.Org}}{{$.Org.Name}}{{else}}{{$.Owner.Name}}{{end}}/{{.Name}}">{{if $.PageIsExplore}}{{.Owner.Name}} / {{end}}{{.Name}}</a>
-				{{if .IsPrivate}}
-					<span class="text gold"><i class="icon octicon octicon-lock"></i></span>
-				{{else if .IsFork}}
+				{{if .IsFork}}
 					<span><i class="icon octicon octicon-repo-forked"></i></span>
+				{{else if .IsPrivate}}
+					<span class="text gold"><i class="icon octicon octicon-lock"></i></span>
 				{{else if .IsMirror}}
 					<span><i class="icon octicon octicon-repo-clone"></i></span>
 				{{end}}

--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -29,7 +29,7 @@
 							{{range .Repos}}
 								<li {{if .IsPrivate}}class="private"{{end}}>
 									<a href="{{AppSubUrl}}/{{$.ContextUser.Name}}/{{.Name}}">
-										<i class="icon octicon octicon-{{if .IsPrivate}}lock{{else if .IsFork}}repo-forked{{else if .IsMirror}}repo-clone{{else}}repo{{end}}"></i>
+										<i class="icon octicon octicon-{{if .IsFork}}repo-forked{{else if .IsPrivate}}lock{{else if .IsMirror}}repo-clone{{else}}repo{{end}}"></i>
 										<strong class="text truncate item-name">{{.Name}}</strong>
 										<span class="ui right text light grey">
 											<i class="octicon octicon-star"></i>{{.NumStars}}


### PR DESCRIPTION
Makes more sense, because private repositories still do have the yellow background.

**Before**:
![screenshot from 2016-01-31 21-39-29](https://cloud.githubusercontent.com/assets/616991/12704841/21973be8-c864-11e5-9575-8815a1a41116.png)

**After**:
![screenshot from 2016-01-31 21-40-23](https://cloud.githubusercontent.com/assets/616991/12704842/25551b1a-c864-11e5-8965-1f91914c955b.png)
