### PR TITLE
Make user search look in username, name and email

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -1142,7 +1142,6 @@ func SearchUserByName(opts *SearchUserOptions) (users []*User, _ int64, _ error)
 	// Append conditions
 	sess := x.Where("lower_name like ?", searchQuery).
 		Or("full_name like ?", searchQuery).
-		Or("email like ?", searchQuery).
 		And("type = ?", opts.Type)
 
 	var countSess xorm.Session

--- a/models/user.go
+++ b/models/user.go
@@ -1137,9 +1137,13 @@ func SearchUserByName(opts *SearchUserOptions) (users []*User, _ int64, _ error)
 		opts.Page = 1
 	}
 
+	searchQuery := "%" + opts.Keyword + "%"
 	users = make([]*User, 0, opts.PageSize)
 	// Append conditions
-	sess := x.Where("lower_name like ?", "%"+opts.Keyword+"%").And("type = ?", opts.Type)
+	sess := x.Where("lower_name like ?", searchQuery).
+		Or("full_name like ?", searchQuery).
+		Or("email like ?", searchQuery).
+		And("type = ?", opts.Type)
 
 	var countSess xorm.Session
 	countSess = *sess


### PR DESCRIPTION
Make user search function look in username (lower_name), full name
(full_name) and primary email (email). This will benefit searching after
user in "explore", admin panel and when adding new collaborators.

As i see it, there are no security issues regarding searching for the primary email and full name. Both are already a part of the users public profile.

This implements #2814, but somehow also #2792.