### PR TITLE
Fixes #3116 - Add YAML support for viewing markdown

### DIFF
--- a/modules/yaml/yaml.go
+++ b/modules/yaml/yaml.go
@@ -1,0 +1,90 @@
+// Copyright 2014 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package yaml
+
+import (
+	"fmt"
+	"strings"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+)
+
+func renderHtmlTable(m yaml.MapSlice) string {
+	var thead, tbody string
+	var mi yaml.MapItem
+	for _, mi = range m {
+		key := mi.Key
+		value := mi.Value
+
+		if  key != nil && reflect.TypeOf(key).String() == "yaml.MapSlice" {
+			key = renderHtmlTable(key.(yaml.MapSlice))
+		}
+		thead += fmt.Sprintf("<th>%v</th>", key)
+
+		if value != nil && reflect.TypeOf(value).String() == "yaml.MapSlice" {
+			value = renderHtmlTable(value.(yaml.MapSlice))
+		}
+		tbody += fmt.Sprintf("<td>%v</td>", value)
+	}
+
+	table := ""
+	if len(thead) > 0 {
+		table = fmt.Sprintf(`<table data="yaml-metadata"><thead><tr>%s</tr></thead><tbody><tr>%s</tr></table>`, thead, tbody)
+	}
+	return table
+}
+
+func RenderYamlHtmlTable(data []byte) []byte {
+	m := yaml.MapSlice{}
+
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return []byte("")
+	}
+
+	return []byte(renderHtmlTable(m))
+}
+
+func StripYamlFromText(data []byte) []byte {
+	m := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return data
+	}
+
+	lines := strings.Split(string(data), "\r\n")
+	if len(lines) == 1 {
+		lines = strings.Split(string(data), "\n")
+	}
+	if len(lines) < 1 || lines[0] != "---" {
+		return data
+	}
+	body := ""
+	atBody := false
+	for i, line := range lines {
+		if i == 0 {
+			continue
+		}
+		if line == "---" {
+			atBody = true
+		} else if atBody {
+			body += line+"\n"
+		}
+	}
+	return []byte(body)
+}
+
+// RenderString renders any YAML section (top of file, denoted by --- on first line and end of YAML)
+// into an HTML table and appends ready of the text after
+func Render(rawBytes []byte) []byte {
+	htmlTable := RenderYamlHtmlTable(rawBytes)
+	body := StripYamlFromText(rawBytes)
+	return append(htmlTable, body...)
+}
+
+// Renders the YAML and text as a string
+func RenderString(rawBytes []byte) string {
+	return string(Render(rawBytes))
+}
+

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2691,3 +2691,28 @@ footer .ui.language .menu {
 .ui.user.list .item .description a:hover {
   text-decoration: underline;
 }
+.markdown-body table {
+  display: block;
+  width: 100%;
+  overflow: auto;
+  word-break: keep-all;
+}
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+table[data-table-type="yaml-metadata"] {
+  font-size: 12px;
+  line-height: 1;
+}
+.markdown-body table tr {
+  background-color: #fff;
+  border-top: 1px solid #ccc;
+}
+.markdown-body table th, .markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #ddd;
+}
+.markdown-body table th {
+  font-weight: bold;
+}
+

--- a/routers/api/v1/misc/markdown.go
+++ b/routers/api/v1/misc/markdown.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogits/gogs/modules/context"
 	"github.com/gogits/gogs/modules/markdown"
+	"github.com/gogits/gogs/modules/yaml"
 )
 
 // https://github.com/gogits/go-gogs-client/wiki/Miscellaneous#render-an-arbitrary-markdown-document
@@ -23,12 +24,15 @@ func Markdown(ctx *context.APIContext, form api.MarkdownOption) {
 		return
 	}
 
+	var yamlHtml, markdownBody []byte
+	yamlHtml = yaml.RenderYamlHtmlTable([]byte(form.Text))
 	switch form.Mode {
 	case "gfm":
-		ctx.Write(markdown.Render([]byte(form.Text), form.Context, nil))
+		markdownBody = markdown.Render(yaml.StripYamlFromText([]byte(form.Text)), form.Context, nil)
 	default:
-		ctx.Write(markdown.RenderRaw([]byte(form.Text), ""))
+		markdownBody = markdown.RenderRaw([]byte(form.Text), "")
 	}
+	ctx.Write(append(yamlHtml, markdownBody...))
 }
 
 // https://github.com/gogits/go-gogs-client/wiki/Miscellaneous#render-a-markdown-document-in-raw-mode

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogits/gogs/modules/markdown"
 	"github.com/gogits/gogs/modules/template"
 	"github.com/gogits/gogs/modules/template/highlight"
+	"github.com/gogits/gogs/modules/yaml"
 )
 
 const (
@@ -105,7 +106,9 @@ func Home(ctx *context.Context) {
 				readmeExist := markdown.IsMarkdownFile(blob.Name()) || markdown.IsReadmeFile(blob.Name())
 				ctx.Data["ReadmeExist"] = readmeExist
 				if readmeExist {
-					ctx.Data["FileContent"] = string(markdown.Render(buf, path.Dir(treeLink), ctx.Repo.Repository.ComposeMetas()))
+					yamlHtml := yaml.RenderYamlHtmlTable(buf)
+					markdownBody := markdown.Render(yaml.StripYamlFromText(buf), path.Dir(treeLink), ctx.Repo.Repository.ComposeMetas())
+					ctx.Data["FileContent"] = string(append(yamlHtml, markdownBody...))
 				} else {
 					if err, content := template.ToUtf8WithErr(buf); err != nil {
 						if err != nil {

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -26,7 +26,9 @@
 	<div class="ui attached table segment">
 		<div class="file-view {{if .ReadmeExist}}markdown{{else if .IsFileText}}code-view{{end}} has-emoji">
 			{{if .ReadmeExist}}
+				<article class="markdown-body" itemprop="text">
 				{{if .FileContent}}{{.FileContent | Str2html}}{{end}}
+				</article>
 			{{else if not .IsFileText}}
 				<div class="view-raw ui center">
 					{{if .IsImageFile}}


### PR DESCRIPTION
Adds support for YAML data at top of Markdown file

Github allows for YAML at the top of a Markdown to be displayed in an HTML
table when viewing the file. This adds that ability to Gogs.

Example:

```
---
language: en
module: translation_checking
author: Jim Smith
version: 1.2
---
# Translation Checking
## How to check

This is the text
```

This can easily be done with the go-yaml parser, which knows how to find the YAML and make a map from it.

See: https://github.com/blog/1647-viewing-yaml-metadata-in-your-documents
Example on Github:
https://github.com/unfoldingWord/unfoldingWord.github.io/blob/master/pages/content/tn.md
Imports: https://github.com/go-yaml/yaml