### PR TITLE
Fix syntax highlighting for markdown code blocks on issue description/comment save

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -385,6 +385,9 @@ function initRepository() {
                             } else {
                                 $render_content.html(data.content);
                                 emojify.run($render_content[0]);
+                                $('pre code', $render_content[0]).each(function(i, block) {
+                                    hljs.highlightBlock(block);
+                                });
                             }
                         });
                 });


### PR DESCRIPTION
Looks like I missed something in #2538. Markdown code block syntax highlighting did still not work when updating an issue description or comment. Is fixed now.

**Before**:
![](https://cloud.githubusercontent.com/assets/616991/12734250/a8896262-c93f-11e5-8f47-95517cf80c1f.gif)

**After**:
![](https://cloud.githubusercontent.com/assets/616991/12734253/aad4007c-c93f-11e5-83d5-dc57db1a21dc.gif)
