### PR TITLE
routers/repo/release: Check tags when adding release

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -81,6 +81,7 @@ func createTag(gitRepo *git.Repository, rel *Release) error {
 				return fmt.Errorf("GetTagCommit: %v", err)
 			}
 
+			rel.Sha1 = commit.ID.String()
 			rel.NumCommits, err = commit.CommitsCount()
 			if err != nil {
 				return fmt.Errorf("CommitsCount: %v", err)


### PR DESCRIPTION
The `NewReleasePost` function always uses the `form.Target` parameter when
quering the repo for the commit to use. That is sufficent when creating a
release based on the current `HEAD` of a branch but if one would want to
create a release based on an already available tag the release page will
link to the current `HEAD` instead of the appropiate tag commit.

Let's check the given `form.TagName` if it exists and use that tag commit
for the new `release` entry.

You can observe the faulty behavior at the https://try.gogs.io/nalla/test-repo2/releases page. Have a look at release 1. The original valid commit link [`c4b66f39ec`](https://try.gogs.io/nalla/test-repo2/commit/c4b66f39ecc83f592545c336c27d95def62bb3c0) was replaced with the current head commit [`2ccadb7a4a`](https://try.gogs.io/nalla/test-repo2/src/2ccadb7a4a8fca8a93c639ee84c874e77b33d921) after creating the release on the already created tag [`1`](https://try.gogs.io/nalla/test-repo2/src/1)