### PR TITLE
Add AddCollaborator API Endpoint

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -234,7 +234,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 					m.Combo("/:id").Patch(bind(api.EditHookOption{}), repo.EditHook).
 						Delete(repo.DeleteHook)
 				})
-				m.Put("/collaborators/:collaborator", repo.AddCollaborator)
+				m.Put("/collaborators/:collaborator", bind(api.AddCollaboratorOption{}), repo.AddCollaborator)
 				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
 				m.Get("/archive/*", repo.GetArchive)
 				m.Group("/branches", func() {

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -234,6 +234,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 					m.Combo("/:id").Patch(bind(api.EditHookOption{}), repo.EditHook).
 						Delete(repo.DeleteHook)
 				})
+				m.Put("/collaborators/:collaborator", repo.AddCollaborator)
 				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
 				m.Get("/archive/*", repo.GetArchive)
 				m.Group("/branches", func() {

--- a/routers/api/v1/repo/collaborators.go
+++ b/routers/api/v1/repo/collaborators.go
@@ -1,0 +1,31 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package repo
+
+import (
+	"github.com/gogits/gogs/models"
+	"github.com/gogits/gogs/modules/middleware"
+)
+
+func AddCollaborator(ctx *middleware.Context) {
+	collaborator, err := models.GetUserByName(ctx.Params(":collaborator"))
+
+	if err != nil {
+		if models.IsErrUserNotExist(err) {
+			ctx.APIError(422, "", err)
+		} else {
+			ctx.APIError(500, "GetUserByName", err)
+		}
+		return
+	}
+
+	if err := ctx.Repo.Repository.AddCollaborator(collaborator); err != nil {
+		ctx.APIError(500, "AddCollaborator", err)
+		return
+	}
+
+	ctx.Status(204)
+	return
+}

--- a/routers/api/v1/repo/collaborators.go
+++ b/routers/api/v1/repo/collaborators.go
@@ -8,23 +8,23 @@ import (
 	api "github.com/gogits/go-gogs-client"
 
 	"github.com/gogits/gogs/models"
-	"github.com/gogits/gogs/modules/middleware"
+	"github.com/gogits/gogs/modules/context"
 )
 
-func AddCollaborator(ctx *middleware.Context, form api.AddCollaboratorOption) {
+func AddCollaborator(ctx *context.APIContext, form api.AddCollaboratorOption) {
 	collaborator, err := models.GetUserByName(ctx.Params(":collaborator"))
 
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
-			ctx.APIError(422, "", err)
+			ctx.Error(422, "", err)
 		} else {
-			ctx.APIError(500, "GetUserByName", err)
+			ctx.Error(500, "GetUserByName", err)
 		}
 		return
 	}
 
 	if err := ctx.Repo.Repository.AddCollaborator(collaborator); err != nil {
-		ctx.APIError(500, "AddCollaborator", err)
+		ctx.Error(500, "AddCollaborator", err)
 		return
 	}
 
@@ -36,11 +36,11 @@ func AddCollaborator(ctx *middleware.Context, form api.AddCollaboratorOption) {
 	} else if form.Permission != nil && *form.Permission == "admin" {
 		mode = models.ACCESS_MODE_ADMIN
 	} else if form.Permission != nil {
-		ctx.APIError(500, "Permission", "Invalid permission type")
+		ctx.Error(500, "Permission", "Invalid permission type")
 		return
 	}
 	if err := ctx.Repo.Repository.ChangeCollaborationAccessMode(collaborator.Id, mode); err != nil {
-		ctx.APIError(500, "ChangeCollaborationAccessMode", err)
+		ctx.Error(500, "ChangeCollaborationAccessMode", err)
 		return
 	}
 


### PR DESCRIPTION
Adds the `PUT /repos/:username/:reponame/collaborators/:collaborator` endpoint, based on https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator, allowing the API to add collaborators to a repository.

I messed up #2775 (it was opened on the wrong branch).

**EDIT**: now implements `permission` like github's api, taking one of three arguments, "pull", "push" or "admin".
I can squash into one commit if that is prefered.