### PR TITLE
docker: Support timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER jp@roemer.im
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat
+ && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
 
 ENV GOGS_CUSTOM /data/gogs
 


### PR DESCRIPTION
When I am providing timezone to a container via the TZ environment variable, it isn't getting picked since the `/usr/share/zoneinfo` (`tzdata` package) is missing.
This causing 2 hours difference in the container's logs.

Below is the evidence showing this behavior:

```
host $ docker exec -ti gogs bash

bash-4.3# echo $TZ
Europe/Amsterdam

bash-4.3# date                                                                                                                                          
Sun Jul 10 08:48:12 GMT 2016

bash-4.3# apk add tzdata
(1/1) Installing tzdata (2015g-r0)
Executing busybox-1.24.2-r0.trigger
OK: 40 MiB in 32 packages

bash-4.3# date
Sun Jul 10 10:49:30 CEST 2016
```
