### PR TITLE
models/issue: Don't get issue repo until added

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -403,7 +403,7 @@ func newIssue(e *xorm.Session, repo *Repository, issue *Issue, labelIDs []int64,
 		}
 	}
 
-	return issue.loadAttributes()
+	return nil
 }
 
 // NewIssue creates new issue with labels for repository.
@@ -420,6 +420,10 @@ func NewIssue(repo *Repository, issue *Issue, labelIDs []int64, uuids []string) 
 
 	if err = sess.Commit(); err != nil {
 		return fmt.Errorf("Commit: %v", err)
+	}
+
+	if err = issue.loadAttributes(); err != nil {
+		return fmt.Errorf("loadAttributes: %v", err)
 	}
 
 	// Notify watchers.

--- a/models/pull.go
+++ b/models/pull.go
@@ -330,19 +330,6 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 		return fmt.Errorf("newIssue: %v", err)
 	}
 
-	// Notify watchers.
-	act := &Action{
-		ActUserID:    pull.Poster.Id,
-		ActUserName:  pull.Poster.Name,
-		ActEmail:     pull.Poster.Email,
-		OpType:       ACTION_CREATE_PULL_REQUEST,
-		Content:      fmt.Sprintf("%d|%s", pull.Index, pull.Name),
-		RepoID:       repo.ID,
-		RepoUserName: repo.Owner.Name,
-		RepoName:     repo.Name,
-		IsPrivate:    repo.IsPrivate,
-	}
-
 	pr.Index = pull.Index
 	if err = repo.SavePatch(pr.Index, patch); err != nil {
 		return fmt.Errorf("SavePatch: %v", err)
@@ -363,6 +350,23 @@ func NewPullRequest(repo *Repository, pull *Issue, labelIDs []int64, uuids []str
 
 	if err = sess.Commit(); err != nil {
 		return fmt.Errorf("Commit: %v", err)
+	}
+
+	if err = pull.loadAttributes(); err != nil {
+		return fmt.Errorf("loadAttributes: %v", err)
+	}
+
+	// Notify watchers.
+	act := &Action{
+		ActUserID:    pull.Poster.Id,
+		ActUserName:  pull.Poster.Name,
+		ActEmail:     pull.Poster.Email,
+		OpType:       ACTION_CREATE_PULL_REQUEST,
+		Content:      fmt.Sprintf("%d|%s", pull.Index, pull.Name),
+		RepoID:       repo.ID,
+		RepoUserName: repo.Owner.Name,
+		RepoName:     repo.Name,
+		IsPrivate:    repo.IsPrivate,
 	}
 
 	if err = NotifyWatchers(act); err != nil {


### PR DESCRIPTION
Wait until we're done adding a new issue to the database to attempt to
search the `repository' table for the issue's repository id. Otherwise,
on SQLite, retrieving the repository will fail, probably for the same
reason as #2700 (and ea802742) -- the SQLite driver for xorm can't
retrieve objects after something was updated.

Fixes #3291.