### PR TITLE
Use relative url when showing forked from

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -321,6 +321,11 @@ func (repo *Repository) RepoLink() string {
 	return setting.AppSubUrl + "/" + repo.MustOwner().Name + "/" + repo.Name
 }
 
+func (repo *Repository) RepoRelLink() string {
+	return "/" + repo.MustOwner().Name + "/" + repo.Name
+}
+
+
 func (repo *Repository) ComposeCompareURL(oldCommitID, newCommitID string) string {
 	return fmt.Sprintf("%s/%s/compare/%s...%s", repo.MustOwner().Name, repo.Name, oldCommitID, newCommitID)
 }

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -10,7 +10,7 @@
 						<div class="divider"> / </div>
 						<a href="{{$.RepoLink}}">{{.Name}}</a>
 						{{if .IsMirror}}<div class="fork-flag">{{$.i18n.Tr "repo.mirror_from"}} <a target="_blank" href="{{$.Mirror.Address}}">{{$.Mirror.Address}}</a></div>{{end}}
-						{{if .IsFork}}<div class="fork-flag">{{$.i18n.Tr "repo.forked_from"}} <a href="{{.BaseRepo.RepoLink}}">{{SubStr .BaseRepo.RepoLink 1 -1}}</a></div>{{end}}
+						{{if .IsFork}}<div class="fork-flag">{{$.i18n.Tr "repo.forked_from"}} <a href="{{.BaseRepo.RepoLink}}">{{SubStr .BaseRepo.RepoRelLink 1 -1}}</a></div>{{end}}
 					</div>
 
 					<div class="ui right">


### PR DESCRIPTION
Addresses #2588

Will show something like forked from joshfng/gogs instead of forked from subpath/joshfng/gogs