### PR TITLE
Fix #2221 LDAP username attribute must be fetched

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -153,7 +153,7 @@ func (ls *Source) SearchEntry(name, passwd string, directBind bool) (string, str
 
 	search := ldap.NewSearchRequest(
 		userDN, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, userFilter,
-		[]string{ls.AttributeName, ls.AttributeSurname, ls.AttributeMail},
+		[]string{ls.AttributeUsername, ls.AttributeName, ls.AttributeSurname, ls.AttributeMail},
 		nil)
 
 	sr, err := l.Search(search)


### PR DESCRIPTION
This is fix-up for 573305f. Forgot to fetch AttributeUsername value from the
LDAP server, so the setting was effectively not working as intended.