### PR TITLE
Improve diff highlight

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -334,11 +334,13 @@ RUN_AT_START = true
 SCHEDULE = @every 24h
 
 [git]
-; Max number of lines allowed of a single file in diff view.
+; Disables highlight of added and removed changes
+DISABLE_DIFF_HIGHLIGHT = false
+; Max number of lines allowed of a single file in diff view
 MAX_GIT_DIFF_LINES = 1000
-; Max number of characters of a line allowed in diff view.
+; Max number of characters of a line allowed in diff view
 MAX_GIT_DIFF_LINE_CHARACTERS = 500
-; Max number of files shown in diff view.
+; Max number of files shown in diff view
 MAX_GIT_DIFF_FILES = 100
 ; Arguments for command 'git gc', e.g. "--aggressive --auto"
 ; see more on http://git-scm.com/docs/git-gc/1.7.5

--- a/models/git_diff_test.go
+++ b/models/git_diff_test.go
@@ -33,38 +33,3 @@ func TestDiffToHTML(t *testing.T) {
 		dmp.Diff{dmp.DiffEqual, " biz"},
 	}, DIFF_LINE_DEL))
 }
-
-// test if GetLine is return the correct lines
-func TestGetLine(t *testing.T) {
-	ds := DiffSection{Lines: []*DiffLine{
-		&DiffLine{LeftIdx: 28, RightIdx: 28, Type: DIFF_LINE_PLAIN},
-		&DiffLine{LeftIdx: 29, RightIdx: 29, Type: DIFF_LINE_PLAIN},
-		&DiffLine{LeftIdx: 30, RightIdx: 30, Type: DIFF_LINE_PLAIN},
-		&DiffLine{LeftIdx: 31, RightIdx: 0, Type: DIFF_LINE_DEL},
-		&DiffLine{LeftIdx: 0, RightIdx: 31, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 0, RightIdx: 32, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 32, RightIdx: 33, Type: DIFF_LINE_PLAIN},
-		&DiffLine{LeftIdx: 33, RightIdx: 0, Type: DIFF_LINE_DEL},
-		&DiffLine{LeftIdx: 34, RightIdx: 0, Type: DIFF_LINE_DEL},
-		&DiffLine{LeftIdx: 35, RightIdx: 0, Type: DIFF_LINE_DEL},
-		&DiffLine{LeftIdx: 36, RightIdx: 0, Type: DIFF_LINE_DEL},
-		&DiffLine{LeftIdx: 0, RightIdx: 34, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 0, RightIdx: 35, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 0, RightIdx: 36, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 0, RightIdx: 37, Type: DIFF_LINE_ADD},
-		&DiffLine{LeftIdx: 37, RightIdx: 38, Type: DIFF_LINE_PLAIN},
-		&DiffLine{LeftIdx: 38, RightIdx: 39, Type: DIFF_LINE_PLAIN},
-	}}
-
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 31), ds.Lines[4])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 31), ds.Lines[3])
-
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 33), ds.Lines[11])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 34), ds.Lines[12])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 35), ds.Lines[13])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_ADD, 36), ds.Lines[14])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 34), ds.Lines[7])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 35), ds.Lines[8])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 36), ds.Lines[9])
-	assertLineEqual(t, ds.GetLine(DIFF_LINE_DEL, 37), ds.Lines[10])
-}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -191,6 +191,7 @@ var (
 
 	// Git settings
 	Git struct {
+		DisableDiffHighlight     bool
 		MaxGitDiffLines          int
 		MaxGitDiffLineCharacters int
 		MaxGitDiffFiles          int


### PR DESCRIPTION
1) Try to reduce memory allocations
2) Add possibility to disable diff highlight (can improve performance for large diffs)
3) Tweaking with cost for prettier (cleaner) diffs
4) Do not calculate diff when the number of removed lines in a block is not equal to the number of added lines (this usually resulted in ugly diffs)

Examples for 3:
- [Before](https://cloud.githubusercontent.com/assets/7011819/17458691/267b2dec-5bf1-11e6-83bd-7ddd3b44695e.png) - [After](https://cloud.githubusercontent.com/assets/7011819/17458692/3696e752-5bf1-11e6-927a-2aaee9a79e3a.png)
- [Before](https://cloud.githubusercontent.com/assets/7011819/17458695/46950c24-5bf1-11e6-87eb-f924bd82a3c5.png) - [After](https://cloud.githubusercontent.com/assets/7011819/17458697/52679558-5bf1-11e6-9852-ad88cc2621b5.png)
- [Before](https://cloud.githubusercontent.com/assets/7011819/17458701/5ddd5ce2-5bf1-11e6-8d82-bd7d36853ab7.png) - [After](https://cloud.githubusercontent.com/assets/7011819/17458705/678f231a-5bf1-11e6-86b1-a359646fb1bb.png)

Example for 4:
- [Before](https://cloud.githubusercontent.com/assets/7011819/17458708/778da41c-5bf1-11e6-8fcd-fc6ed8a768f4.png) - [After](https://cloud.githubusercontent.com/assets/7011819/17458713/81218264-5bf1-11e6-9bc9-83bf81f69ebb.png)

It's hard to get this 100%, but it's more accurate now.