### PR TITLE
Add support for .diff and .patch

### DIFF
--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -195,7 +195,19 @@ func Diff(ctx *context.Context) {
 }
 
 func RawDiff(ctx *context.Context) {
-	panic("not implemented")
+	userName := ctx.Repo.Owner.Name
+	repoName := ctx.Repo.Repository.Name
+	commitID := ctx.Params(":sha")
+	diffType := ctx.Params(":ext")
+
+	diff, err := models.GetRawDiff(models.RepoPath(userName, repoName),
+		commitID, diffType)
+	if err != nil {
+		ctx.Handle(404, "GetRawDiff", err)
+		return
+	}
+	ctx.HandleText(200, diff)
+
 }
 
 func CompareDiff(ctx *context.Context) {


### PR DESCRIPTION
Add the ability to get text-diff and format-patch by adding .diff or
.patch in the end of a commit url. Issue #2641

With the current behavior with the wildcard in the route, this is the only solution i see. There are probably more elegant ways to solve the problem, but that will require some rethinking. What is your opinion @Unknwon?

And "maxlines", that should not have any impact on this..?