### PR TITLE
fixes #2563

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -1179,6 +1179,7 @@ func (m *Milestone) AfterSet(colName string, _ xorm.Cell) {
 		if m.Deadline.Year() == 9999 {
 			return
 		}
+		m.Deadline = regulateTimeZone(m.Deadline)
 
 		m.DeadlineString = m.Deadline.Format("2006-01-02")
 		if time.Now().After(m.Deadline) {

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -1079,7 +1079,7 @@ func NewMilestonePost(ctx *middleware.Context, form auth.CreateMilestoneForm) {
 	if len(form.Deadline) == 0 {
 		form.Deadline = "9999-12-31"
 	}
-	deadline, err := time.Parse("2006-01-02", form.Deadline)
+	deadline, err := time.ParseInLocation("2006-01-02", form.Deadline, time.Local)
 	if err != nil {
 		ctx.Data["Err_Deadline"] = true
 		ctx.RenderWithErr(ctx.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &form)
@@ -1139,7 +1139,7 @@ func EditMilestonePost(ctx *middleware.Context, form auth.CreateMilestoneForm) {
 	if len(form.Deadline) == 0 {
 		form.Deadline = "9999-12-31"
 	}
-	deadline, err := time.Parse("2006-01-02", form.Deadline)
+	deadline, err := time.ParseInLocation("2006-01-02", form.Deadline, time.Local)
 	if err != nil {
 		ctx.Data["Err_Deadline"] = true
 		ctx.RenderWithErr(ctx.Tr("repo.milestones.invalid_due_date_format"), MILESTONE_NEW, &form)


### PR DESCRIPTION
fixes #2563 

There were actually _two_ bugs. First, it parsed the user-input as UTC and converted it to local-time when saving to the database, then, when loading it treated it (again) as UTC and converted it to local-time.