### PR TITLE
Add support for .diff and .patch

### DIFF
--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -418,13 +418,13 @@ func GetDiffRange(repoPath, beforeCommitID string, afterCommitID string, maxLine
 	return diff, nil
 }
 
-func GetRawDiff(repoPath, commitId, diffType string) (string, error) {
+func GetRawDiff(repoPath, commitID, diffType string) (string, error) {
 	repo, err := git.OpenRepository(repoPath)
 	if err != nil {
 		return "", err
 	}
 
-	commit, err := repo.GetCommit(commitId)
+	commit, err := repo.GetCommit(commitID)
 	if err != nil {
 		return "", err
 	}
@@ -433,17 +433,17 @@ func GetRawDiff(repoPath, commitId, diffType string) (string, error) {
 	switch diffType {
 	case "diff":
 		if commit.ParentCount() == 0 {
-			cmd = exec.Command("git", "show", commitId)
+			cmd = exec.Command("git", "show", commitID)
 		} else {
 			c, _ := commit.Parent(0)
-			cmd = exec.Command("git", "diff", "-M", c.ID.String(), commitId)
+			cmd = exec.Command("git", "diff", "-M", c.ID.String(), commitID)
 		}
 	case "patch":
 		if commit.ParentCount() == 0 {
-			cmd = exec.Command("git", "format-patch", "--no-signature", "--stdout", "--root", commitId)
+			cmd = exec.Command("git", "format-patch", "--no-signature", "--stdout", "--root", commitID)
 		} else {
 			c, _ := commit.Parent(0)
-			query := fmt.Sprintf("%s...%s", commitId, c.ID.String())
+			query := fmt.Sprintf("%s...%s", commitID, c.ID.String())
 			cmd = exec.Command("git", "format-patch", "--no-signature", "--stdout", query)
 		}
 	default:
@@ -460,6 +460,6 @@ func GetRawDiff(repoPath, commitId, diffType string) (string, error) {
 	return string(stdout), nil
 }
 
-func GetDiffCommit(repoPath, commitId string, maxLines, maxLineCharacteres, maxFiles int) (*Diff, error) {
-	return GetDiffRange(repoPath, "", commitId, maxLines, maxLineCharacteres, maxFiles)
+func GetDiffCommit(repoPath, commitID string, maxLines, maxLineCharacteres, maxFiles int) (*Diff, error) {
+	return GetDiffRange(repoPath, "", commitID, maxLines, maxLineCharacteres, maxFiles)
 }

--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -450,12 +450,14 @@ func GetRawDiff(repoPath, commitID, diffType string) (string, error) {
 		return "", fmt.Errorf("Invalid diffType '%s'", diffType)
 	}
 
+	stderr := new(bytes.Buffer)
+
 	cmd.Dir = repoPath
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = stderr
 
 	stdout, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Stdout: %v", err)
+		return "", fmt.Errorf("Stdout: %v; Stderr: %s", err, stderr.String())
 	}
 	return string(stdout), nil
 }

--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -418,6 +418,44 @@ func GetDiffRange(repoPath, beforeCommitID string, afterCommitID string, maxLine
 	return diff, nil
 }
 
+func GetRawDiff(repoPath, commitId string, diffType string) (string, error) {
+	repo, err := git.OpenRepository(repoPath)
+	if err != nil {
+		return "", err
+	}
+
+	commit, err := repo.GetCommit(commitId)
+	if err != nil {
+		return "", err
+	}
+
+	var cmd *exec.Cmd
+	if diffType == "diff" {
+		if commit.ParentCount() == 0 {
+			cmd = exec.Command("git", "show", commitId)
+		} else {
+			c, _ := commit.Parent(0)
+			cmd = exec.Command("git", "diff", "-M", c.ID.String(), commitId)
+		}
+	} else {
+		if commit.ParentCount() == 0 {
+			cmd = exec.Command("git", "format-patch", "--no-signature", "--stdout", "--root", commitId)
+		} else {
+			c, _ := commit.Parent(0)
+			query := fmt.Sprintf("%s...%s", commitId, c.ID.String())
+			cmd = exec.Command("git", "format-patch", "--no-signature", "--stdout", query)
+		}
+	}
+	cmd.Dir = repoPath
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Stdout: %v", err)
+	}
+	return string(stdout), nil
+}
+
 func GetDiffCommit(repoPath, commitId string, maxLines, maxLineCharacteres, maxFiles int) (*Diff, error) {
 	return GetDiffRange(repoPath, "", commitId, maxLines, maxLineCharacteres, maxFiles)
 }

--- a/models/git_diff.go
+++ b/models/git_diff.go
@@ -457,7 +457,7 @@ func GetRawDiff(repoPath, commitID, diffType string) (string, error) {
 
 	stdout, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Stdout: %v; Stderr: %s", err, stderr.String())
+		return "", fmt.Errorf("%v - %s", err, stderr)
 	}
 	return string(stdout), nil
 }

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -195,7 +195,18 @@ func Diff(ctx *context.Context) {
 }
 
 func RawDiff(ctx *context.Context) {
-	panic("not implemented")
+	userName := ctx.Repo.Owner.Name
+	repoName := ctx.Repo.Repository.Name
+	commitID := ctx.Params(":sha")
+	diffType := ctx.Params(":ext")
+
+	diff, err := models.GetRawDiff(models.RepoPath(userName, repoName),
+		commitID, diffType)
+	if err != nil {
+		ctx.Handle(404, "GetRawDiff", err)
+		return
+	}
+	ctx.HandleText(200, diff)
 }
 
 func CompareDiff(ctx *context.Context) {

--- a/routers/repo/commit.go
+++ b/routers/repo/commit.go
@@ -195,13 +195,11 @@ func Diff(ctx *context.Context) {
 }
 
 func RawDiff(ctx *context.Context) {
-	userName := ctx.Repo.Owner.Name
-	repoName := ctx.Repo.Repository.Name
-	commitID := ctx.Params(":sha")
-	diffType := ctx.Params(":ext")
-
-	diff, err := models.GetRawDiff(models.RepoPath(userName, repoName),
-		commitID, diffType)
+	diff, err := models.GetRawDiff(
+		models.RepoPath(ctx.Repo.Owner.Name, ctx.Repo.Repository.Name),
+		ctx.Params(":sha"),
+		ctx.Params(":ext"),
+	)
 	if err != nil {
 		ctx.Handle(404, "GetRawDiff", err)
 		return


### PR DESCRIPTION
Add the ability to get text-diff and format-patch by adding .diff or
.patch in the end of a commit url. Issue #2641

Obsoletes PR #2846

Signed-off-by: Dennis Chen <barracks510@gmail.com>