### PR TITLE
Fixes #2407 View diff file on submodule gives a 404 page

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -160,6 +160,7 @@ type DiffFile struct {
 	IsDeleted          bool
 	IsBin              bool
 	IsRenamed          bool
+	IsSubmodule        bool
 	Sections           []*DiffSection
 	IsIncomplete       bool
 }
@@ -306,7 +307,7 @@ func ParsePatch(maxLines, maxLineCharacteres, maxFiles int, reader io.Reader) (*
 			}
 			curFileLinesCount = 0
 
-			// Check file diff type.
+			// Check file diff type and is submodule.
 			for {
 				line, err := input.ReadString('\n')
 				if err != nil {
@@ -333,6 +334,9 @@ func ParsePatch(maxLines, maxLineCharacteres, maxFiles int, reader io.Reader) (*
 					curFile.Name = b
 				}
 				if curFile.Type > 0 {
+					if strings.HasSuffix(line, " 160000\n") {
+						curFile.IsSubmodule = true
+					}
 					break
 				}
 			}

--- a/templates/repo/diff_box.tmpl
+++ b/templates/repo/diff_box.tmpl
@@ -68,13 +68,15 @@
 						{{end}}
 					</div>
 					<span class="file">{{if $file.IsRenamed}}{{$file.OldName}} &rarr; {{end}}{{$file.Name}}</span>
-					<div class="ui right">
-						{{if $file.IsDeleted}}
-							<a class="ui basic tiny button" rel="nofollow" href="{{EscapePound $.BeforeSourcePath}}/{{EscapePound .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
-						{{else}}
-							<a class="ui basic tiny button" rel="nofollow" href="{{EscapePound $.SourcePath}}/{{EscapePound .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
-						{{end}}
-					</div>
+					{{if not $file.IsSubmodule}}
+						<div class="ui right">
+							{{if $file.IsDeleted}}
+								<a class="ui basic tiny button" rel="nofollow" href="{{EscapePound $.BeforeSourcePath}}/{{EscapePound .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+							{{else}}
+								<a class="ui basic tiny button" rel="nofollow" href="{{EscapePound $.SourcePath}}/{{EscapePound .Name}}">{{$.i18n.Tr "repo.diff.view_file"}}</a>
+							{{end}}
+						</div>
+					{{end}}
 				</h4>
 				<div class="ui attached table segment">
 					{{if not $file.IsRenamed}}


### PR DESCRIPTION
Git determines submodules as files with file mode 160000. I retreived the file mode from git output and added appropriate field `IsSubmodule` to `DiffFile` struct. Also I disabled view file button on UI for submodules like on github