### PR TITLE
#2505 Allow to fork and disallow to create PRs for mirrors.

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -470,7 +470,7 @@ func runWeb(ctx *cli.Context) {
 			m.Post("/delete", repo.DeleteRelease)
 		}, reqRepoAdmin, middleware.RepoRef())
 
-		m.Combo("/compare/*", repo.MustEnablePulls).Get(repo.CompareAndPullRequest).
+		m.Combo("/compare/*", repo.MustAllowPulls).Get(repo.CompareAndPullRequest).
 			Post(bindIgnErr(auth.CreateIssueForm{}), repo.CompareAndPullRequestPost)
 	}, reqSignIn, middleware.RepoAssignment(), repo.MustBeNotBare)
 
@@ -503,7 +503,7 @@ func runWeb(ctx *cli.Context) {
 			m.Get("/commits", middleware.RepoRef(), repo.ViewPullCommits)
 			m.Get("/files", middleware.RepoRef(), repo.ViewPullFiles)
 			m.Post("/merge", reqRepoAdmin, repo.MergePullRequest)
-		}, repo.MustEnablePulls)
+		}, repo.MustAllowPulls)
 
 		m.Group("", func() {
 			m.Get("/src/*", repo.Home)

--- a/models/repo.go
+++ b/models/repo.go
@@ -332,7 +332,17 @@ func (repo *Repository) IsOwnedBy(userID int64) bool {
 
 // CanBeForked returns true if repository meets the requirements of being forked.
 func (repo *Repository) CanBeForked() bool {
-	return !repo.IsBare && !repo.IsMirror
+	return !repo.IsBare
+}
+
+// CanEnablePulls returns true if repository meets the requirements of accepting pulls.
+func (repo *Repository) CanEnablePulls() bool {
+	return !repo.IsMirror
+}
+
+// AllowPulls returns true if repository meets the requirements of accepting pulls and has them enabled.
+func (repo *Repository) AllowsPulls() bool {
+	return repo.CanEnablePulls() && repo.EnablePulls;
 }
 
 func (repo *Repository) NextIssueIndex() int64 {

--- a/modules/middleware/repo.go
+++ b/modules/middleware/repo.go
@@ -167,7 +167,7 @@ func RepoAssignment(args ...bool) macaron.Handler {
 		ctx.Data["IsRepositoryOwner"] = ctx.Repo.IsOwner()
 		ctx.Data["IsRepositoryAdmin"] = ctx.Repo.IsAdmin()
 		ctx.Data["IsRepositoryPusher"] = ctx.Repo.IsPusher()
-		ctx.Data["CanPullRequest"] = ctx.Repo.IsAdmin() && repo.BaseRepo != nil && repo.BaseRepo.EnablePulls
+		ctx.Data["CanPullRequest"] = ctx.Repo.IsAdmin() && repo.BaseRepo != nil && repo.BaseRepo.AllowsPulls()
 
 		ctx.Data["DisableSSH"] = setting.DisableSSH
 		ctx.Data["CloneLink"] = repo.CloneLink()

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -48,7 +48,9 @@ func MustEnableIssues(ctx *middleware.Context) {
 }
 
 func MustEnablePulls(ctx *middleware.Context) {
-	if !ctx.Repo.Repository.EnablePulls {
+	if !ctx.Repo.Repository.CanEnablePulls() {
+		ctx.Handle(404, "Unsupported", nil)
+	} else if !ctx.Repo.Repository.EnablePulls {
 		ctx.Handle(404, "MustEnablePulls", nil)
 	}
 

--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -47,11 +47,9 @@ func MustEnableIssues(ctx *middleware.Context) {
 	}
 }
 
-func MustEnablePulls(ctx *middleware.Context) {
-	if !ctx.Repo.Repository.CanEnablePulls() {
-		ctx.Handle(404, "Unsupported", nil)
-	} else if !ctx.Repo.Repository.EnablePulls {
-		ctx.Handle(404, "MustEnablePulls", nil)
+func MustAllowPulls(ctx *middleware.Context) {
+	if !ctx.Repo.Repository.AllowsPulls() {
+		ctx.Handle(404, "MustAllowPulls", nil)
 	}
 
 	ctx.Data["HasForkedRepo"] = ctx.IsSigned && ctx.User.HasForkedRepo(ctx.Repo.Repository.ID)
@@ -73,7 +71,7 @@ func RetrieveLabels(ctx *middleware.Context) {
 func Issues(ctx *middleware.Context) {
 	isPullList := ctx.Params(":type") == "pulls"
 	if isPullList {
-		MustEnablePulls(ctx)
+		MustAllowPulls(ctx)
 		if ctx.Written() {
 			return
 		}

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -57,7 +57,7 @@
 					<i class="icon octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
 				</a>
 			{{end}}
-			{{if .Repository.EnablePulls}}
+			{{if .Repository.AllowsPulls}}
 				<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
 					<i class="icon octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
 				</a>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -117,15 +117,17 @@
 							<p class="help">{{.i18n.Tr "repo.settings.tracker_url_format_desc" | Str2html}}</p>
 						</div>
 
-						<div class="ui divider"></div>
+						{{if .Repository.CanEnablePulls}}
+							<div class="ui divider"></div>
 
-						<div class="inline field">
-							<label>{{.i18n.Tr "repo.pulls"}}</label>
-							<div class="ui checkbox">
-								<input name="enable_pulls" type="checkbox" {{if .Repository.EnablePulls}}checked{{end}}>
-								<label>{{.i18n.Tr "repo.settings.pulls_desc"}}</label>
+							<div class="inline field">
+								<label>{{.i18n.Tr "repo.pulls"}}</label>
+								<div class="ui checkbox">
+									<input name="enable_pulls" type="checkbox" {{if .Repository.EnablePulls}}checked{{end}}>
+									<label>{{.i18n.Tr "repo.settings.pulls_desc"}}</label>
+								</div>
 							</div>
-						</div>
+						{{end}}
 
 						<div class="ui divider"></div>
 						<div class="field">


### PR DESCRIPTION
Allow to fork and disallow to create PRs for mirrors, which addresses issue #2505.

Changes have been made to handle cases of prior created mirror repositories to provide backwards-compatibility.

Pull Requests were disabled, because...
  1) Mirrors are supposed to be read-only (merging a pull request would write to the it).
  2) prior to this change, no forks could have been made from within the GUI, making Pull Request support redundant.