### PR TITLE
Fix of template error in "/:owner/:repo/pulls"

### DIFF
--- a/templates/repo/issue/list.tmpl
+++ b/templates/repo/issue/list.tmpl
@@ -8,7 +8,7 @@
 				{{if .PageIsIssueList}}
 					<a class="ui green button" href="{{.RepoLink}}/issues/new">{{.i18n.Tr "repo.issues.new"}}</a>
 				{{else}}
-					<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.Repository.DefaultBranch}}...{{.PullRequestCtx.HeadInfo}}">{{.i18n.Tr "repo.pulls.new"}}</a>
+					<a class="ui green button {{if not .PullRequestCtx.Allowed}}disabled{{end}}" href="{{if not .PullRequestCtx.Allowed}}#{{else}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.Repository.DefaultBranch}}...{{.PullRequestCtx.HeadInfo}}{{end}}">{{.i18n.Tr "repo.pulls.new"}}</a>
 				{{end}}
 			</div>
 		</div>


### PR DESCRIPTION
If anonymous (not signed in user) requests page "/:owner/:repo/pulls" he gets an error:

```
template: repo/issue/list:11:105: executing "repo/issue/list" at <.PullRequestCtx.Base...>: nil pointer evaluating *models.Repository.Link
```

This pull request fixes that.