### PR TITLE
Set HTML meta values corresponding to repository

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -3,8 +3,8 @@
 <head data-suburl="{{AppSubUrl}}">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-	<meta name="author" content="Gogs - Go Git Service" />
-	<meta name="description" content="Gogs (Go Git Service) is a painless self-hosted Git service written in Go" />
+	<meta name="author" content="{{if .Repository }}{{.Owner.Name}}{{else}}Gogs - Go Git Service{{end}}" />
+	<meta name="description" content="{{if .Repository }}{{.Repository.Name}} - {{.Repository.Description}}{{else}}Gogs (Go Git Service) is a painless self-hosted Git service written in Go{{end}}" />
 	<meta name="keywords" content="go, git, self-hosted, gogs">
 	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />


### PR DESCRIPTION
Use the authors name, and the description of the repo in HTML meta.
Pages without repository context will display as before. This implements #2670.