### PR TITLE
Add a default repository permission to orgs

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -382,6 +382,9 @@ func runWeb(ctx *cli.Context) error {
 					m.Post("/slack/:id", bindIgnErr(auth.NewSlackHookForm{}), repo.SlackHooksEditPost)
 				})
 
+				m.Combo("/member_privileges").Get(org.SettingsMemberPrivileges).
+					Post(bindIgnErr(auth.UpdateOrgDefaultRepoPerm{}), org.SettingsUpdateDefaultRepoPerm)
+
 				m.Route("/delete", "GET,POST", org.SettingsDelete)
 			})
 

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -758,6 +758,19 @@ settings.delete_org_title = Organization Deletion
 settings.delete_org_desc = This organization is going to be deleted permanently, do you want to continue?
 settings.hooks_desc = Add webhooks that will be triggered for <strong>all repositories</strong> under this organization.
 
+settings.member_privileges = Member privileges
+settings.default_repo_perm = Default repository permission
+settings.default_repo_perm_desc = Choose the default permission level for organization members.
+settings.default_repo_perm.admin = Admin
+settings.default_repo_perm.admin_desc = Members will be able to clone, pull, push, and add new collaborators to all repositories.
+settings.default_repo_perm.write = Write
+settings.default_repo_perm.write_desc = Members will be able to clone, pull and push all repositories.
+settings.default_repo_perm.read = Read
+settings.default_repo_perm.read_desc = Members will be able to clone and pull all repositories.
+settings.default_repo_perm.none = None
+settings.default_repo_perm.none_desc = Members will only be able to clone and pull public repositories. To give a member additional access, you'll need to add them to teams or make them collaborators on individual repositories.
+settings.save = Save
+
 members.membership_visibility = Membership Visibility:
 members.public = Public
 members.public_helper = make private

--- a/models/user.go
+++ b/models/user.go
@@ -104,6 +104,7 @@ type User struct {
 	NumMembers  int
 	Teams       []*Team `xorm:"-"`
 	Members     []*User `xorm:"-"`
+	DefaultRepoPerm	AccessMode
 }
 
 func (u *User) BeforeInsert() {

--- a/modules/auth/org.go
+++ b/modules/auth/org.go
@@ -37,6 +37,14 @@ func (f *UpdateOrgSettingForm) Validate(ctx *macaron.Context, errs binding.Error
 	return validate(errs, ctx.Data, f, ctx.Locale)
 }
 
+type UpdateOrgDefaultRepoPerm struct {
+	Permission  string
+}
+
+func (f *UpdateOrgDefaultRepoPerm) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
+	return validate(errs, ctx.Data, f, ctx.Locale)
+}
+
 // ___________
 // \__    ___/___ _____    _____
 //   |    |_/ __ \\__  \  /     \

