### PR TITLE
api: delete repository webhooks

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -221,9 +221,12 @@ func RegisterRoutes(m *macaron.Macaron) {
 				Delete(repo.Delete)
 
 			m.Group("/:username/:reponame", func() {
-				m.Combo("/hooks").Get(repo.ListHooks).
-					Post(bind(api.CreateHookOption{}), repo.CreateHook)
-				m.Patch("/hooks/:id:int", bind(api.EditHookOption{}), repo.EditHook)
+				m.Group("/hooks", func() {
+					m.Combo("").Get(repo.ListHooks).
+						Post(bind(api.CreateHookOption{}), repo.CreateHook)
+					m.Combo("/:id:int").Patch(bind(api.EditHookOption{}), repo.EditHook).
+						Delete(repo.DeleteHook)
+				})
 				m.Get("/raw/*", context.RepoRef(), repo.GetRawFile)
 				m.Get("/archive/*", repo.GetArchive)
 				m.Group("/branches", func() {

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -96,6 +96,15 @@ func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
 	ctx.JSON(201, convert.ToHook(ctx.Repo.RepoLink, w))
 }
 
+func DeleteHook(ctx *context.APIContext) {
+	if err := models.DeleteWebhook(ctx.ParamsInt64(":id")); err != nil {
+		ctx.Error(500, "DeleteWebhook", err)
+		return
+	}
+
+	ctx.Status(204)
+}
+
 // https://github.com/gogits/go-gogs-client/wiki/Repositories#edit-a-hook
 func EditHook(ctx *context.APIContext, form api.EditHookOption) {
 	w, err := models.GetWebhookByRepoID(ctx.Repo.Repository.ID, ctx.ParamsInt64(":id"))


### PR DESCRIPTION
Allows the deletion of a webhook from a repository at the
/:user/:repo/hooks/:id endpoint.

Solves drone/drone#1603.

Signed-off-by: Dennis Chen <barracks510@gmail.com>