### PR TITLE
ISSUE_TEMPLATE: suggestion to test at try.gogs.io

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,6 +11,10 @@ For bug reports, please give the relevant info:
   - [ ] PostgreSQL
   - [ ] MySQL
   - [ ] SQLite
+- Can you reproduce the bug at http://try.gogs.io:
+  - [ ] Yes
+  - [ ] No
+  - [ ] Not relevant
 - Log gist:
 
 ## Description


### PR DESCRIPTION
Please, make sure you are targeting the `develop` branch!

More instructions about contributing with Gogs code can be found here:
https://github.com/gogits/gogs/wiki/Contributing-Code

I've noticed that a lot of issues cannot be reproduced on http://try.gogs.io,
which either hints about specific database type problems or
hints about bugs which are already solved in the newer version
(as http://try.gogs.io is usually a newer build).

This patch adds the suggestion to test the issue at http://try.gogs.io in
the Github "issue template". The user can answer: "Yes", "No", "Not relevant".

"Not relevant" is an option where testing on http://try.gogs.io makes no sense as
the bug is unrelated to the Web UI or is very specific in nature.