--- a/routers/org/setting.go
+++ b/routers/org/setting.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	SETTINGS_OPTIONS base.TplName = "org/settings/options"
-	SETTINGS_DELETE  base.TplName = "org/settings/delete"
-	SETTINGS_HOOKS   base.TplName = "org/settings/hooks"
+	SETTINGS_OPTIONS           base.TplName = "org/settings/options"
+	SETTINGS_DELETE            base.TplName = "org/settings/delete"
+	SETTINGS_HOOKS             base.TplName = "org/settings/hooks"
+	SETTINGS_MEMBER_PRIVILEGES base.TplName = "org/settings/member_privileges"
 )
 
 func Settings(ctx *context.Context) {
@@ -174,4 +175,21 @@ func DeleteWebhook(ctx *context.Context) {
 	ctx.JSON(200, map[string]interface{}{
 		"redirect": ctx.Org.OrgLink + "/settings/hooks",
 	})
+}
+
+func SettingsMemberPrivileges(ctx *context.Context) {
+	ctx.Data["PageIsSettingsMemberPrivileges"] = true
+	ctx.Data["DefaultRepoPerm"] = ctx.Org.Organization.DefaultRepoPerm
+	ctx.HTML(200, SETTINGS_MEMBER_PRIVILEGES)
+}
+
+func SettingsUpdateDefaultRepoPerm(ctx *context.Context, form auth.UpdateOrgDefaultRepoPerm) {
+	if err := ctx.Org.Organization.UpdateDefaultRepoPerm(models.ParseAccessMode(form.Permission)); err != nil {
+		ctx.Flash.Error(err.Error())
+	} else {
+		ctx.Flash.Success(ctx.Tr("org.settings.update_default_repo_perm_success"))
+	}
+	ctx.Data["PageIsSettingsMemberPrivileges"] = true
+	ctx.Data["DefaultRepoPerm"] = ctx.Org.Organization.DefaultRepoPerm
+	ctx.Redirect(ctx.Org.OrgLink + "/settings/member_privileges")
 }

--- a/templates/org/settings/member_privileges.tmpl
+++ b/templates/org/settings/member_privileges.tmpl
@@ -1,0 +1,37 @@
+{{template "base/head" .}}
+<div class="organization settings options">
+	{{template "org/header" .}}
+	<div class="ui container">
+		<div class="ui grid">
+			{{template "org/settings/navbar" .}}
+			<div class="twelve wide column content">
+				{{template "base/alert" .}}
+				<h4 class="ui top attached header">
+					{{.i18n.Tr "org.settings.default_repo_perm"}}
+				</h4>
+				<div class="ui attached segment">
+					<form class="ui form" action="{{.Link}}" method="post">
+						{{.CsrfTokenHtml}}
+						<div class="item">
+							{{.i18n.Tr "org.settings.default_repo_perm_desc"}}
+						</div>
+						<input {{if ge .DefaultRepoPerm 3}}checked{{end}} id="admin" name="permission" value="admin" type="radio">
+						<label for="admin">{{.i18n.Tr "org.settings.default_repo_perm.admin"}}</label>
+						<div>{{.i18n.Tr "org.settings.default_repo_perm.admin_desc"}}</div>
+						<input {{if eq .DefaultRepoPerm 2}}checked{{end}} id="write" name="permission" value="write" type="radio">
+						<label for="write">{{.i18n.Tr "org.settings.default_repo_perm.write"}}</label>
+						<div>{{.i18n.Tr "org.settings.default_repo_perm.write_desc"}}</div>
+						<input {{if eq .DefaultRepoPerm 1}}checked{{end}} id="read" name="permission" value="read" type="radio">
+						<label for="read">{{.i18n.Tr "org.settings.default_repo_perm.read"}}</label>
+						<div>{{.i18n.Tr "org.settings.default_repo_perm.read_desc"}}</div>
+						<input {{if eq .DefaultRepoPerm 0}}checked{{end}} id="none" name="permission" value="none" type="radio">
+						<label for="none">{{.i18n.Tr "org.settings.default_repo_perm.none"}}</label>
+						<div>{{.i18n.Tr "org.settings.default_repo_perm.none_desc"}}</div>
+						<button class="ui green button">{{.i18n.Tr "org.settings.save"}}</button>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/templates/org/settings/navbar.tmpl
+++ b/templates/org/settings/navbar.tmpl
@@ -4,6 +4,9 @@
 		<a class="{{if .PageIsSettingsOptions}}active{{end}} item" href="{{.OrgLink}}/settings">
 			{{.i18n.Tr "org.settings.options"}}
 		</a>
+		<a class="{{if .PageIsSettingsMemberPrivileges}}active{{end}} item" href="{{.OrgLink}}/settings/member_privileges">
+			{{.i18n.Tr "org.settings.member_privileges"}}
+		</a>
 		<a class="{{if .PageIsSettingsHooks}}active{{end}} item" href="{{.OrgLink}}/settings/hooks">
 			{{.i18n.Tr "repo.settings.hooks"}}
 		</a>


### PR DESCRIPTION
This patch allows the org admin to set the default access mode of the Org's member to all of the org's Repositories.
