### PR TITLE
Escape unescaped periods in route regular expression

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -516,7 +516,7 @@ func runWeb(ctx *cli.Context) {
 			m.Get("/forks", repo.Forks)
 		}, middleware.RepoRef())
 
-		m.Get("/compare/:before([a-z0-9]{40})...:after([a-z0-9]{40})", repo.CompareDiff)
+		m.Get("/compare/:before([a-z0-9]{40})\\.\\.\\.:after([a-z0-9]{40})", repo.CompareDiff)
 	}, ignSignIn, middleware.RepoAssignment(), repo.MustBeNotBare)
 	m.Group("/:username/:reponame", func() {
 		m.Get("/stars", repo.Stars)


### PR DESCRIPTION
Works: `/compare/sha1...sha1`
Works: `/compare/sha1FOOsha1` <-- make this don't work anymore

---

Side note:

Actually, I was trying to make [7-digit sha1 sums](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1) work, but I failed, because you can't make a Hex from an odd length string ([here](https://github.com/gogits/git-module/blob/3c8c495/sha1.go#L86)).

Another thing: I really wonder why gogs does not use [libgit2](https://libgit2.github.com) (like GitHub, BitBucket, etc.). Is that on purpose?