### PR TITLE
Hide the download archive button when viewing wiki pages

### DIFF
--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -41,13 +41,6 @@
 					<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
 						<i class="octicon octicon-clippy"></i>
 					</button>
-					<div class="ui basic jump dropdown icon button">
-						<i class="download icon"></i>
-						<div class="menu">
-							<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip"><i class="icon octicon octicon-file-zip"></i> ZIP</a>
-							<a class="item" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.tar.gz"><i class="icon octicon octicon-file-zip"></i> TAR.GZ</a>
-						</div>
-					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
After 
![gogsdlwikibutton](https://cloud.githubusercontent.com/assets/488912/13391654/85595e2a-decd-11e5-87cd-8ebfa2b93d26.PNG)
