### PR TITLE
  change  setting.go -> LocalUrl default value  to MustString(string(Protocol) + "://localhost:" + HttpPort + "/")

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -331,7 +331,7 @@ func NewContext() {
 	Domain = sec.Key("DOMAIN").MustString("localhost")
 	HttpAddr = sec.Key("HTTP_ADDR").MustString("0.0.0.0")
 	HttpPort = sec.Key("HTTP_PORT").MustString("3000")
-	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString("http://localhost:" + HttpPort + "/")
+	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(string(Protocol) + "://localhost:" + HttpPort + "/")
 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(workDir)


### PR DESCRIPTION
change  setting.go -> LocalUrl  value default to  `sec.Key("LOCAL_ROOT_URL").MustString(Protocol + HttpAddr + HttpPort + "/") `  

###  when lost to congfig the app.ini file, if user use https protocol , webhook can not work !

issue #3077  

https://github.com/gogits/gogs/wiki/Contributing-Code

