### PR TITLE
Fix relative links in markdown files

### DIFF
--- a/modules/markdown/markdown.go
+++ b/modules/markdown/markdown.go
@@ -357,7 +357,7 @@ OUTER_LOOP:
 
 // Render renders Markdown to HTML with special links.
 func Render(rawBytes []byte, urlPrefix string, metas map[string]string) []byte {
-	urlPrefix = bytes.Replace(urlPrefix, spaceBytes, spaceEncodedBytes, -1)
+	urlPrefix = bytes.Replace(urlPrefix, string(spaceBytes), string(spaceEncodedBytes), -1)
 	result := RenderRaw(rawBytes, urlPrefix)
 	result = PostProcess(result, urlPrefix, metas)
 	result = Sanitizer.SanitizeBytes(result)

--- a/modules/markdown/markdown.go
+++ b/modules/markdown/markdown.go
@@ -357,6 +357,7 @@ OUTER_LOOP:
 
 // Render renders Markdown to HTML with special links.
 func Render(rawBytes []byte, urlPrefix string, metas map[string]string) []byte {
+	urlPrefix = bytes.Replace(urlPrefix, spaceBytes, spaceEncodedBytes, -1)
 	result := RenderRaw(rawBytes, urlPrefix)
 	result = PostProcess(result, urlPrefix, metas)
 	result = Sanitizer.SanitizeBytes(result)


### PR DESCRIPTION
Replace spaces with "%20" in "urlPrefix", before markdown processing.
The spaces were causing blackfriday (markdown processor) to behave
strange. This fixes #2545.