### PR TITLE
Fixes #2669: Allows alphanumeric issue style for external issue tracker links

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -576,6 +576,9 @@ settings.external_wiki_url_desc = Visitors will be redirected to URL when they c
 settings.issues_desc = Enable builtin lightweight issue tracker
 settings.use_external_issue_tracker = Use external issue tracker
 settings.tracker_url_format = External Issue Tracker URL Format
+settings.tracker_issue_style = External Issue Tracker Naming Style:
+settings.tracker_issue_style.numeric = Numeric <span class="ui light grey text">(1234)</span>
+settings.tracker_issue_style.alphanumeric = Alphanumeric <span class="ui light grey text">(ABC-123, DEFG-234, ...)</span>
 settings.tracker_url_format_desc = You can use placeholder <code>{user} {repo} {index}</code> for user name, repository name and issue index.
 settings.pulls_desc = Enable pull requests to accept public contributions
 settings.danger_zone = Danger Zone

--- a/models/repo.go
+++ b/models/repo.go
@@ -170,6 +170,7 @@ type Repository struct {
 	EnableIssues          bool `xorm:"NOT NULL DEFAULT true"`
 	EnableExternalTracker bool
 	ExternalTrackerFormat string
+	ExternalTrackerStyle  string
 	ExternalMetas         map[string]string `xorm:"-"`
 	EnablePulls           bool              `xorm:"NOT NULL DEFAULT true"`
 
@@ -254,6 +255,13 @@ func (repo *Repository) ComposeMetas() map[string]string {
 			"user":   repo.MustOwner().Name,
 			"repo":   repo.Name,
 		}
+		switch repo.ExternalTrackerStyle {
+		case markdown.ISSUE_NAME_STYLE_ALPHANUMERIC:
+			repo.ExternalMetas["style"] = markdown.ISSUE_NAME_STYLE_ALPHANUMERIC
+		default:
+			repo.ExternalMetas["style"] = markdown.ISSUE_NAME_STYLE_NUMERIC
+		}
+
 	}
 	return repo.ExternalMetas
 }

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -1,0 +1,62 @@
+package models_test
+
+import (
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+	. "github.com/gogits/gogs/models"
+
+	"github.com/gogits/gogs/modules/markdown"
+)
+
+func TestRepo(t *testing.T) {
+	Convey("The metas map", t, func () {
+		var repo = new(Repository)
+		repo.Name = "testrepo"
+		repo.Owner = new(User)
+		repo.Owner.Name = "testuser"
+		repo.ExternalTrackerFormat = "https://someurl.com/{user}/{repo}/{issue}"
+
+		Convey("When no external tracker is configured", func () {
+			Convey("It should be nil", func () {
+				repo.EnableExternalTracker = false
+				So(repo.ComposeMetas(), ShouldEqual, map[string]string(nil))
+			})
+			Convey("It should be nil even if other settings are present", func () {
+				repo.EnableExternalTracker = false
+				repo.ExternalTrackerFormat = "http://someurl.com/{user}/{repo}/{issue}"
+				repo.ExternalTrackerStyle = markdown.ISSUE_NAME_STYLE_NUMERIC
+				So(repo.ComposeMetas(), ShouldEqual, map[string]string(nil))
+			})
+		})
+
+		Convey("When an external issue tracker is configured", func () {
+			repo.EnableExternalTracker = true
+			Convey("It should default to numeric issue style", func () {
+				metas := repo.ComposeMetas()
+				So(metas["style"], ShouldEqual, markdown.ISSUE_NAME_STYLE_NUMERIC)
+			})
+			Convey("It should pass through numeric issue style setting", func () {
+				repo.ExternalTrackerStyle = markdown.ISSUE_NAME_STYLE_NUMERIC
+				metas := repo.ComposeMetas()
+				So(metas["style"], ShouldEqual, markdown.ISSUE_NAME_STYLE_NUMERIC)
+			})
+			Convey("It should pass through alphanumeric issue style setting", func () {
+				repo.ExternalTrackerStyle = markdown.ISSUE_NAME_STYLE_ALPHANUMERIC
+				metas := repo.ComposeMetas()
+				So(metas["style"], ShouldEqual, markdown.ISSUE_NAME_STYLE_ALPHANUMERIC)
+			})
+			Convey("It should contain the user name", func () {
+				metas := repo.ComposeMetas()
+				So(metas["user"], ShouldEqual, "testuser")
+			})
+			Convey("It should contain the repo name", func () {
+				metas := repo.ComposeMetas()
+				So(metas["repo"], ShouldEqual, "testrepo")
+			})
+			Convey("It should contain the URL format", func () {
+				metas := repo.ComposeMetas()
+				So(metas["format"], ShouldEqual, "https://someurl.com/{user}/{repo}/{issue}")
+			})
+		})
+	})
+}

