### PR TITLE
Display org member's full name in link title.

### DIFF
--- a/templates/org/home.tmpl
+++ b/templates/org/home.tmpl
@@ -47,7 +47,7 @@
 					{{$isMember := .IsOrganizationMember}}
 					{{range .Members}}
 						{{if or $isMember (.IsPublicMember $.Org.Id)}}
-							<a href="{{.HomeLink}}" title="{{.Name}}"><img class="ui avatar" src="{{.AvatarLink}}"></a>
+							<a href="{{.HomeLink}}" title="{{.Name}}{{if .FullName}} ({{.FullName}}){{end}}"><img class="ui avatar" src="{{.AvatarLink}}"></a>
 						{{end}}
 					{{end}}
 				</div>


### PR DESCRIPTION
![org-avatar](https://cloud.githubusercontent.com/assets/4578365/13828780/affae862-ebc3-11e5-8ab2-f29e63e7bb23.png)

Implements #2841.
