### PR TITLE
Lighter icon colors for repo files

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1248,9 +1248,13 @@ footer .ui.language .menu {
 .repository.file.list #repo-files-table tbody .octicon {
   margin-left: 3px;
   margin-right: 5px;
+  color: #777;
 }
 .repository.file.list #repo-files-table tbody .octicon.octicon-mail-reply {
   margin-right: 10px;
+}
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory {
+  color: #1e70bf;
 }
 .repository.file.list #repo-files-table td {
   padding-top: 8px;

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1253,7 +1253,8 @@ footer .ui.language .menu {
 .repository.file.list #repo-files-table tbody .octicon.octicon-mail-reply {
   margin-right: 10px;
 }
-.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory {
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-directory,
+.repository.file.list #repo-files-table tbody .octicon.octicon-file-submodule {
   color: #1e70bf;
 }
 .repository.file.list #repo-files-table td {

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -184,7 +184,7 @@
 					&.octicon-mail-reply {
 						margin-right: 10px;
 					}
-					&.octicon-file-directory {
+					&.octicon-file-directory, &.octicon-file-submodule {
 						color: #1e70bf;
 					}
 				}

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -59,7 +59,7 @@
 			}
 			.item {
 				padding: 0px;
-			}			
+			}
 			.label.color {
 				padding: 0 8px;
 				margin-right: 5px;
@@ -180,8 +180,12 @@
 				.octicon {
 					margin-left: 3px;
 					margin-right: 5px;
+					color: #777;
 					&.octicon-mail-reply {
 						margin-right: 10px;
+					}
+					&.octicon-file-directory {
+						color: #1e70bf;
 					}
 				}
 			}


### PR DESCRIPTION
Small visual change to file icon colors:

### Before
![before](https://cloud.githubusercontent.com/assets/115237/17276659/cfae8f4c-572f-11e6-916e-056ccda370ef.png)

### After
![after](https://cloud.githubusercontent.com/assets/115237/17276660/cfb2d8b8-572f-11e6-9907-5e5a5d8f1f0c.png)
