### PR TITLE
Dockerfile cleanup for Alpine 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,8 @@ MAINTAINER jp@roemer.im
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.6/gosu-amd64 /usr/sbin/gosu
-RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories \
- && apk -U --no-progress upgrade \
- && apk -U --no-progress add ca-certificates bash git linux-pam s6@edge curl openssh socat \
- && chmod +x /usr/sbin/gosu
+RUN chmod +x /usr/sbin/gosu \
+ && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat
 
 ENV GOGS_CUSTOM /data/gogs
 


### PR DESCRIPTION
Eliminates some package-manager wrangling which has become unnecessary since the Dockerfile was written (~half a year ago, targetting alpine 3.2). In particular, by eliminating the edge pin, we're a bit more insulated from possible breaking changes in edge (package upgrades in stable are not supposed to be breaking).

- s6 is in main in 3.3, so we no longer need to mangle the repos file
- official image is periodically updated, so it's not preferred to do
  upgrades downstream (usually harmless, but inelegant)
- apk-tools in 3.3 supports --no-cache to avoid leaving the APKINDEX
  files in the image