### PR TITLE
Implementing the "theme-color" meta tag.

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -27,6 +27,10 @@ EXPLORE_PAGING_NUM = 20
 ISSUE_PAGING_NUM = 10
 ; Number of maximum commits showed in one activity feed
 FEED_MAX_COMMIT_NUM = 5
+; Value of `theme-color` meta tag, used by Android >= 5.0
+; An invalid color like "none" or "disable" will have the default style
+; More info: https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
+THEME_COLOR_META_TAG = `#ff5343`
 
 [ui.admin]
 ; Number of users that are showed in one page

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -114,6 +114,7 @@ var (
 	AdminRepoPagingNum   int
 	AdminNoticePagingNum int
 	AdminOrgPagingNum    int
+	ThemeColorMetaTag    string
 
 	// Markdown sttings
 	Markdown struct {
@@ -407,6 +408,7 @@ func NewContext() {
 	AdminRepoPagingNum = sec.Key("REPO_PAGING_NUM").MustInt(50)
 	AdminNoticePagingNum = sec.Key("NOTICE_PAGING_NUM").MustInt(50)
 	AdminOrgPagingNum = sec.Key("ORG_PAGING_NUM").MustInt(50)
+	ThemeColorMetaTag = sec.Key("THEME_COLOR_META_TAG").MustString("#ff5343")
 
 	sec = Cfg.Section("picture")
 	PictureService = sec.Key("SERVICE").In("server", []string{"server"})

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -98,6 +98,9 @@ var Funcs template.FuncMap = map[string]interface{}{
 		return strings.Replace(strings.Replace(str, "%", "%25", -1), "#", "%23", -1)
 	},
 	"RenderCommitMessage": RenderCommitMessage,
+	"ThemeColorMetaTag": func() string {
+		return setting.ThemeColorMetaTag
+	},
 }
 
 func Safe(raw string) template.HTML {

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -34,6 +34,8 @@
 	<script src="{{AppSubUrl}}/js/gogs.js?v={{MD5 AppVer}}"></script>
 
 	<title>{{if .Title}}{{.Title}} - {{end}}{{AppName}}</title>
+
+	<meta name="theme-color" content="{{ThemeColorMetaTag}}">
 </head>
 <body>
 	<div class="full height">


### PR DESCRIPTION
Used by Android >= 5.0 to make the top bar colored.

Reference: https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android

Before:
<img width="300px" src="https://cloud.githubusercontent.com/assets/7011819/12896437/2697c100-ce89-11e5-9bca-1bb22a11d712.png"/>

After:
<img width="300px" src="https://cloud.githubusercontent.com/assets/7011819/12896439/2af9a650-ce89-11e5-85b9-875ea284ee4e.png"/>