### PR TITLE
Adding small arrows on issue comments pointing to the user avatar

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2088,11 +2088,32 @@ footer .container .links > *:first-child {
 .repository.view.issue .comment-list .comment .content .header {
   font-weight: normal;
   padding: auto 15px;
+  position:relative;
   color: #767676;
   background-color: #f7f7f7;
   border-bottom: 1px solid #eee;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
+}
+.repository.view.issue .comment-list .comment .content .header:after, .repository.view.issue .comment-list .comment .content .header:before {
+  right: 100%;
+  top: 50%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.repository.view.issue .comment-list .comment .content .header:after {
+  border-right-color: #f7f7f7;
+  border-width: 8px;
+  margin-top: -8px;
+}
+.repository.view.issue .comment-list .comment .content .header:before {
+  border-right-color: #D4D4D5;
+  border-width: 9px;
+  margin-top: -9px;
 }
 .repository.view.issue .comment-list .comment .content .header .text {
   max-width: 78%;


### PR DESCRIPTION
Added small arrows pointing to user avatars similiar to github

Example: 
![gogsarrows](https://cloud.githubusercontent.com/assets/488912/12832444/efc99df0-cb91-11e5-8678-137e83d98a56.PNG)
