### PR TITLE
Changed Turkish language name to 'Türkçe'

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -353,7 +353,7 @@ MAX_RESPONSE_ITEMS = 50
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台湾）,Deutsch,Français,Nederlands,Latviešu,Русский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomalainen,Türk,čeština
+NAMES = English,简体中文,繁體中文（香港）,繁體中文（台湾）,Deutsch,Français,Nederlands,Latviešu,Русский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomalainen,Türkçe,čeština
 
 ; Used for datetimepicker
 [i18n.datelang]


### PR DESCRIPTION
Turkish language name changed to 'Türkçe' from 'Türk' because 'Türk' meaning is 'Turkish People' in Turkey but 'Türkçe' meaning is 'Turkish Language'.