### PR TITLE
tell macaron to use auto head

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -130,6 +130,8 @@ func newMacaron() *macaron.Macaron {
 		IndentJSON: macaron.Env != macaron.PROD,
 	}))
 
+	m.SetAutoHead(true)
+
 	localeNames, err := bindata.AssetDir("conf/locale")
 	if err != nil {
 		log.Fatal(4, "Fail to list locale files: %v", err)


### PR DESCRIPTION
My monitoring software (monit) recently added this:

>Fixed: The HTTP protocol-test now uses HEAD instead of GET if no content check is set. That is, if you only want to test the response status for a given URL and not the content of the response. This should make the test faster and save bandwidth.

Which was causing checks to `gogs` to return 404. Enabling SetAutoHead in Macaron resolves the issue.

Before adding this diff and running `curl -vI <url>`
```
< HTTP/1.1 404 Not Found
HTTP/1.1 404 Not Found
```
After:
```
< HTTP/1.1 200 OK
HTTP/1.1 200 OK

```
