### PR TITLE
Add API endpoint for getting user by token

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -195,6 +195,7 @@ func RegisterRoutes(m *macaron.Macaron) {
 		}, reqToken())
 
 		m.Group("/user", func() {
+			m.Get("", user.GetSignedInUser)
 			m.Combo("/emails").Get(user.ListEmails).
 				Post(bind(api.CreateEmailOption{}), user.AddEmail).
 				Delete(bind(api.CreateEmailOption{}), user.DeleteEmail)

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -70,3 +70,8 @@ func GetInfo(ctx *context.APIContext) {
 	}
 	ctx.JSON(200, &api.User{u.ID, u.Name, u.FullName, u.Email, u.AvatarLink()})
 }
+
+func GetSignedInUser(ctx *context.APIContext) {
+	u := ctx.User;
+	ctx.JSON(200, &api.User{u.ID, u.Name, u.FullName, u.Email, u.AvatarLink()})
+}


### PR DESCRIPTION
This pull request adds a new API endpoint for getting a user from an access token. The endpoint is `GET user/`, and is analogous to the Github endpoint `GET user/` (https://developer.github.com/v3/users/#get-the-authenticated-user).

To the best of my knowledge, @Unknwon contacted @richmahn yesterday (08/06/2016) expressing interest in this feature.