### PR TITLE
Set description meta tag correctly

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -3,19 +3,8 @@
 <head data-suburl="{{AppSubUrl}}">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-	<meta name="author" content="
-	{{- if .Repository -}}
-		{{.Owner.Name}}
-	{{- else -}}
-		Gogs - Go Git Service
-	{{- end}}" />
-	<meta name="description" content="
-	{{- if.Repository -}}
-		{{.Repository.Name}}
-		{{- if .Repository.Description}} - {{.Repository.Description}}{{end}}
-	{{- else -}}
-		Gogs (Go Git Service) is a painless self-hosted Git service written in Go
-	{{- end}}" />
+    <meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}Gogs - Go Git Service{{end}}" />
+	<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}Gogs (Go Git Service) is a painless self-hosted Git service written in Go{{end}}" />
 	<meta name="keywords" content="go, git, self-hosted, gogs">
 	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -3,7 +3,7 @@
 <head data-suburl="{{AppSubUrl}}">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}Gogs - Go Git Service{{end}}" />
+	<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}Gogs - Go Git Service{{end}}" />
 	<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}Gogs (Go Git Service) is a painless self-hosted Git service written in Go{{end}}" />
 	<meta name="keywords" content="go, git, self-hosted, gogs">
 	<meta name="referrer" content="no-referrer" />

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -3,8 +3,19 @@
 <head data-suburl="{{AppSubUrl}}">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-	<meta name="author" content="{{if .Repository }}{{.Owner.Name}}{{else}}Gogs - Go Git Service{{end}}" />
-	<meta name="description" content="{{if .Repository }}{{.Repository.Name}} - {{.Repository.Description}}{{else}}Gogs (Go Git Service) is a painless self-hosted Git service written in Go{{end}}" />
+	<meta name="author" content="
+	{{- if .Repository -}}
+		{{.Owner.Name}}
+	{{- else -}}
+		Gogs - Go Git Service
+	{{- end}}" />
+	<meta name="description" content="
+	{{- if.Repository -}}
+		{{.Repository.Name}}
+		{{- if .Repository.Description}} - {{.Repository.Description}}{{end}}
+	{{- else -}}
+		Gogs (Go Git Service) is a painless self-hosted Git service written in Go
+	{{- end}}" />
 	<meta name="keywords" content="go, git, self-hosted, gogs">
 	<meta name="referrer" content="no-referrer" />
 	<meta name="_csrf" content="{{.CsrfToken}}" />


### PR DESCRIPTION
Set the description meta tag correctly when there is no repo
description. Also use the  ability to trim trailing whitespaces,
to make the template cleaner.

This cleans up the current code, and fixes [moltam's](https://github.com/moltam) comment in #2670.