### PR TITLE
Added Units for repo, access and team. First step of three on #3027.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ gogs.sublime-project
 gogs.sublime-workspace
 /release
 vendor
+.vscode

--- a/models/access.go
+++ b/models/access.go
@@ -55,6 +55,7 @@ type Access struct {
 	UserID int64 `xorm:"UNIQUE(s)"`
 	RepoID int64 `xorm:"UNIQUE(s)"`
 	Mode   AccessMode
+	Units  []UnitType `xorm:"json"`
 }
 
 func accessLevel(e Engine, u *User, repo *Repository) (AccessMode, error) {

--- a/models/access.go
+++ b/models/access.go
@@ -167,6 +167,7 @@ func (repo *Repository) refreshAccesses(e Engine, accessMap map[int64]AccessMode
 			UserID: userID,
 			RepoID: repo.ID,
 			Mode:   mode,
+			Units:  UnitTypes,
 		})
 	}
 

--- a/models/migrations.go
+++ b/models/migrations.go
@@ -69,15 +69,15 @@ type Version struct {
 // If you want to "retire" a migration, remove it from the top of the list and
 // update _MIN_VER_DB accordingly
 var migrations = []Migration{
-	NewMigration("fix locale file load panic", fixLocaleFileLoadPanic),                     // V4 -> V5:v0.6.0
-	NewMigration("trim action compare URL prefix", trimCommitActionAppUrlPrefix),           // V5 -> V6:v0.6.3
-	NewMigration("generate issue-label from issue", issueToIssueLabel),                     // V6 -> V7:v0.6.4
-	NewMigration("refactor attachment table", attachmentRefactor),                          // V7 -> V8:v0.6.4
-	NewMigration("rename pull request fields", renamePullRequestFields),                    // V8 -> V9:v0.6.16
-	NewMigration("clean up migrate repo info", cleanUpMigrateRepoInfo),                     // V9 -> V10:v0.6.20
-	NewMigration("generate rands and salt for organizations", generateOrgRandsAndSalt),     // V10 -> V11:v0.8.5
-	NewMigration("convert date to unix timestamp", convertDateToUnix),                      // V11 -> V12:v0.9.2
-	NewMigration("add plugins for repo, team and access tables", addPluginsToTables, true), // V12 -> V13:v0.9.23
+	NewMigration("fix locale file load panic", fixLocaleFileLoadPanic),                 // V4 -> V5:v0.6.0
+	NewMigration("trim action compare URL prefix", trimCommitActionAppUrlPrefix),       // V5 -> V6:v0.6.3
+	NewMigration("generate issue-label from issue", issueToIssueLabel),                 // V6 -> V7:v0.6.4
+	NewMigration("refactor attachment table", attachmentRefactor),                      // V7 -> V8:v0.6.4
+	NewMigration("rename pull request fields", renamePullRequestFields),                // V8 -> V9:v0.6.16
+	NewMigration("clean up migrate repo info", cleanUpMigrateRepoInfo),                 // V9 -> V10:v0.6.20
+	NewMigration("generate rands and salt for organizations", generateOrgRandsAndSalt), // V10 -> V11:v0.8.5
+	NewMigration("convert date to unix timestamp", convertDateToUnix),                  // V11 -> V12:v0.9.2
+	NewMigration("add units for repo, team and access tables", addUnitsToTables, true), // V12 -> V13:v0.9.23
 }
 
 // Migrate database to current version
@@ -680,7 +680,7 @@ func convertDateToUnix(x *xorm.Engine) (err error) {
 	return nil
 }
 
-func addPluginsToTables(x *xorm.Engine) error {
+func addUnitsToTables(x *xorm.Engine) error {
 	if _, err := x.Update(&Access{
 		Units: UnitTypes,
 	}); err != nil {

--- a/models/migrations.go
+++ b/models/migrations.go
@@ -682,19 +682,19 @@ func convertDateToUnix(x *xorm.Engine) (err error) {
 
 func addPluginsToTables(x *xorm.Engine) error {
 	if _, err := x.Update(&Access{
-		Units: unitTypes,
+		Units: UnitTypes,
 	}); err != nil {
 		return err
 	}
 
 	if _, err := x.Update(&Team{
-		Units: unitTypes,
+		Units: UnitTypes,
 	}); err != nil {
 		return err
 	}
 
 	if _, err := x.Update(&Repository{
-		Units: unitTypes,
+		Units: UnitTypes,
 	}); err != nil {
 		return err
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-xorm/xorm"
 	_ "github.com/lib/pq"
 
-	"github.com/gogits/gogs/models/migrations"
 	"github.com/gogits/gogs/modules/setting"
 )
 
@@ -176,12 +175,16 @@ func NewEngine() (err error) {
 		return err
 	}
 
-	if err = migrations.Migrate(x); err != nil {
-		return fmt.Errorf("migrate: %v", err)
+	if err = Migrate(x, false); err != nil {
+		return fmt.Errorf("migrates before sync: %v", err)
 	}
 
 	if err = x.StoreEngine("InnoDB").Sync2(tables...); err != nil {
 		return fmt.Errorf("sync database struct error: %v\n", err)
+	}
+
+	if err = Migrate(x, true); err != nil {
+		return fmt.Errorf("migrates after sync: %v", err)
 	}
 
 	return nil

--- a/models/org.go
+++ b/models/org.go
@@ -142,6 +142,7 @@ func CreateOrganization(org, owner *User) (err error) {
 		Name:       OWNER_TEAM,
 		Authorize:  ACCESS_MODE_OWNER,
 		NumMembers: 1,
+		Units:      UnitTypes,
 	}
 	if _, err = sess.Insert(t); err != nil {
 		return fmt.Errorf("insert owner team: %v", err)

--- a/models/org_team.go
+++ b/models/org_team.go
@@ -24,6 +24,7 @@ type Team struct {
 	Members     []*User       `xorm:"-"`
 	NumRepos    int
 	NumMembers  int
+	Units       []UnitType `xorm:"json"`
 }
 
 // IsOwnerTeam returns true if team is owner team.

--- a/models/repo.go
+++ b/models/repo.go
@@ -1012,6 +1012,7 @@ func CreateRepository(u *User, opts CreateRepoOptions) (_ *Repository, err error
 		EnableWiki:   true,
 		EnableIssues: true,
 		EnablePulls:  true,
+		Units:        UnitTypes,
 	}
 
 	sess := x.NewSession()
@@ -2058,6 +2059,7 @@ func ForkRepository(u *User, oldRepo *Repository, name, desc string) (_ *Reposit
 		IsPrivate:     oldRepo.IsPrivate,
 		IsFork:        true,
 		ForkID:        oldRepo.ID,
+		Units:         oldRepo.Units,
 	}
 
 	sess := x.NewSession()

--- a/models/repo.go
+++ b/models/repo.go
@@ -174,6 +174,8 @@ type Repository struct {
 	ExternalMetas         map[string]string `xorm:"-"`
 	EnablePulls           bool              `xorm:"NOT NULL DEFAULT true"`
 
+	Units []UnitType `xorm:"json"` // repos's units, so let's remove EnableWiki, EnableIssues, EnablePulls after all are ready
+
 	IsFork   bool `xorm:"NOT NULL DEFAULT false"`
 	ForkID   int64
 	BaseRepo *Repository `xorm:"-"`
@@ -182,6 +184,15 @@ type Repository struct {
 	CreatedUnix int64
 	Updated     time.Time `xorm:"-"`
 	UpdatedUnix int64
+}
+
+func (repo *Repository) UnitEnabled(unitKey string) bool {
+	for _, tp := range repo.Units {
+		if Units[tp].NameKey == unitKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (repo *Repository) BeforeInsert() {

--- a/models/unit.go
+++ b/models/unit.go
@@ -73,7 +73,7 @@ var (
 		},
 	}
 
-	unitTypes = []UnitType{
+	UnitTypes = []UnitType{
 		UnitCode,
 		UnitIssues,
 		UnitPRs,

--- a/models/unit.go
+++ b/models/unit.go
@@ -1,0 +1,85 @@
+package models
+
+type UnitType int
+
+const (
+	UnitCode UnitType = iota
+	UnitIssues
+	UnitPRs
+	UnitCommits
+	UnitReleases
+	UnitWiki
+	UnitSettings
+)
+
+type Unit struct {
+	UnitType
+	NameKey string
+	Uri     string
+	DescKey string
+	Idx     int
+}
+
+var (
+	Units = map[UnitType]Unit{
+		UnitCode: {
+			UnitCode,
+			"repo.code",
+			"/",
+			"repo.code_desc",
+			0,
+		},
+		UnitIssues: {
+			UnitIssues,
+			"repo.issues",
+			"/issues",
+			"repo.issues_desc",
+			1,
+		},
+		UnitPRs: {
+			UnitPRs,
+			"repo.pulls",
+			"/pulls",
+			"repo.pulls_desc",
+			2,
+		},
+		UnitCommits: {
+			UnitCommits,
+			"repo.commits",
+			"/commits/master",
+			"repo.commits_desc",
+			3,
+		},
+		UnitReleases: {
+			UnitReleases,
+			"repo.releases",
+			"/releases",
+			"repo.releases_desc",
+			4,
+		},
+		UnitWiki: {
+			UnitWiki,
+			"repo.wiki",
+			"/wiki",
+			"repo.wiki_desc",
+			5,
+		},
+		UnitSettings: {
+			UnitSettings,
+			"repo.settings",
+			"/settings",
+			"repo.settings_desc",
+			6,
+		},
+	}
+
+	unitTypes = []UnitType{
+		UnitCode,
+		UnitIssues,
+		UnitPRs,
+		UnitCommits,
+		UnitReleases,
+		UnitWiki,
+		UnitSettings,
+	}
+)

--- a/routers/api/v1/admin/org_team.go
+++ b/routers/api/v1/admin/org_team.go
@@ -19,6 +19,7 @@ func CreateTeam(ctx *context.APIContext, form api.CreateTeamOption) {
 		Name:        form.Name,
 		Description: form.Description,
 		Authorize:   models.ParseAccessMode(form.Permission),
+		Units:       models.UnitTypes,
 	}
 	if err := models.NewTeam(team); err != nil {
 		if models.IsErrTeamAlreadyExist(err) {

--- a/routers/org/teams.go
+++ b/routers/org/teams.go
@@ -159,6 +159,7 @@ func NewTeamPost(ctx *context.Context, form auth.CreateTeamForm) {
 		Name:        form.TeamName,
 		Description: form.Description,
 		Authorize:   models.ParseAccessMode(form.Permission),
+		Units:       models.UnitTypes,
 	}
 	ctx.Data["Team"] = t
 

--- a/routers/repo/setting.go
+++ b/routers/repo/setting.go
@@ -124,14 +124,29 @@ func SettingsPost(ctx *context.Context, form auth.RepoSettingForm) {
 		ctx.Redirect(repo.RepoLink() + "/settings")
 
 	case "advanced":
+		repo.Units = []models.UnitType{
+			models.UnitCode,
+			models.UnitCommits,
+			models.UnitReleases,
+			models.UnitSettings,
+		}
 		repo.EnableWiki = form.EnableWiki
+		if form.EnableWiki {
+			repo.Units = append(repo.Units, models.UnitWiki)
+		}
 		repo.EnableExternalWiki = form.EnableExternalWiki
 		repo.ExternalWikiURL = form.ExternalWikiURL
 		repo.EnableIssues = form.EnableIssues
+		if form.EnableIssues {
+			repo.Units = append(repo.Units, models.UnitIssues)
+		}
 		repo.EnableExternalTracker = form.EnableExternalTracker
 		repo.ExternalTrackerFormat = form.TrackerURLFormat
 		repo.ExternalTrackerStyle = form.TrackerIssueStyle
 		repo.EnablePulls = form.EnablePulls
+		if form.EnablePulls {
+			repo.Units = append(repo.Units, models.UnitPRs)
+		}
 
 		if err := models.UpdateRepository(repo, false); err != nil {
 			ctx.Handle(500, "UpdateRepository", err)

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -49,36 +49,56 @@
 {{if not (or .IsBareRepo .IsDiffCompare)}}
 	<div class="ui tabs container">
 		<div class="ui tabular menu navbar">
+			{{if .Repository.UnitEnabled "repo.code"}}
 			<a class="{{if .PageIsViewCode}}active{{end}} item" href="{{.RepoLink}}">
 				<i class="icon octicon octicon-code"></i> {{.i18n.Tr "repo.code"}}
 			</a>
-			{{if .Repository.EnableIssues}}
-				<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
-					<i class="icon octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
-				</a>
 			{{end}}
-			{{if .Repository.AllowsPulls}}
-				<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
-					<i class="icon octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
-				</a>
+
+			{{if .Repository.UnitEnabled "repo.issues"}}
+				{{if .Repository.EnableIssues}}
+					<a class="{{if .PageIsIssueList}}active{{end}} item" href="{{.RepoLink}}/issues">
+						<i class="icon octicon octicon-issue-opened"></i> {{.i18n.Tr "repo.issues"}} <span class="ui {{if not .Repository.NumOpenIssues}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenIssues}}</span>
+					</a>
+				{{end}}
 			{{end}}
+			
+			{{if .Repository.UnitEnabled "repo.pulls"}}
+				{{if .Repository.AllowsPulls}}
+					<a class="{{if .PageIsPullList}}active{{end}} item" href="{{.RepoLink}}/pulls">
+						<i class="icon octicon octicon-git-pull-request"></i> {{.i18n.Tr "repo.pulls"}} <span class="ui {{if not .Repository.NumOpenPulls}}gray{{else}}blue{{end}} small label">{{.Repository.NumOpenPulls}}</span>
+					</a>
+				{{end}}
+			{{end}}
+
+			{{if .Repository.UnitEnabled "repo.commits"}}
 			<a class="{{if (or (.PageIsCommits) (.PageIsDiff))}}active{{end}} item" href="{{.RepoLink}}/commits/{{EscapePound .BranchName}}">
 				<i class="icon octicon octicon-history"></i> {{.i18n.Tr "repo.commits"}} <span class="ui {{if not .CommitsCount}}gray{{else}}blue{{end}} small label">{{.CommitsCount}}</span>
 			</a>
+			{{end}}
+			
+			{{if .Repository.UnitEnabled "repo.releases"}}
 			<a class="{{if .PageIsReleaseList}}active{{end}} item" href="{{.RepoLink}}/releases">
 				<i class="icon octicon octicon-tag"></i> {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .Repository.NumTags}}gray{{else}}blue{{end}} small label">{{.Repository.NumTags}}</span>
 			</a>
-			{{if .Repository.EnableWiki}}
-				<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki">
-					<i class="icon octicon octicon-book"></i> {{.i18n.Tr "repo.wiki"}}
-				</a>
 			{{end}}
-			{{if .IsRepositoryAdmin}}
-				<div class="right menu">
-					<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
-						<i class="icon octicon octicon-tools"></i> {{.i18n.Tr "repo.settings"}}
+
+			{{if .Repository.UnitEnabled "repo.wiki"}}
+				{{if .Repository.EnableWiki}}
+					<a class="{{if .PageIsWiki}}active{{end}} item" href="{{.RepoLink}}/wiki">
+						<i class="icon octicon octicon-book"></i> {{.i18n.Tr "repo.wiki"}}
 					</a>
-				</div>
+				{{end}}
+			{{end}}
+
+			{{if .Repository.UnitEnabled "repo.settings"}}
+				{{if .IsRepositoryAdmin}}
+					<div class="right menu">
+						<a class="{{if .PageIsSettings}}active{{end}} item" href="{{.RepoLink}}/settings">
+							<i class="icon octicon octicon-tools"></i> {{.i18n.Tr "repo.settings"}}
+						</a>
+					</div>
+				{{end}}
 			{{end}}
 		</div>
 	</div>


### PR DESCRIPTION
For the first step of #3027, we added units for repository, access and team. And it's completely compatible with old repos. And there are no any changes on User's UI.

The second, we can change repo's settings page to let user to choose which units admin to want. Code, Issues,  Pulls, Commits, Releases, Wiki, Settings. So the repos' home page will dynamically show the units according the repo's settings.

The last step, we will change repo's access and team's access page to dynamically show the units according the user's access.