### PR TITLE
Fix empty space surrounding hidden issue labels

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1137,13 +1137,15 @@ footer .ui.language .menu {
 .repository .metas .ui.list .hide {
   display: none!important;
 }
+.repository .metas .ui.list .item {
+  padding: 0px;
+}
 .repository .metas .ui.list .label.color {
   padding: 0 8px;
   margin-right: 5px;
 }
 .repository .metas .ui.list a {
-  padding-top: 5px;
-  padding-right: 10px;
+  margin: 2px 0;
 }
 .repository .metas .ui.list a .text {
   color: #444;

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -53,13 +53,15 @@
 			.hide {
 				display: none!important;
 			}
+			.item {
+				padding: 0px;
+			}			
 			.label.color {
 				padding: 0 8px;
 				margin-right: 5px;
 			}
 			a {
-				padding-top: 5px;
-				padding-right: 10px;
+				margin: 2px 0;
 				.text {
 					color: #444;
 					&:hover {


### PR DESCRIPTION
Hidden labels on an issue still have some padding, meaning labels move slightly further down as the amount of labels increase.

Before
![labelsbefore](https://cloud.githubusercontent.com/assets/488912/16227175/1aa8d47e-37a7-11e6-8f20-de76e48d0968.png)


After
![labelsafter](https://cloud.githubusercontent.com/assets/488912/16227179/1de5db00-37a7-11e6-909c-c0ede259b790.png)



