### PR TITLE
avatar: make custom and generated avatars equal

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"image/jpeg"
 	_ "image/jpeg"
 	"image/png"
 	"os"
@@ -222,7 +221,7 @@ func (u *User) GenerateRandomAvatar() error {
 	}
 	defer fw.Close()
 
-	if err = jpeg.Encode(fw, img, nil); err != nil {
+	if err = png.Encode(fw, img); err != nil {
 		return fmt.Errorf("Encode: %v", err)
 	}
 
@@ -321,7 +320,7 @@ func (u *User) UploadAvatar(data []byte) error {
 		return fmt.Errorf("Decode: %v", err)
 	}
 
-	m := resize.Resize(290, 290, img, resize.NearestNeighbor)
+	m := resize.Resize(avatar.AVATAR_SIZE, avatar.AVATAR_SIZE, img, resize.NearestNeighbor)
 
 	sess := x.NewSession()
 	defer sessionRelease(sess)

--- a/modules/avatar/avatar.go
+++ b/modules/avatar/avatar.go
@@ -14,7 +14,7 @@ import (
 	"github.com/issue9/identicon"
 )
 
-const _RANDOM_AVATAR_SIZE = 200
+const AVATAR_SIZE = 290
 
 // RandomImage generates and returns a random avatar image unique to input data
 // in custom size (height and width).
@@ -39,5 +39,5 @@ func RandomImageSize(size int, data []byte) (image.Image, error) {
 // RandomImage generates and returns a random avatar image unique to input data
 // in default size (height and width).
 func RandomImage(data []byte) (image.Image, error) {
-	return RandomImageSize(_RANDOM_AVATAR_SIZE, data)
+	return RandomImageSize(AVATAR_SIZE, data)
 }


### PR DESCRIPTION
Sets all avatars to use PNG image format.
Keeps avatars consistent at 290x290px resolution.

Signed-off-by: Dennis Chen <barracks510@gmail.com>