### PR TITLE
Added: Ability to delete org avatar.

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -368,6 +368,7 @@ func runWeb(ctx *cli.Context) {
 				m.Combo("").Get(org.Settings).
 					Post(bindIgnErr(auth.UpdateOrgSettingForm{}), org.SettingsPost)
 				m.Post("/avatar", binding.MultipartForm(auth.UploadAvatarForm{}), org.SettingsAvatar)
+				m.Post("/avatar/delete", org.SettingsDeleteAvatar)
 
 				m.Group("/hooks", func() {
 					m.Get("", org.Webhooks)

--- a/models/user.go
+++ b/models/user.go
@@ -346,6 +346,19 @@ func (u *User) UploadAvatar(data []byte) error {
 	return sess.Commit()
 }
 
+// DeleteAvatar deletes the user's custom avatar.
+func (u *User) DeleteAvatar() error {
+	log.Info("Deleting user avatar: %s", u.CustomAvatarPath())
+	os.Remove(u.CustomAvatarPath())
+
+	u.UseCustomAvatar = false
+	if err := UpdateUser(u); err != nil {
+		return fmt.Errorf("updateUser: %v", err)
+	}
+
+	return nil
+}
+
 // IsAdminOfRepo returns true if user has admin or higher access of repository.
 func (u *User) IsAdminOfRepo(repo *Repository) bool {
 	has, err := HasAccess(u, repo, ACCESS_MODE_ADMIN)

--- a/routers/org/setting.go
+++ b/routers/org/setting.go
@@ -96,6 +96,14 @@ func SettingsAvatar(ctx *middleware.Context, form auth.UploadAvatarForm) {
 	ctx.Redirect(ctx.Org.OrgLink + "/settings")
 }
 
+func SettingsDeleteAvatar(ctx *middleware.Context) {
+	if err := ctx.Org.Organization.DeleteAvatar(); err != nil {
+		ctx.Flash.Error(err.Error())
+	}
+
+	ctx.Redirect(ctx.Org.OrgLink + "/settings")
+}
+
 func SettingsDelete(ctx *middleware.Context) {
 	ctx.Data["Title"] = ctx.Tr("org.settings")
 	ctx.Data["PageIsSettingsDelete"] = true

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/Unknwon/com"
@@ -156,12 +155,10 @@ func SettingsAvatar(ctx *middleware.Context, form auth.UploadAvatarForm) {
 }
 
 func SettingsDeleteAvatar(ctx *middleware.Context) {
-	os.Remove(ctx.User.CustomAvatarPath())
-
-	ctx.User.UseCustomAvatar = false
-	if err := models.UpdateUser(ctx.User); err != nil {
-		ctx.Flash.Error(fmt.Sprintf("UpdateUser: %v", err))
+	if err := ctx.User.DeleteAvatar(); err != nil {
+		ctx.Flash.Error(err.Error())
 	}
+
 	ctx.Redirect(setting.AppSubUrl + "/user/settings")
 }
 

--- a/templates/org/settings/options.tmpl
+++ b/templates/org/settings/options.tmpl
@@ -59,6 +59,7 @@
 
 						<div class="field">
 							<button class="ui green button">{{$.i18n.Tr "settings.update_avatar"}}</button>
+							<a class="ui red button delete-post" data-request-url="{{.Link}}/avatar/delete" data-done-url="{{.Link}}">{{$.i18n.Tr "settings.delete_current_avatar"}}</a>
 						</div>
 					</form>
 				</div>


### PR DESCRIPTION
Implements #2763.

I created a new DeleteAvatar() method in the User model. Both settings router (user and org) uses this method.

Because the 'Enable Custom Avatar' option is not present in the org's settings form, after deleting the org's avatar no new custom avatar is generated, the default Gravatar picture is displayed (https://secure.gravatar.com/avatar/?s=100). Does this needs a fix? May I include the option in the org's form too, or generate a random avatar after deleting the previous?