--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -96,6 +96,7 @@ type RepoSettingForm struct {
 	EnableIssues          bool
 	EnableExternalTracker bool
 	TrackerURLFormat      string
+	TrackerIssueStyle     string
 	EnablePulls           bool
 }
 

--- a/modules/markdown/markdown_test.go
+++ b/modules/markdown/markdown_test.go
@@ -1,0 +1,236 @@
+package markdown_test
+
+import (
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+	. "github.com/gogits/gogs/modules/markdown"
+
+	"github.com/gogits/gogs/modules/setting"
+)
+
+func TestMarkdown(t *testing.T) {
+	var (
+		urlPrefix = "/prefix"
+		metas map[string]string = nil
+	)
+	setting.AppSubUrlDepth = 0
+
+	Convey("Rendering an issue link", t, func () {
+		Convey("To the internal issue tracker", func () {
+			Convey("It should not render anything when there are no issues", func () {
+				testCases := []string {
+					"",
+					"this is a test",
+					"test 123 123 1234",
+					"#",
+					"# # #",
+					"# 123",
+					"#abcd",
+					"##1234",
+					"test#1234",
+					"#1234test",
+					" test #1234test",
+				}
+
+				for i := 0; i < len(testCases); i++ {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i])
+				}
+			})
+			Convey("It should render freestanding issue mentions", func () {
+				testCases := []string {
+					"#1234 test", "<a href=\"/prefix/issues/1234\">#1234</a> test",
+					"test #1234 issue", "test <a href=\"/prefix/issues/1234\">#1234</a> issue",
+					"test issue #1234", "test issue <a href=\"/prefix/issues/1234\">#1234</a>",
+					"#5 test", "<a href=\"/prefix/issues/5\">#5</a> test",
+					"test #5 issue", "test <a href=\"/prefix/issues/5\">#5</a> issue",
+					"test issue #5", "test issue <a href=\"/prefix/issues/5\">#5</a>",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should not render issue without leading space", func () {
+				input := []byte("test#54321 issue")
+				expected := "test#54321 issue"
+				So(string(RenderIssueIndexPattern(input, urlPrefix, metas)), ShouldEqual, expected)
+			})
+			Convey("It should not render issue without trailing space", func () {
+				input := []byte("test #54321issue")
+				expected := "test #54321issue"
+				So(string(RenderIssueIndexPattern(input, urlPrefix, metas)), ShouldEqual, expected)
+			})
+			Convey("It should render issue in parentheses", func () {
+				testCases := []string {
+					"(#54321 issue)", "(<a href=\"/prefix/issues/54321\">#54321</a> issue)",
+					"test (#54321) issue", "test (<a href=\"/prefix/issues/54321\">#54321</a>) issue",
+					"test (#54321 extra) issue", "test (<a href=\"/prefix/issues/54321\">#54321</a> extra) issue",
+					"test (#54321 issue)", "test (<a href=\"/prefix/issues/54321\">#54321</a> issue)",
+					"test (#54321)", "test (<a href=\"/prefix/issues/54321\">#54321</a>)",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should render multiple issues in the same line", func () {
+				testCases := []string {
+					"#54321 #1243", "<a href=\"/prefix/issues/54321\">#54321</a> <a href=\"/prefix/issues/1243\">#1243</a>",
+					"test #54321 #1243", "test <a href=\"/prefix/issues/54321\">#54321</a> <a href=\"/prefix/issues/1243\">#1243</a>",
+					"(#54321 #1243)", "(<a href=\"/prefix/issues/54321\">#54321</a> <a href=\"/prefix/issues/1243\">#1243</a>)",
+					"(#54321)(#1243)", "(<a href=\"/prefix/issues/54321\">#54321</a>)(<a href=\"/prefix/issues/1243\">#1243</a>)",
+					"text #54321 test #1243 issue", "text <a href=\"/prefix/issues/54321\">#54321</a> test <a href=\"/prefix/issues/1243\">#1243</a> issue",
+					"#1 (#4321) test", "<a href=\"/prefix/issues/1\">#1</a> (<a href=\"/prefix/issues/4321\">#4321</a>) test",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+		})
+		Convey("To an external issue tracker with numeric style", func () {
+			metas = make(map[string]string)
+			metas["format"] = "https://someurl.com/{user}/{repo}/{index}"
+			metas["user"] = "someuser"
+			metas["repo"] = "somerepo"
+			metas["style"] = ISSUE_NAME_STYLE_NUMERIC
+
+			Convey("should not render anything when there are no issues", func () {
+				testCases := []string {
+					"this is a test",
+					"test 123 123 1234",
+					"#",
+					"# # #",
+					"# 123",
+					"#abcd",
+				}
+
+				for i := 0; i < len(testCases); i++ {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i])
+				}
+			})
+			Convey("It should render freestanding issue", func () {
+				testCases := []string {
+					"#1234 test", "<a href=\"https://someurl.com/someuser/somerepo/1234\">#1234</a> test",
+					"test #1234 issue", "test <a href=\"https://someurl.com/someuser/somerepo/1234\">#1234</a> issue",
+					"test issue #1234", "test issue <a href=\"https://someurl.com/someuser/somerepo/1234\">#1234</a>",
+					"#5 test", "<a href=\"https://someurl.com/someuser/somerepo/5\">#5</a> test",
+					"test #5 issue", "test <a href=\"https://someurl.com/someuser/somerepo/5\">#5</a> issue",
+					"test issue #5", "test issue <a href=\"https://someurl.com/someuser/somerepo/5\">#5</a>",
+				}
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should not render issue mention without leading space", func () {
+				input := []byte("test#54321 issue")
+				expected := "test#54321 issue"
+				So(string(RenderIssueIndexPattern(input, urlPrefix, metas)), ShouldEqual, expected)
+			})
+			Convey("It should not render issue mention without trailing space", func () {
+				input := []byte("test #54321issue")
+				expected := "test #54321issue"
+				So(string(RenderIssueIndexPattern(input, urlPrefix, metas)), ShouldEqual, expected)
+			})
+			Convey("It should render mention in parentheses", func () {
+				testCases := []string {
+					"(#54321 issue)", "(<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> issue)",
+					"test (#54321) issue", "test (<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a>) issue",
+					"test (#54321 extra) issue", "test (<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> extra) issue",
+					"test (#54321 issue)", "test (<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> issue)",
+					"test (#54321)", "test (<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a>)",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should render multiple mentions in the same line", func () {
+				testCases := []string {
+					"#54321 #1243", "<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> <a href=\"https://someurl.com/someuser/somerepo/1243\">#1243</a>",
+					"test #54321 #1243", "test <a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> <a href=\"https://someurl.com/someuser/somerepo/1243\">#1243</a>",
+					"(#54321 #1243)", "(<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> <a href=\"https://someurl.com/someuser/somerepo/1243\">#1243</a>)",
+					"(#54321)(#1243)", "(<a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a>)(<a href=\"https://someurl.com/someuser/somerepo/1243\">#1243</a>)",
+					"text #54321 test #1243 issue", "text <a href=\"https://someurl.com/someuser/somerepo/54321\">#54321</a> test <a href=\"https://someurl.com/someuser/somerepo/1243\">#1243</a> issue",
+					"#1 (#4321) test", "<a href=\"https://someurl.com/someuser/somerepo/1\">#1</a> (<a href=\"https://someurl.com/someuser/somerepo/4321\">#4321</a>) test",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+		})
+		Convey("To an external issue tracker with alphanumeric style", func () {
+			metas = make(map[string]string)
+			metas["format"] = "https://someurl.com/{user}/{repo}/?b={index}"
+			metas["user"] = "someuser"
+			metas["repo"] = "somerepo"
+			metas["style"] = ISSUE_NAME_STYLE_ALPHANUMERIC
+			Convey("It should not render anything when there are no issues", func () {
+				testCases := []string {
+					"",
+					"this is a test",
+					"test 123 123 1234",
+					"#",
+					"##1234",
+					"# 123",
+					"#abcd",
+					"test #123",
+					"abc-1234", // issue prefix must be capital
+					"ABc-1234", // issue prefix must be _all_ capital
+					"ABCDEFGHIJK-1234", // the limit is 10 characters in the prefix
+					"ABC1234", // dash is required
+					"test ABC- test", // number is required
+					"test -1234 test", // prefix is required
+					"testABC-123 test", // leading space is required
+					"test ABC-123test", // trailing space is required
+					"ABC-0123", // no leading zero
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i])
+				}
+			})
+			Convey("It should render freestanding issue", func () {
+				testCases := []string {
+					"OTT-1234 test", "<a href=\"https://someurl.com/someuser/somerepo/?b=OTT-1234\">OTT-1234</a> test",
+					"test T-12 issue", "test <a href=\"https://someurl.com/someuser/somerepo/?b=T-12\">T-12</a> issue",
+					"test issue ABCDEFGHIJ-1234567890", "test issue <a href=\"https://someurl.com/someuser/somerepo/?b=ABCDEFGHIJ-1234567890\">ABCDEFGHIJ-1234567890</a>",
+					"A-1 test", "<a href=\"https://someurl.com/someuser/somerepo/?b=A-1\">A-1</a> test",
+					"test ZED-1 issue", "test <a href=\"https://someurl.com/someuser/somerepo/?b=ZED-1\">ZED-1</a> issue",
+					"test issue DEED-7154", "test issue <a href=\"https://someurl.com/someuser/somerepo/?b=DEED-7154\">DEED-7154</a>",
+				}
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should render mention in parentheses", func () {
+				testCases := []string {
+					"(ABG-124 issue)", "(<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> issue)",
+					"test (ABG-124) issue", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>) issue",
+					"test (ABG-124 extra) issue", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> extra) issue",
+					"test (ABG-124 issue)", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> issue)",
+					"test (ABG-124)", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>)",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should render multiple mentions in the same line", func () {
+				testCases := []string {
+					"ABG-124 OTT-4321", "<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> <a href=\"https://someurl.com/someuser/somerepo/?b=OTT-4321\">OTT-4321</a>",
+					"test ABG-124 OTT-4321", "test <a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> <a href=\"https://someurl.com/someuser/somerepo/?b=OTT-4321\">OTT-4321</a>",
+					"(ABG-124 OTT-4321)", "(<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> <a href=\"https://someurl.com/someuser/somerepo/?b=OTT-4321\">OTT-4321</a>)",
+					"(ABG-124)(OTT-4321)", "(<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>)(<a href=\"https://someurl.com/someuser/somerepo/?b=OTT-4321\">OTT-4321</a>)",
+					"text ABG-124 test OTT-4321 issue", "text <a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> test <a href=\"https://someurl.com/someuser/somerepo/?b=OTT-4321\">OTT-4321</a> issue",
+					"A-1 (RRE-345) test", "<a href=\"https://someurl.com/someuser/somerepo/?b=A-1\">A-1</a> (<a href=\"https://someurl.com/someuser/somerepo/?b=RRE-345\">RRE-345</a>) test",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+		})
+	})
+}

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -130,6 +130,7 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 		repo.EnableIssues = form.EnableIssues
 		repo.EnableExternalTracker = form.EnableExternalTracker
 		repo.ExternalTrackerFormat = form.TrackerURLFormat
+		repo.ExternalTrackerStyle = form.TrackerIssueStyle
 		repo.EnablePulls = form.EnablePulls
 
 		if err := models.UpdateRepository(repo, false); err != nil {

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -116,6 +116,21 @@
 							<input id="tracker_url_format" name="tracker_url_format" type="url" value="{{.Repository.ExternalTrackerFormat}}" placeholder="e.g. https://github.com/{user}/{repo}/issues/{index}">
 							<p class="help">{{.i18n.Tr "repo.settings.tracker_url_format_desc" | Str2html}}</p>
 						</div>
+						<div class="inline fields">
+							<label for="issue_style">{{.i18n.Tr "repo.settings.tracker_issue_style"}}</label>
+							<div class="field">
+								<div class="ui radio checkbox">
+									<input class="hidden" tabindex="0" name="tracker_issue_style" type="radio" value="numeric"  {{if eq .Repository.ExternalTrackerStyle "numeric"}}checked=""{{end}}/>
+									<label>{{.i18n.Tr "repo.settings.tracker_issue_style.numeric" | Safe}}</label>
+								</div>
+							</div>
+							<div class="field">
+								<div class="ui radio checkbox">
+									<input class="hidden" tabindex="0" name="tracker_issue_style" type="radio" value="alphanumeric"  {{if eq .Repository.ExternalTrackerStyle "alphanumeric"}}checked=""{{end}}/>
+									<label>{{.i18n.Tr "repo.settings.tracker_issue_style.alphanumeric" | Safe}}</label>
+								</div>
+							</div>
+						</div>
 
 						{{if .Repository.CanEnablePulls}}
 							<div class="ui divider"></div>


### PR DESCRIPTION
Allow to use alphanumeric issue mentions (e.g. ABC-1234) for external links.  This works specifically with JIRA and Bloodhound.