### PR TITLE
Added webkit-font-smoothing

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -8,6 +8,7 @@ body {
   font-family: "Helvetica Neue", "Meiryo Ui", "Microsoft YaHei", Arial, Helvetica, sans-serif !important;
   background-color: #fff;
   overflow-y: scroll;
+  -webkit-font-smoothing: antialiased;
 }
 img {
   border-radius: 3px;


### PR DESCRIPTION
Here I've added webkit font smoothing to make it look nicer on Mac's

Before:
![](https://files.deanpcmad.com/2016/Screen-Shot-2016-05-13-21-13-43-ZpJeZKTwoq.png)

After:
![](https://files.deanpcmad.com/2016/Screen-Shot-2016-05-13-21-14-40-v84EZFpqRM.png)