### PR TITLE
Add DPlatform as an installation way

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ There are 5 ways to install Gogs:
 - [Sandstorm](https://github.com/cem/gogs-sandstorm)
 - [sloppy.io](https://github.com/sloppyio/quickstarters/tree/master/gogs)
 - [YunoHost](https://github.com/mbugeia/gogs_ynh)
+- [DPlatform](https://github.com/j8r/DPlatform)
 
 ## Software and Service Support
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -68,6 +68,7 @@ Gogs 的目标是打造一个最简单、最快速和最轻松的方式搭建自
 - [Sandstorm](https://github.com/cem/gogs-sandstorm)
 - [sloppy.io](https://github.com/sloppyio/quickstarters/tree/master/gogs)
 - [YunoHost](https://github.com/mbugeia/gogs_ynh)
+- [DPlatform](https://github.com/j8r/DPlatform)
 
 ## 软件及服务支持
 


### PR DESCRIPTION
Hello, i'm the creator of [DPlatform](https://github.com/j8r/DPlatform), that aims to make it easy to install self-hosted applications.
I really like your Git service, so I added its support to my project.
I would like to add a link to it on your main page, so that other people can easily install Gogs on their Linux servers.