### PR TITLE
Fixes #2447 where SSH keys aren't removed from authorized_keys

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -165,6 +165,9 @@ func CheckPublicKeyString(content string) (_ string, err error) {
 		return "", errors.New("only a single line with a single key please")
 	}
 
+	// remove any unnecessary whitespace now
+	content = strings.TrimSpace(content)
+
 	fields := strings.Fields(content)
 	if len(fields) < 2 {
 		return "", errors.New("too less fields")

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -374,6 +374,11 @@ func rewriteAuthorizedKeys(key *PublicKey, p, tmpP string) error {
 			break
 		}
 	}
+
+	if !isFound {
+		log.Warn("SSH key %d not found in authorized_keys file for deletion", key.ID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Figured I'd try to show some of my love for Gogs with a bugfix. :) Thank you again for the project! :+1: 

I made two separate commits so you could only cherry-pick the one if you wanted. I can also rebase into a single commit if you'd prefer.

This fixes the bug at the root of the problem. I did some debugging and found that in the loop where you're searching for the key, the keyword is found, but the SSH key's content is not. It seems that an extra space was being added to the SSH key before it was inserted into the database, but it was trimmed off when it was added to the `authorized_keys` file.

I couldn't determine any code responsible for adding the spaces, so I'm imaginging it's something browser-side, or even just how I was copying & pasting it. Since trailing space should be superfluous anyway, I went ahead and removed it when you validate the SSH key. Because you were returning `content` back out and using that value everywhere you called `CheckPublicKey()` it seemed like an ideal place to "sanitize" the input.

I considered additionally adding a `TrimSpace()` on the way out of the database (or even just when rewriting the `authorized_keys` file), but figured I'd leave that call up to you. If you'd like me to add code to do so, just let me know which function would be ideal to put it in (`GetPublicKey()` or `rewriteAuthorizedKeys()` or wherever else).

What this means is that anyone currently affected will continue to be affected (i.e. if there's already spaces in the DB, you're out of luck.) For any new SSH keys, the bug shouldn't be present.