### PR TITLE
use monospace font for wiki and issue textareas (fix #2869)

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1506,6 +1506,7 @@ footer .container .links > *:first-child {
 }
 .repository.view.issue .comment-list .comment .ui.form textarea {
   height: 200px;
+  font-family: "Consolas", monospace;
 }
 .repository.view.issue .comment-list .comment .edit.buttons {
   margin-top: 10px;
@@ -1587,6 +1588,7 @@ footer .container .links > *:first-child {
 }
 .repository .comment.form .content textarea {
   height: 200px;
+  font-family: "Consolas", monospace;
 }
 .repository .label.list {
   list-style: none;
@@ -1965,6 +1967,9 @@ footer .container .links > *:first-child {
 }
 .repository.wiki.start .ui.segment .mega-octicon {
   font-size: 48px;
+}
+.repository.wiki.new .CodeMirror .CodeMirror-code {
+  font-family: "Consolas", monospace;
 }
 .repository.wiki.new .CodeMirror .CodeMirror-code .cm-comment {
   background: inherit;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -70,8 +70,8 @@
 		}
 	}
 	.header-wrapper {
-		background-color: #FAFAFA; 
-		margin-top: -15px; 
+		background-color: #FAFAFA;
+		margin-top: -15px;
 		padding-top: 15px;
 
 		.ui.tabs.divider {
@@ -281,7 +281,7 @@
 				#avatar-arrow;
 				&:after {
 					border-right-color: #fff;
-				}				
+				}
 				.markdown {
 					font-size: 14px;
 				}
@@ -456,6 +456,7 @@
 					}
 					textarea {
 						height: 200px;
+						font-family: "Consolas", monospace;
 					}
 				}
 
@@ -531,6 +532,7 @@
 			}
 			textarea {
 				height: 200px;
+                font-family: "Consolas", monospace;
 			}
 		}
 	}
@@ -992,8 +994,11 @@
 
 		&.new {
 			.CodeMirror {
-				.CodeMirror-code .cm-comment {
-					background: inherit;
+				.CodeMirror-code {
+					font-family: "Consolas", monospace;
+					.cm-comment {
+						background: inherit;
+					}
 				}
 			}
 
@@ -1302,7 +1307,7 @@
 		border-right-color: #D4D4D5;
 		border-width: 9px;
 		margin-top: -9px;
-	}	
+	}
 	&:after {
 		border-right-color: #f7f7f7;
 		border-width: 8px;


### PR DESCRIPTION
Using a monospace font, makes editing easier (e.g. tables, code).
![new wiki page](https://cloud.githubusercontent.com/assets/576555/13985822/33169c7e-f0ff-11e5-9b7c-3948f0f01b77.png)

![new issue](https://cloud.githubusercontent.com/assets/576555/13985834/4257ed32-f0ff-11e5-9b6e-9f4c4aea96ca.png)
