### PR TITLE
Update ISC license

### DIFF
--- a/conf/license/ISC license
+++ b/conf/license/ISC license
@@ -1,6 +1,5 @@
 ISC License:
-Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC") 
-Copyright (c) 1995-2003 by Internet Software Consortium
+Copyright (c) Year(s), Company or Person's Name
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
New one from Wikipedia and https://opensource.org/licenses/ISC.
I think the original one is for code owned by the Internet Systems Consortium.