### PR TITLE
port 25 do not work, and port 465 is right

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -167,7 +167,7 @@ SEND_BUFFER_LEN = 100
 SUBJECT = %(APP_NAME)s
 ; Mail server
 ; Gmail: smtp.gmail.com:587
-; QQ: smtp.qq.com:25
+; QQ: smtp.qq.com:465
 ; Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used.
 HOST = 
 ; Disable HELO operation when hostname are different.


### PR DESCRIPTION
Please, make sure you are targeting the `develop` branch!

More instructions about contributing with Gogs code can be found here:
https://github.com/gogits/gogs/wiki/Contributing-Code

QQ STMP host port is 465

host = smtp.qq.com:465

and need the Authorized