### PR TITLE
Ignore Response Body for Slack Hooks #3169

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -584,14 +584,6 @@ func (t *HookTask) deliver() {
 		return
 	}
 	t.ResponseInfo.Body = string(p)
-
-	switch t.Type {
-	case SLACK:
-		if t.ResponseInfo.Body != "ok" {
-			log.Error(5, "slack failed with: %s", t.ResponseInfo.Body)
-			t.IsSucceed = false
-		}
-	}
 }
 
 // DeliverHooks checks and delivers undelivered hooks.


### PR DESCRIPTION
This fixes #3169 

As per https://api.slack.com/incoming-webhooks ("Handling errors") the response body is undefined and should therefore not be checked.