### PR TITLE
Fix logging adapter changes

### DIFF
--- a/modules/log/log.go
+++ b/modules/log/log.go
@@ -26,7 +26,7 @@ func NewLogger(bufLen int64, mode, config string) {
 	for _, l := range loggers {
 		if l.adapter == mode {
 			isExist = true
-			l = logger
+			logger = l
 		}
 	}
 	if !isExist {


### PR DESCRIPTION
Fixes #2798

This allows `config.ini` to override logging levels for the console.