### PR TITLE
Improving issue and pull request templates.

### DIFF
--- a/routers/repo/issue.go
+++ b/routers/repo/issue.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Unknwon/com"
 	"github.com/Unknwon/paginater"
 
+	"github.com/gogits/git-module"
+
 	"github.com/gogits/gogs/models"
 	"github.com/gogits/gogs/modules/auth"
 	"github.com/gogits/gogs/modules/base"
@@ -38,17 +40,18 @@ const (
 	MILESTONE_NEW  base.TplName = "repo/issue/milestone_new"
 	MILESTONE_EDIT base.TplName = "repo/issue/milestone_edit"
 
-	ISSUE_TEMPLATE_KEY = "IssueTemplate"
+	ISSUE_TEMPLATE_KEY  = "IssueTemplate"
+	ISSUE_TEMPLATE_FILE = "ISSUE_TEMPLATE"
 )
 
 var (
 	ErrFileTypeForbidden = errors.New("File type is not allowed")
 	ErrTooManyFiles      = errors.New("Maximum number of files to upload exceeded")
 
-	IssueTemplateCandidates = []string{
-		"ISSUE_TEMPLATE.md",
-		".gogs/ISSUE_TEMPLATE.md",
-		".github/ISSUE_TEMPLATE.md",
+	IssueFolderCandidates = []string{
+		"/",
+		".gogs/",
+		".github/",
 	}
 )
 
@@ -288,9 +291,10 @@ func RetrieveRepoMetas(ctx *context.Context, repo *models.Repository) []*models.
 	return labels
 }
 
-func getFileContentFromDefaultBranch(ctx *context.Context, filename string) (string, bool) {
+func getFileContentFromDefaultBranch(ctx *context.Context, foldername string, filename string) (string, bool) {
 	var r io.Reader
 	var bytes []byte
+	var entries git.Entries
 
 	if ctx.Repo.Commit == nil {
 		var err error
@@ -300,24 +304,32 @@ func getFileContentFromDefaultBranch(ctx *context.Context, filename string) (str
 		}
 	}
 
-	entry, err := ctx.Repo.Commit.GetTreeEntryByPath(filename)
+	subtree, err := ctx.Repo.Commit.SubTree(foldername)
 	if err != nil {
 		return "", false
 	}
-	r, err = entry.Blob().Data()
-	if err != nil {
-		return "", false
+	filenameMd := filename + ".md"
+	entries, err = subtree.ListEntries()
+	for i := range entries {
+		entryName := entries[i].Name()
+		if strings.EqualFold(entryName, filename) || strings.EqualFold(entryName, filenameMd) {
+			r, err = entries[i].Blob().Data()
+			if err != nil {
+				return "", false
+			}
+			bytes, err = ioutil.ReadAll(r)
+			if err != nil {
+				return "", false
+			}
+			return string(bytes), true
+		}
 	}
-	bytes, err = ioutil.ReadAll(r)
-	if err != nil {
-		return "", false
-	}
-	return string(bytes), true
+	return "", false
 }
 
-func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleFiles []string) {
-	for _, filename := range possibleFiles {
-		content, found := getFileContentFromDefaultBranch(ctx, filename)
+func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleFolders []string, filename string) {
+	for _, folder := range possibleFolders {
+		content, found := getFileContentFromDefaultBranch(ctx, folder, filename)
 		if found {
 			ctx.Data[ctxDataKey] = content
 			return
@@ -328,7 +340,7 @@ func setTemplateIfExists(ctx *context.Context, ctxDataKey string, possibleFiles 
 func NewIssue(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.issues.new")
 	ctx.Data["PageIsIssueList"] = true
-	setTemplateIfExists(ctx, ISSUE_TEMPLATE_KEY, IssueTemplateCandidates)
+	setTemplateIfExists(ctx, ISSUE_TEMPLATE_KEY, IssueFolderCandidates, ISSUE_TEMPLATE_FILE)
 	renderAttachmentSettings(ctx)
 
 	RetrieveRepoMetas(ctx, ctx.Repo.Repository)

--- a/routers/repo/pull.go
+++ b/routers/repo/pull.go
@@ -28,14 +28,7 @@ const (
 	PULL_FILES   base.TplName = "repo/pulls/files"
 
 	PULL_REQUEST_TEMPLATE_KEY = "PullRequestTemplate"
-)
-
-var (
-	PullRequestTemplateCandidates = []string{
-		"PULL_REQUEST.md",
-		".gogs/PULL_REQUEST.md",
-		".github/PULL_REQUEST.md",
-	}
+	PULL_REQUEST_TEMPLATE_FILE = "PULL_REQUEST_TEMPLATE"
 )
 
 func getForkRepository(ctx *context.Context) *models.Repository {
@@ -578,7 +571,7 @@ func CompareAndPullRequest(ctx *context.Context) {
 	ctx.Data["PageIsComparePull"] = true
 	ctx.Data["IsDiffCompare"] = true
 	ctx.Data["RequireHighlightJS"] = true
-	setTemplateIfExists(ctx, PULL_REQUEST_TEMPLATE_KEY, PullRequestTemplateCandidates)
+	setTemplateIfExists(ctx, PULL_REQUEST_TEMPLATE_KEY, IssueFolderCandidates, PULL_REQUEST_TEMPLATE_FILE)
 	renderAttachmentSettings(ctx)
 
 	headUser, headRepo, headGitRepo, prInfo, baseBranch, headBranch := ParseCompareInfo(ctx)


### PR DESCRIPTION
This makes the behavior a bit more compliant with GitHub's:

- Case insensitive:

`ISSUE_TEMPLATE`, `issue_template`, etc. all work.

- Any extension:

The file can have any extension (.txt, .md, etc) or none.