### PR TITLE
Admins and user itself sees private org relations on profile

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -254,24 +254,27 @@ func IsPublicMembership(orgId, uid int64) bool {
 	return has
 }
 
-func getPublicOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
+func getOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {
 	orgs := make([]*User, 0, 10)
-	return orgs, sess.Where("`org_user`.uid=?", userID).And("`org_user`.is_public=?", true).
+	return orgs, sess.Where("`org_user`.uid=?", userID).
 		Join("INNER", "`org_user`", "`org_user`.org_id=`user`.id").Find(&orgs)
 }
 
 // GetPublicOrgsByUserID returns a list of organizations that the given user ID
 // has joined publicly.
-func GetPublicOrgsByUserID(userID int64) ([]*User, error) {
+func GetOrgsByUserID(userID int64) ([]*User, error) {
 	sess := x.NewSession()
-	return getPublicOrgsByUserID(sess, userID)
+	return getOrgsByUserID(sess, userID)
 }
 
 // GetPublicOrgsByUserID returns a list of organizations that the given user ID
 // has joined publicly, ordered descending by the given condition.
-func GetPublicOrgsByUserIDDesc(userID int64, desc string) ([]*User, error) {
+func GetOrgsByUserIDDesc(userID int64, desc string, all bool) ([]*User, error) {
 	sess := x.NewSession()
-	return getPublicOrgsByUserID(sess.Desc(desc), userID)
+	if !all {
+		sess.And("`org_user`.is_public=?", true)
+	}
+	return getOrgsByUserID(sess.Desc(desc), userID)
 }
 
 func getOwnedOrgsByUserID(sess *xorm.Session, userID int64) ([]*User, error) {

--- a/routers/user/profile.go
+++ b/routers/user/profile.go
@@ -75,11 +75,12 @@ func Profile(ctx *middleware.Context) {
 	ctx.Data["PageIsUserProfile"] = true
 	ctx.Data["Owner"] = u
 
-	orgs, err := models.GetPublicOrgsByUserIDDesc(u.Id, "updated")
+	orgs, err := models.GetOrgsByUserIDDesc(u.Id, "updated", ctx.User.IsAdmin || ctx.User.Id == u.Id)
 	if err != nil {
-		ctx.Handle(500, "GetPublicOrgsByUserIDDesc", err)
+		ctx.Handle(500, "GetOrgsByUserIDDesc", err)
 		return
 	}
+
 	ctx.Data["Orgs"] = orgs
 
 	tab := ctx.Query("tab")

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -60,11 +60,7 @@
 							{{if .Orgs}}
 							<li>
 								{{range .Orgs}}
-									{{if $.Owner.IsPublicMember .Id}}
-										<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}}" data-position="top center" data-variation="tiny inverted"></a>
-									{{else}}
-										<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}} (Private)" data-position="top center" data-variation="tiny inverted"></a>
-									{{end}}
+									<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}}" data-position="top center" data-variation="tiny inverted"></a>
 								{{end}}
 							</li>
 							{{end}}

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -60,7 +60,11 @@
 							{{if .Orgs}}
 							<li>
 								{{range .Orgs}}
-									<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}}" data-position="top center" data-variation="tiny inverted"></a>
+									{{if $.Owner.IsPublicMember .Id}}
+										<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}}" data-position="top center" data-variation="tiny inverted"></a>
+									{{else}}
+										<a href="{{.HomeLink}}"><img class="ui mini image poping up" src="{{.AvatarLink}}" data-content="{{.Name}} (Private)" data-position="top center" data-variation="tiny inverted"></a>
+									{{end}}
 								{{end}}
 							</li>
 							{{end}}


### PR DESCRIPTION
This is inspired by @Unknwon 's post in #2571 
The only thing left to do is let org admins see the private repos as well. And maybe get a yellow outline or something on the avatar