### PR TITLE
add user DisplayName in mail From when notifying on issue

### DIFF
--- a/modules/mailer/mail.go
+++ b/modules/mailer/mail.go
@@ -126,11 +126,12 @@ func SendIssueNotifyMail(u, owner *models.User, repo *models.Repository, issue *
 		return tos, nil
 	}
 
+	from := fmt.Sprintf("\"%s\" <%s>", u.DisplayName(), setting.MailService.From)
 	subject := fmt.Sprintf("[%s] %s (#%d)", repo.Name, issue.Name, issue.Index)
 	content := fmt.Sprintf("%s<br>-<br> <a href=\"%s%s/%s/issues/%d\">View it on Gogs</a>.",
 		markdown.RenderSpecialLink([]byte(strings.Replace(issue.Content, "\n", "<br>", -1)), owner.Name+"/"+repo.Name, repo.ComposeMetas()),
 		setting.AppUrl, owner.Name, repo.Name, issue.Index)
-	msg := NewMessage(tos, subject, content)
+	msg := NewMessageFrom(tos, from, subject, content)
 	msg.Info = fmt.Sprintf("Subject: %s, issue notify", subject)
 
 	SendAsync(msg)


### PR DESCRIPTION
the From: header in mails sent on issue messages notification was always set to the default setting.MailService.From parameter.

This PR adds a more speaking From: header, letting the mail address unchanged.