### PR TITLE
init script call gogs with wrong params

### DIFF
--- a/scripts/init/centos/gogs
+++ b/scripts/init/centos/gogs
@@ -49,7 +49,7 @@ DAEMON_OPTS="--check $NAME"
 start() {
   cd ${GOGS_HOME}
   echo -n "Starting ${SERVICENAME}: "
-  daemon $DAEMON_OPTS "${GOGS_PATH} web > ${LOGFILE} 2>&1 &"
+  daemon $DAEMON_OPTS "${GOGS_PATH} run web > ${LOGFILE} 2>&1 &"
   RETVAL=$?
   echo
   [ $RETVAL = 0 ] && touch ${LOCKFILE}


### PR DESCRIPTION
we should run gogs like
```
gogs run web
```

instead of
```
gogs web
```

Otherwise we would get error like below in log file.
```
[rh@CloudY gogs]# gogs web
Usage:
  gogs run COMMAND [options]
  gogs scale TYPE=NUM
  gogs logs [--tail|-n NUMBER]
  gogs config:get VAR
  gogs config:set VAR=VALUE
  gogs configure
  gogs reconfigure
```