### PR TITLE
Reduce line number creation to one DOM manipulation

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1043,10 +1043,14 @@ $(window).load(function () {
         var $num_list = $('.code-view .lines-num');
 
         // Building blocks.
+        var $toappendblock = [];
+        var $toappendnum_list = [];
         for (var i = 0; i < lines.length; i++) {
-            $block.append('<li class="L' + (i + 1) + '" rel="L' + (i + 1) + '">' + lines[i] + '</li>');
-            $num_list.append('<span id="L' + (i + 1) + '">' + (i + 1) + '</span>');
+            $toappendblock.push('<li class="L' + (i + 1) + '" rel="L' + (i + 1) + '">' + lines[i] + '</li>');
+            $toappendnum_list.push('<span id="L' + (i + 1) + '">' + (i + 1) + '</span>');
         }
+        $block.append($toappendblock.join(''));
+        $num_list.append($toappendnum_list.join(''));
 
         $(document).on('click', '.lines-num span', function (e) {
             var $select = $(this);


### PR DESCRIPTION
I noticed that there was a large delay when loading a file in the web interface before the line numbers displayed. This PR does not remove the delay, but it does improve it slightly.

This PR reduces the on load event handler time from ~700-900ms to ~70-90ms.

To verify my timings:
Use the Chrome developer tools "Timeline", reload the page. Mouseover the 'load' Event to see the timing.

Note that I am seeing a lot of fluctuation in the timings between refresh, but my changes are consistently <100ms, and the original is consistently >700ms