### PR TITLE
Add the AddOrgMembership API endpoint

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -249,6 +249,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Group("/orgs/:orgname", func() {
 			m.Combo("").Get(org.Get).Patch(bind(api.EditOrgOption{}), org.Edit)
 			m.Combo("/teams").Get(org.ListTeams)
+			m.Put("/memberships/:username", bind(api.AddOrgMembershipOption{}), org.AddOrgMembership)
 		}, OrgAssignment(true))
 
 		m.Any("/*", func(ctx *context.Context) {

--- a/routers/api/v1/org/members.go
+++ b/routers/api/v1/org/members.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package org
+
+import (
+	api "github.com/gogits/go-gogs-client"
+
+	"github.com/gogits/gogs/modules/context"
+	"github.com/gogits/gogs/routers/api/v1/convert"
+	"github.com/gogits/gogs/routers/api/v1/user"
+)
+
+func AddOrgMembership(ctx *context.APIContext, form api.AddOrgMembershipOption) {
+	org := user.GetUserByParamsName(ctx, ":orgname")
+	member := user.GetUserByParamsName(ctx, ":username")
+	if ctx.Written() {
+		return
+	}
+
+	if !org.IsOwnedBy(ctx.User.Id) {
+		ctx.Status(403)
+		return
+	}
+
+	if err := org.AddMember(member.Id); err != nil {
+		ctx.Error(500, "AddMember", err)
+		return
+	}
+	if form.Role == "admin" {
+		team, err := org.GetOwnerTeam();
+		if err != nil {
+			ctx.Error(500, "GetOwnerTeam", err)
+			return
+		}
+		if err := team.AddMember(member.Id); err != nil {
+			ctx.Error(500, "AddMember", err)
+			return
+		}
+	}
+	ret := map[string]interface{} {
+		"organization": convert.ToOrganization(org),
+		"user": convert.ToUser(member),
+	}
+	ctx.JSON(200, ret)
+}


### PR DESCRIPTION
This adds a new API, `PUT /orgs/:orgname/memberships/:username`, based on https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership .

It allows adding the given username to the given organization. It also supports the "role" parameter, and adds the user to the owner team if given "admin".

Note that this is similar to #2577, but it follows the GitHub API Spec more closely, which I think is a plus.