### PR TITLE
Add small arrows on issue comments pointing to users avatar

### DIFF
--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -376,8 +376,29 @@
 				.content {
 					margin-left: 4em;
 					.header {
+						&:before, &:after {
+							right: 100%;
+							top: 50%;
+							border: solid transparent;
+							content: " ";
+							height: 0;
+							width: 0;
+							position: absolute;
+							pointer-events: none;
+						}
+						&:before {
+							border-right-color: #D4D4D5;
+							border-width: 9px;
+							margin-top: -9px;
+						}	
+						&:after {
+							border-right-color: #f7f7f7;
+							border-width: 8px;
+							margin-top: -8px;
+						}					
 						font-weight: normal;
 						padding: auto 15px;
+						position: relative;
 						color: #767676;
 						background-color: #f7f7f7;
 						border-bottom: 1px solid #eee;


### PR DESCRIPTION
Added small arrows pointing to user avatars similiar to github

Example:
![gogsarrows](https://cloud.githubusercontent.com/assets/488912/12857060/fe908138-cc3f-11e5-9648-400ebfc7674d.PNG)
