### PR TITLE
Image attachments keep aspect ratio

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1460,8 +1460,33 @@ footer .container .links > *:first-child {
 .repository.view.issue .comment-list .comment .content > .bottom.segment {
   background: #f3f4f5;
 }
+.repository.view.issue .comment-list .comment .content > .bottom.segment .ui.images::after {
+  clear: both;
+  content: ' ';
+  display: block;
+}
+.repository.view.issue .comment-list .comment .content > .bottom.segment a {
+  display: block;
+  float: left;
+  margin: 5px;
+  padding: 5px;
+  height: 150px;
+  border: solid 1px #eee;
+  border-radius: 3px;
+  max-width: 150px;
+  background-color: #fff;
+}
+.repository.view.issue .comment-list .comment .content > .bottom.segment a:before {
+  content: "";
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+}
 .repository.view.issue .comment-list .comment .content > .bottom.segment .ui.image {
-  max-height: 150px;
+  max-height: 100%;
+  width: auto;
+  margin: 0;
+  vertical-align: middle;
 }
 .repository.view.issue .comment-list .comment .ui.form .field:first-child {
   clear: none;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -413,8 +413,33 @@
 					}
 					> .bottom.segment {
 						background: #f3f4f5;
+						.ui.images::after {
+							clear: both;
+							content: ' ';
+							display: block;
+						}
+						a {
+							display: block;
+							float: left;
+							margin: 5px;
+							padding: 5px;
+							height: 150px;
+							border: solid 1px #eee;
+							border-radius: 3px;
+							max-width: 150px;
+							background-color: #fff;
+							&:before {
+								content:' ';
+								display: inline-block;
+								height: 100%;
+								vertical-align: middle;
+							}
+						}
 						.ui.image {
-							max-height: 150px;
+							max-height: 100%;
+							width: auto;
+							margin: 0;
+							vertical-align: middle;
 						}
 					}
 				}


### PR DESCRIPTION
Currently attachments in issues are stretched into their 150x150px box - most of the time this looks fine but for long, non-square or icons ize images this can soon look untidy and pixelated

I have made CSS changes to change them to look like this:
![example-attachments_r1_c1](https://cloud.githubusercontent.com/assets/6347946/13355421/38bcb74c-dc98-11e5-8d44-d12a0b15ffbb.jpg)

