### PR TITLE
Update uses of updated and created

### DIFF
--- a/models/access.go
+++ b/models/access.go
@@ -110,7 +110,7 @@ func (u *User) GetAccessibleRepositories() ([]*Repository, error) {
 		repoIDs = append(repoIDs, access.RepoID)
 	}
 	repos := make([]*Repository, 0, len(repoIDs))
-	return repos, x.Where("owner_id != ?", u.Id).In("id", repoIDs).Desc("updated").Find(&repos)
+	return repos, x.Where("owner_id != ?", u.Id).In("id", repoIDs).Desc("updated_unix").Find(&repos)
 }
 
 func maxAccessMode(modes ...AccessMode) AccessMode {

--- a/models/issue.go
+++ b/models/issue.go
@@ -495,11 +495,11 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 
 	switch opts.SortType {
 	case "oldest":
-		sess.Asc("created")
+		sess.Asc("created_unix")
 	case "recentupdate":
-		sess.Desc("updated")
+		sess.Desc("updated_unix")
 	case "leastupdate":
-		sess.Asc("updated")
+		sess.Asc("updated_unix")
 	case "mostcomment":
 		sess.Desc("num_comments")
 	case "leastcomment":
@@ -507,7 +507,7 @@ func Issues(opts *IssuesOptions) ([]*Issue, error) {
 	case "priority":
 		sess.Desc("priority")
 	default:
-		sess.Desc("created")
+		sess.Desc("created_unix")
 	}
 
 	labelIDs := base.StringsToInt64s(strings.Split(opts.Labels, ","))

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -310,7 +310,7 @@ func GetCommentByID(id int64) (*Comment, error) {
 // GetCommentsByIssueID returns all comments of issue by given ID.
 func GetCommentsByIssueID(issueID int64) ([]*Comment, error) {
 	comments := make([]*Comment, 0, 10)
-	return comments, x.Where("issue_id=?", issueID).Asc("created").Find(&comments)
+	return comments, x.Where("issue_id=?", issueID).Asc("created_unix").Find(&comments)
 }
 
 // UpdateComment updates information of comment.

--- a/models/release.go
+++ b/models/release.go
@@ -131,7 +131,7 @@ func GetReleaseByID(id int64) (*Release, error) {
 
 // GetReleasesByRepoID returns a list of releases of repository.
 func GetReleasesByRepoID(repoID int64) (rels []*Release, err error) {
-	err = x.Desc("created").Find(&rels, Release{RepoID: repoID})
+	err = x.Desc("created_unix").Find(&rels, Release{RepoID: repoID})
 	return rels, err
 }
 

--- a/models/repo.go
+++ b/models/repo.go
@@ -1464,7 +1464,8 @@ func GetRepositoryByID(id int64) (*Repository, error) {
 // GetRepositories returns a list of repositories of given user.
 func GetRepositories(uid int64, private bool) ([]*Repository, error) {
 	repos := make([]*Repository, 0, 10)
-	sess := x.Desc("updated")
+	sess := x.Desc("updated_unix")
+
 	if !private {
 		sess.Where("is_private=?", false)
 	}
@@ -1475,7 +1476,7 @@ func GetRepositories(uid int64, private bool) ([]*Repository, error) {
 // GetRecentUpdatedRepositories returns the list of repositories that are recently updated.
 func GetRecentUpdatedRepositories(page int) (repos []*Repository, err error) {
 	return repos, x.Limit(setting.ExplorePagingNum, (page-1)*setting.ExplorePagingNum).
-		Where("is_private=?", false).Limit(setting.ExplorePagingNum).Desc("updated").Find(&repos)
+		Where("is_private=?", false).Limit(setting.ExplorePagingNum).Desc("updated_unix").Find(&repos)
 }
 
 func getRepositoryCount(e Engine, u *User) (int64, error) {

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -34,7 +34,7 @@ func MustBeNotBare(ctx *middleware.Context) {
 }
 
 func checkContextUser(ctx *middleware.Context, uid int64) *models.User {
-	orgs, err := models.GetOwnedOrgsByUserIDDesc(ctx.User.Id, "updated")
+	orgs, err := models.GetOwnedOrgsByUserIDDesc(ctx.User.Id, "updated_unix")
 	if err != nil {
 		ctx.Handle(500, "GetOwnedOrgsByUserIDDesc", err)
 		return nil


### PR DESCRIPTION
Using mysql/5.7.11 and a new installation from deploy branch 5267dce21023802818b0c0c16ba2ca47c146e1b5 , various pages show error page 500.

Navigating to the dashboard will give:

```
.routers/user/home.go:123 Dashboard()] [E] GetRepositories: Error 1054: Unknown column 'updated' in 'order clause'
```

To reproduce:

1. Pull the latest develop branch (5267dce21023802818b0c0c16ba2ca47c146e1b5)
1. Create a new database
1. Install, configure gogs, login as user
1.  Try to navigate to the dashboard

I've investigated a bit and found a change was introduced in ad513a20e939691828ba415c9a565e8ff3daa95f that migrated all `updated` and `created` fields to `updated_unix` and `created_unix`.

Checking out a commit before ad513a, gogs will work without issues.

On clean databases the original fields (updated, created) do not exist.
Renaming the fields makes the page load.

I've read the contributing guide but please let me know if I missed something.
