### PR TITLE
Do not assume avatar needs be changed from gravatar.com

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -220,8 +220,7 @@ org_still_own_repo = This organization still has ownership of repositories, you 
 target_branch_not_exist = Target branch does not exist.
 
 [user]
-change_avatar = Change your avatar at gravatar.com
-change_custom_avatar = Change your avatar in settings
+change_avatar = Change your avatar
 join_on = Joined on
 repositories = Repositories
 activity = Public Activity

--- a/templates/user/profile.tmpl
+++ b/templates/user/profile.tmpl
@@ -4,12 +4,8 @@
 		<div class="ui grid">
 			<div class="ui five wide column">
 				<div class="ui card">
-					{{if and (or .Owner.UseCustomAvatar DisableGravatar) (eq .SignedUserName .Owner.Name)}}
-						<a class="image poping up" href="{{AppSubUrl}}/user/settings" id="profile-avatar" data-content="{{.i18n.Tr "user.change_custom_avatar"}}" data-variation="inverted tiny" data-position="bottom center">
-							<img src="{{.Owner.AvatarLink}}?s=290" title="{{.Owner.Name}}"/>
-						</a>
-					{{else if eq .SignedUserName .Owner.Name}}
-						<a class="image poping up" href="http://gravatar.com/emails/" id="profile-avatar" data-content="{{.i18n.Tr "user.change_avatar"}}" data-variation="inverted tiny" data-position="bottom center">
+					{{if eq .SignedUserName .Owner.Name}}
+						<a class="image poping up" href="{{AppSubUrl}}/user/settings" id="profile-avatar" data-content="{{.i18n.Tr "user.change_avatar"}}" data-variation="inverted tiny" data-position="bottom center">
 							<img src="{{.Owner.AvatarLink}}?s=290" title="{{.Owner.Name}}"/>
 						</a>
 					{{else}}


### PR DESCRIPTION
Do not assume avatar needs be changed from gravatar.com
    
Always send user to settings screen to change avatar.
Drops "change_custom_avatar" localized message, keeps "change_avatar"
for the generic one.

