### PR TITLE
getEngine() now handles DB parameters (#2972)

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -97,14 +97,18 @@ func LoadConfigs() {
 
 func getEngine() (*xorm.Engine, error) {
 	cnnstr := ""
+	var Param string = "?"
+	if strings.Contains(DbCfg.Name,Param) {
+		Param="&"
+	}
 	switch DbCfg.Type {
 	case "mysql":
 		if DbCfg.Host[0] == '/' { // looks like a unix socket
-			cnnstr = fmt.Sprintf("%s:%s@unix(%s)/%s?charset=utf8&parseTime=true",
-				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name)
+			cnnstr = fmt.Sprintf("%s:%s@unix(%s)/%s%scharset=utf8&parseTime=true",
+				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name, Param)
 		} else {
-			cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8&parseTime=true",
-				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name)
+			cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s%scharset=utf8&parseTime=true",
+				DbCfg.User, DbCfg.Passwd, DbCfg.Host, DbCfg.Name, Param)
 		}
 	case "postgres":
 		var host, port = "127.0.0.1", "5432"
@@ -115,8 +119,8 @@ func getEngine() (*xorm.Engine, error) {
 		if len(fields) > 1 && len(strings.TrimSpace(fields[1])) > 0 {
 			port = fields[1]
 		}
-		cnnstr = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-			url.QueryEscape(DbCfg.User), url.QueryEscape(DbCfg.Passwd), host, port, DbCfg.Name, DbCfg.SSLMode)
+		cnnstr = fmt.Sprintf("postgres://%s:%s@%s:%s/%s%ssslmode=%s",
+			url.QueryEscape(DbCfg.User), url.QueryEscape(DbCfg.Passwd), host, port, DbCfg.Name, Param, DbCfg.SSLMode)
 	case "sqlite3":
 		if !EnableSQLite3 {
 			return nil, fmt.Errorf("Unknown database type: %s", DbCfg.Type)


### PR DESCRIPTION
For reference, Issue #2972. 

Beforehand, any DSN parameters on MySQL or Postgres databases would cause an error due to the concatenated strings not checking if parameters already exists. 

getEngine() now checks for existing parameters and correctly address the additional strings being concatenated for the databases according to whether a parameter exists. User may enter `database name` with or without parameters now. 

This helps for certain databases that require specific configurations, such as MySQL databases using `old_passwords=1` with the `allowOldPasswords=1` argument being passed to the DSN. 
