### PR TITLE
Add the ability to run crond inside the Docker container

### DIFF
--- a/docker/s6/crond/run
+++ b/docker/s6/crond/run
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Crontabs are located by default in /var/spool/cron/crontabs/
+# The default configuration is also calling all the scripts in /etc/periodic/${period}
+
+if test -f ./setup; then
+    source ./setup
+fi
+
+exec gosu root /usr/sbin/crond -fS

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -48,6 +48,15 @@ else
     create_socat_links
 fi
 
+CROND=$(echo "$RUN_CROND" | tr '[:upper:]' '[:lower:]')
+if [ "$CROND" = "true" -o "$CROND" = "1" ]; then
+    echo "init:crond  | Cron Daemon (crond) will be run as requested by s6" 1>&2
+    rm -f /app/gogs/docker/s6/crond/down
+else
+    # Tell s6 not to run the crond service
+    touch /app/gogs/docker/s6/crond/down
+fi
+
 # Exec CMD or S6 by default if nothing present
 if [ $# -gt 0 ];then
     exec "$@"


### PR DESCRIPTION
- add the crond initscript for s6
- add the RUN_CROND configuration variable to setup crond
- `crond will` not be run by default (hence the `down` file in the service directory)
- `start.sh` check if RUN_CROND = `true` || `1` and remove this file to tell s6 to run the initscript
- test container is availlable @ `quay.io/0rax/gogs`
- permit the addition of custom cron job by mounting your crontab in `/var/spool/cron/crontabs/`
- you can also add cron script to `/etc/periodic/(15min|hourly|daily|weekly|monthly)/`
- resolves #2597