### PR TITLE
Add MaxRepoCreation to EditUser API

### DIFF
--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -107,6 +107,9 @@ func EditUser(ctx *context.APIContext, form api.EditUserOption) {
 	if form.AllowImportLocal != nil {
 		u.AllowImportLocal = *form.AllowImportLocal
 	}
+	if form.MaxRepoCreation != nil {
+		u.MaxRepoCreation = *form.MaxRepoCreation
+	}
 
 	if err := models.UpdateUser(u); err != nil {
 		if models.IsErrEmailAlreadyUsed(err) {


### PR DESCRIPTION
Allows to edit the MaxRepoCreation of a user through the `PATCH /admin/users/:user` endpoint.

I messed up #2774  (it was opened on the wrong branch).