### PR TITLE
Fix #3315: Release dont use tag creation date

### DIFF
--- a/models/release.go
+++ b/models/release.go
@@ -40,10 +40,9 @@ type Release struct {
 
 func (r *Release) BeforeInsert() {
 	if r.CreatedUnix == 0 {
-                r.CreatedUnix = time.Now().Unix()
+		r.CreatedUnix = time.Now().Unix()
 	}
 }
-
 
 func (r *Release) AfterSet(colName string, _ xorm.Cell) {
 	switch colName {

--- a/models/release.go
+++ b/models/release.go
@@ -39,8 +39,11 @@ type Release struct {
 }
 
 func (r *Release) BeforeInsert() {
-	r.CreatedUnix = time.Now().Unix()
+	if r.CreatedUnix == 0 {
+                r.CreatedUnix = time.Now().Unix()
+	}
 }
+
 
 func (r *Release) AfterSet(colName string, _ xorm.Cell) {
 	switch colName {

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -270,14 +270,6 @@ func EditReleasePost(ctx *context.Context, form auth.EditReleaseForm) {
 		return
 	}
 
-	tag, err := ctx.Repo.GitRepo.GetTag(rel.TagName)
-	if err == nil {
-		commit, err := tag.Commit()
-		if err == nil {
-			rel.CreatedUnix = commit.Author.When.Unix()
-		}
-	}
-
 	rel.Title = form.Title
 	rel.Note = form.Content
 	rel.IsDraft = len(form.Draft) > 0


### PR DESCRIPTION
Like Github, release note now using the tag creation date rather than the web release note creation date (Issue #3315). If tag does not exist yet, last commit on selected branch will be used.