### PR TITLE
Add ServerName to tls.Config in LDAP auth

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -213,6 +213,7 @@ func ldapDial(ls *Source) (*ldap.Conn, error) {
 	if ls.UseSSL {
 		log.Debug("Using TLS for LDAP without verifying: %v", ls.SkipVerify)
 		return ldap.DialTLS("tcp", fmt.Sprintf("%s:%d", ls.Host, ls.Port), &tls.Config{
+			ServerName:         ls.Host,
 			InsecureSkipVerify: ls.SkipVerify,
 		})
 	} else {


### PR DESCRIPTION
From https://godoc.org/crypto/tls#Config

    ServerName is used to verify the hostname on the returned
    certificates unless InsecureSkipVerify is given. It is also included
    in the client's handshake to support virtual hosting unless it is
    an IP address.

This is needed for certificate validation without InsecureSkipVerify.