### PR TITLE
Update docker/build.sh script to use glide & make

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
 .git
 .git/**
-conf
-conf/**
 packager
 packager/**
 scripts
@@ -9,13 +7,13 @@ scripts/**
 .github/
 .github/**
 config.codekit
-LICENSE
-Makefile
 .dockerignore
 *.yml
 *.md
 .bra.toml
 .editorconfig
 .gitignore
-.gopmfile
 Dockerfile*
+vendor
+vendor/**
+gogs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 MAINTAINER jp@roemer.im
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
  && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 MAINTAINER jp@roemer.im
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
  && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat
 

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -2,7 +2,7 @@ FROM hypriot/rpi-alpine-scratch:v3.2
 MAINTAINER jp@roemer.im, raxetul@gmail.com
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-armhf /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/main/"      | tee /etc/apk/repositories    \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -2,7 +2,7 @@ FROM hypriot/rpi-alpine-scratch:v3.2
 MAINTAINER jp@roemer.im, raxetul@gmail.com
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-armhf /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.8/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/main/"      | tee /etc/apk/repositories    \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -2,7 +2,7 @@ FROM hypriot/rpi-alpine-scratch:v3.2
 MAINTAINER jp@roemer.im, raxetul@gmail.com
 
 # Install system utils & Gogs runtime dependencies
-ADD https://github.com/tianon/gosu/releases/download/1.8/gosu-armhf /usr/sbin/gosu
+ADD https://github.com/tianon/gosu/releases/download/1.7/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/main/"      | tee /etc/apk/repositories    \
  && echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,19 +5,26 @@ set -e
 # Set temp environment vars
 export GOPATH=/tmp/go
 export PATH=${PATH}:${GOPATH}/bin
+export GO15VENDOREXPERIMENT=1
 
 # Install build deps
-apk --no-cache --no-progress add --virtual build-deps linux-pam-dev go gcc musl-dev
+apk --no-cache --no-progress add --virtual build-deps build-base linux-pam-dev go
 
-# Init go environment to build Gogs
+# Install glide
+git clone -b 0.10.2 https://github.com/Masterminds/glide ${GOPATH}/src/github.com/Masterminds/glide
+cd ${GOPATH}/src/github.com/Masterminds/glide
+make build
+go install
+
+# Build Gogs
 mkdir -p ${GOPATH}/src/github.com/gogits/
 ln -s /app/gogs/ ${GOPATH}/src/github.com/gogits/gogs
 cd ${GOPATH}/src/github.com/gogits/gogs
-go get -v -tags "sqlite cert pam"
-go build -tags "sqlite cert pam"
+glide install
+make build TAGS="sqlite cert pam"
 
-# Cleanup GOPATH
-rm -r $GOPATH
+# Cleanup GOPATH & vendoring dir
+rm -r $GOPATH /app/gogs/vendor
 
 # Remove build deps
 apk --no-progress del build-deps

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,6 +16,8 @@ cd ${GOPATH}/src/github.com/Masterminds/glide
 make build
 go install
 
+
+
 # Build Gogs
 mkdir -p ${GOPATH}/src/github.com/gogits/
 ln -s /app/gogs/ ${GOPATH}/src/github.com/gogits/gogs


### PR DESCRIPTION
- docker/build.sh will now use glide to fetch dependencies
- glide is built from source to keep compatibility with arm (no pre-prebuilt binary for arm)
- docker/build.sh will also now use the provided Makefile. 
  It will generate an error when trying to get git build hash as we do
  not ship the 88mo .git directory during the build (should not cause
  any problem as the variable it sets was not set previously)
- Updated gosu to 1.9 in `Dockerfile` & `Dockerfile.rpi`
- Tested on OSX (Docker for Mac), Raspberry Pi 2 (ArchLinux) and Raspberry Pi 3 (HypriotOS / Raspbian Jessie)