### PR TITLE
Replace gogs.io http links with https version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Please read detailed information on [Wiki](https://github.com/gogits/gogs/wiki/C
 
 ### Ask For Help
 
-Before opening an issue, please make sure your problem isn't already addressed on the [Troubleshooting](http://gogs.io/docs/intro/troubleshooting.html) and [FAQs](http://gogs.io/docs/intro/faqs.html) pages.
+Before opening an issue, please make sure your problem isn't already addressed on the [Troubleshooting](https://gogs.io/docs/intro/troubleshooting.html) and [FAQs](https://gogs.io/docs/intro/faqs.html) pages.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gogs - Go Git Service [![Build Status](https://travis-ci.org/gogits/gogs.svg?bra
 3. The demo site [try.gogs.io](https://try.gogs.io) is running under `develop` branch.
 4. If you think there are vulnerabilities in the project, please talk privately to **u@gogs.io**. Thanks!
 5. If you're interested in using APIs, we have experimental support with [documentation](https://github.com/gogits/go-gogs-client/wiki).
-6. If your team/company is using Gogs and would like to put your logo on [our website](http://gogs.io), contact us by any means.
+6. If your team/company is using Gogs and would like to put your logo on [our website](https://gogs.io), contact us by any means.
 
 [简体中文](README_ZH.md)
 
@@ -28,11 +28,11 @@ The goal of this project is to make the easiest, fastest, and most painless way 
 
 ## Overview
 
-- Please see the [Documentation](http://gogs.io/docs/intro) for common usages and change log.
+- Please see the [Documentation](https://gogs.io/docs/intro) for common usages and change log.
 - See the [Trello Board](https://trello.com/b/uxAoeLUl/gogs-go-git-service) to follow the develop team.
 - Want to try it before doing anything else? Do it [online](https://try.gogs.io/gogs/gogs)!
-- Having trouble? Get help with [Troubleshooting](http://gogs.io/docs/intro/troubleshooting.html) or [User Forum](https://discuss.gogs.io/).
-- Want to help with localization? Check out the [guide](http://gogs.io/docs/features/i18n.html)!
+- Having trouble? Get help with [Troubleshooting](https://gogs.io/docs/intro/troubleshooting.html) or [User Forum](https://discuss.gogs.io/).
+- Want to help with localization? Check out the [guide](https://gogs.io/docs/features/i18n.html)!
 
 ## Features
 
@@ -63,13 +63,13 @@ The goal of this project is to make the easiest, fastest, and most painless way 
 
 ## Installation
 
-Make sure you install the [prerequisites](http://gogs.io/docs/installation) first.
+Make sure you install the [prerequisites](https://gogs.io/docs/installation) first.
 
 There are 5 ways to install Gogs:
 
-- [Install from binary](http://gogs.io/docs/installation/install_from_binary.html)
-- [Install from source](http://gogs.io/docs/installation/install_from_source.html)
-- [Install from packages](http://gogs.io/docs/installation/install_from_packages.html)
+- [Install from binary](https://gogs.io/docs/installation/install_from_binary.html)
+- [Install from source](https://gogs.io/docs/installation/install_from_source.html)
+- [Install from packages](https://gogs.io/docs/installation/install_from_packages.html)
 - [Ship with Docker](https://github.com/gogits/gogs/tree/master/docker)
 - [Install with Vagrant](https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -9,11 +9,11 @@ Gogs 的目标是打造一个最简单、最快速和最轻松的方式搭建自
 
 ## 项目概览
 
-- 有关基本用法和变更日志，请通过 [使用手册](http://gogs.io/docs/intro/) 查看。
+- 有关基本用法和变更日志，请通过 [使用手册](https://gogs.io/docs/intro/) 查看。
 - 您可以到 [Trello Board](https://trello.com/b/uxAoeLUl/gogs-go-git-service) 跟随开发团队的脚步。
 - 想要先睹为快？直接去 [在线体验](https://try.gogs.io/gogs/gogs) 。
-- 使用过程中遇到问题？尝试从 [故障排查](http://gogs.io/docs/intro/troubleshooting.html) 页面或 [用户论坛](https://discuss.gogs.io/) 获取帮助。
-- 希望帮助多国语言界面的翻译吗？请立即访问 [详情页面](http://gogs.io/docs/features/i18n.html)！
+- 使用过程中遇到问题？尝试从 [故障排查](https://gogs.io/docs/intro/troubleshooting.html) 页面或 [用户论坛](https://discuss.gogs.io/) 获取帮助。
+- 希望帮助多国语言界面的翻译吗？请立即访问 [详情页面](https://gogs.io/docs/features/i18n.html)！
 
 ## 功能特性
 
@@ -44,13 +44,13 @@ Gogs 的目标是打造一个最简单、最快速和最轻松的方式搭建自
 
 ## 安装部署
 
-在安装 Gogs 之前，您需要先安装 [基本环境](http://gogs.io/docs/installation)。
+在安装 Gogs 之前，您需要先安装 [基本环境](https://gogs.io/docs/installation)。
 
 然后，您可以通过以下 5 种方式来安装 Gogs：
 
-- [二进制安装](http://gogs.io/docs/installation/install_from_binary.html)
-- [源码安装](http://gogs.io/docs/installation/install_from_source.html)
-- [包管理安装](http://gogs.io/docs/installation/install_from_packages.html)
+- [二进制安装](https://gogs.io/docs/installation/install_from_binary.html)
+- [源码安装](https://gogs.io/docs/installation/install_from_source.html)
+- [包管理安装](https://gogs.io/docs/installation/install_from_packages.html)
 - [采用 Docker 部署](https://github.com/gogits/gogs/tree/master/docker)
 - [通过 Vagrant 安装](https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,7 +71,7 @@ Most of settings are obvious and easy to understand, but there are some settings
 - **HTTP Port**: Use port you want Gogs to listen on inside Docker container. For example, your Gogs listens on `3000` inside Docker, and you expose it by `10080:3000`, but you still use `3000` for this value.
 - **Application URL**: Use combination of **Domain** and **exposed HTTP Port** values (e.g. `http://192.168.99.100:10080/`).
 
-Full documentation of application settings can be found [here](http://gogs.io/docs/advanced/configuration_cheat_sheet.html).
+Full documentation of application settings can be found [here](https://gogs.io/docs/advanced/configuration_cheat_sheet.html).
 
 ### Container options
 

--- a/routers/install.go
+++ b/routers/install.go
@@ -227,7 +227,7 @@ func InstallPost(ctx *context.Context, form auth.InstallForm) {
 	if err := models.NewTestEngine(x); err != nil {
 		if strings.Contains(err.Error(), `Unknown database type: sqlite3`) {
 			ctx.Data["Err_DbType"] = true
-			ctx.RenderWithErr(ctx.Tr("install.sqlite3_not_available", "http://gogs.io/docs/installation/install_from_binary.html"), INSTALL, &form)
+			ctx.RenderWithErr(ctx.Tr("install.sqlite3_not_available", "https://gogs.io/docs/installation/install_from_binary.html"), INSTALL, &form)
 		} else {
 			ctx.Data["Err_DbSetting"] = true
 			ctx.RenderWithErr(ctx.Tr("install.invalid_db_setting", err), INSTALL, &form)

--- a/scripts/windows/install-as-service.bat
+++ b/scripts/windows/install-as-service.bat
@@ -9,7 +9,7 @@
 :: Make sure Gogs work running manually with "gogs web" before running
 :: this script.
 :: And, please, read carefully the installation docs first:
-:: http://gogs.io/docs/installation
+:: https://gogs.io/docs/installation
 :: To unistall the service, run "nssm remove gogs" and restart Windows.
 
 :: Set the folder where you extracted Gogs. Omit the last slash.

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -24,7 +24,7 @@
 						{{end}}
 					</div>
 				</div>
-				<a target="_blank" href="http://gogs.io">{{.i18n.Tr "website"}}</a>
+				<a target="_blank" href="https://gogs.io">{{.i18n.Tr "website"}}</a>
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}<span class="version">{{GoVer}}</span>{{end}}
 			</div>
 		</div>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -108,7 +108,7 @@
 													<i class="octicon octicon-settings"></i>
 													{{.i18n.Tr "your_settings"}}<!-- Your settings -->
 												</a>
-												<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">
+												<a class="item" target="_blank" href="https://gogs.io/docs" rel="noreferrer">
 													<i class="octicon octicon-question"></i>
 													{{.i18n.Tr "help"}}<!-- Help -->
 												</a>
@@ -132,7 +132,7 @@
 
 								{{else}}
 
-									<a class="item" target="_blank" href="http://gogs.io/docs" rel="noreferrer">{{.i18n.Tr "help"}}</a>
+									<a class="item" target="_blank" href="https://gogs.io/docs" rel="noreferrer">{{.i18n.Tr "help"}}</a>
 									<div class="right menu">
 										{{if .ShowRegistrationButton}}
 											<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -20,7 +20,7 @@
 					<i class="octicon octicon-flame"></i> Einfach zu installieren
 				</h1>
 				<p class="large">
-					Starte einfach <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">die Anwendung</a> für deine Plattform. Gogs gibt es auch für <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a>, <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">Installationspaket</a>.
+					Starte einfach <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">die Anwendung</a> für deine Plattform. Gogs gibt es auch für <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a>, <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a> oder als <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">Installationspaket</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -57,7 +57,7 @@
 					<i class="octicon octicon-flame"></i> 易安装
 				</h1>
 				<p class="large">
-					您除了可以根据操作系统平台通过 <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">二进制运行</a>，还可以通过 <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> 或 <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">包管理</a> 安装。
+					您除了可以根据操作系统平台通过 <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">二进制运行</a>，还可以通过 <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> 或 <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>，以及 <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">包管理</a> 安装。
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -94,10 +94,10 @@
 					<i class="octicon octicon-flame"></i> Facile à installer
 				</h1>
 				<p class="large">
-				    Il suffit de <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">lancer l'exécutable</a> correspondant à votre système. 
+				    Il suffit de <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">lancer l'exécutable</a> correspondant à votre système. 
                     Ou d'utiliser Gogs avec <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> ou 
                     <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>
-                    ou en l'installant depuis un <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">package</a>.
+                    ou en l'installant depuis un <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">package</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -134,7 +134,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplemente <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">arranca el binario</a> para tu plataforma. O usa Gogs con <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> o <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">paquete</a>.
+					Simplemente <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">arranca el binario</a> para tu plataforma. O usa Gogs con <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> o <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, o utilice el <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">paquete</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -171,7 +171,7 @@
 					<i class="octicon octicon-flame"></i> Fácil de instalar
 				</h1>
 				<p class="large">
-					Simplesmente <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gogs com o <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> ou <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">pacote</a>.
+					Simplesmente <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">rode o executável</a> para o seu sistema operacional. Ou obtenha o Gogs com o <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> ou <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, ou baixe o <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">pacote</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -208,7 +208,7 @@
 					<i class="octicon octicon-flame"></i> Простой в установке
 				</h1>
 				<p class="large">
-					Просто <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gogs с <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> или <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">пакет</a>.
+					Просто <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">запустите исполняемый файл</a> для вашей платформы. Изпользуйте Gogs с <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> или <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, или загрузите <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">пакет</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">
@@ -245,7 +245,7 @@
 					<i class="octicon octicon-flame"></i> Easy to install
 				</h1>
 				<p class="large">
-					Simply <a target="_blank" href="http://gogs.io/docs/installation/install_from_binary.html">run the binary</a> for your platform. Or ship Gogs with <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> or <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" href="http://gogs.io/docs/installation/install_from_packages.html">packaged</a>.
+					Simply <a target="_blank" href="https://gogs.io/docs/installation/install_from_binary.html">run the binary</a> for your platform. Or ship Gogs with <a target="_blank" href="https://github.com/gogits/gogs/tree/master/docker">Docker</a> or <a target="_blank" href="https://github.com/geerlingguy/ansible-vagrant-examples/tree/master/gogs">Vagrant</a>, or get it <a target="_blank" href="https://gogs.io/docs/installation/install_from_packages.html">packaged</a>.
 				</p>
 			</div>
 			<div class="eight wide center column">

--- a/templates/repo/settings/hook_gogs.tmpl
+++ b/templates/repo/settings/hook_gogs.tmpl
@@ -1,5 +1,5 @@
 {{if eq .HookType "gogs"}}
-	<p>{{.i18n.Tr "repo.settings.add_webhook_desc" "http://gogs.io/docs/features/webhook.html" | Str2html}}</p>
+	<p>{{.i18n.Tr "repo.settings.add_webhook_desc" "https://gogs.io/docs/features/webhook.html" | Str2html}}</p>
 	<form class="ui form" action="{{.BaseLink}}/settings/hooks/gogs/{{if .PageIsSettingsHooksNew}}new{{else}}{{.Webhook.ID}}{{end}}" method="post">
 		{{.CsrfTokenHtml}}
 		<div class="required field {{if .Err_PayloadURL}}error{{end}}">


### PR DESCRIPTION
Nice you use HTTPS on your website, so now only the links to your website need to be updated.