### PR TITLE
Fix capitalisation of repo-name in news

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -489,7 +489,7 @@ func CommitRepoAction(
 		Content:      string(bs),
 		RepoID:       repo.ID,
 		RepoUserName: repoUserName,
-		RepoName:     repoName,
+		RepoName:     repo.Name,
 		RefName:      refName,
 		IsPrivate:    repo.IsPrivate,
 	}); err != nil {


### PR DESCRIPTION
use 'official' repo.Name instead of incoming repoName; to enforce correct capitalisation