### PR TITLE
Missed quote in struct definition 

### DIFF
--- a/modules/auth/repo_form.go
+++ b/modules/auth/repo_form.go
@@ -143,7 +143,7 @@ func (f *NewWebhookForm) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type NewSlackHookForm struct {
-	PayloadURL string `binding:"Required;Url`
+	PayloadURL string `binding:"Required;Url"`
 	Channel    string `binding:"Required"`
 	Username   string
 	IconURL    string


### PR DESCRIPTION
Missed quote in repo_form.go 

