### PR TITLE
Update Docker documentation about container options

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -73,9 +73,27 @@ Most of settings are obvious and easy to understand, but there are some settings
 
 Full documentation of application settings can be found [here](http://gogs.io/docs/advanced/configuration_cheat_sheet.html).
 
-### Crond
+### Container options
 
-Please set environment variable `RUN_CROND` to be `true` or `1` in order to start `crond` inside the container.
+This container have some options available via environment variables, these options are opt-in features that can help the administration of this container:
+
+- **SOCAT_LINK**:
+  - <u>Possible value:</u>
+      `true`, `false`, `1`, `0`
+  - <u>Default:</u>
+      `true`
+  - <u>Action:</u>
+      Bind linked docker container to localhost socket using socat.
+      Any exported port from a linked container will be binded to the matching port on localhost.
+  - <u>Disclaimer:</u>
+      As this option rely on the environment variable created by docker when a container is linked, this option should be deactivated in managed environment such as Rancher or Kubernetes (set to `0` or `false`)
+- **RUN_CROND**:
+  - <u>Possible value:</u>
+      `true`, `false`, `1`, `0`
+  - <u>Default:</u>
+      `false`
+  - <u>Action:</u>
+      Request crond to be run inside the container. Its default configuration will periodically run all scripts from `/etc/periodic/${period}` but custom crontabs can be added to `/var/spool/cron/crontabs/`.
 
 ## Upgrade
 


### PR DESCRIPTION
As request in [discuss](https://discuss.gogs.io/t/document-socat-link-and-its-relevance-with-kubernetes/228), i've updated the docker documentation to include more information about our container options such as `SOCAT_LINK`:
- Created a `Container options` section in `docker/README.md`
- Added documentation for `SOCAT_LINK`
- Moved `RUN_CROND` documentation to this new section