### PR TITLE
Do not show the "Sign up for free" button in issue tracker

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -485,7 +485,7 @@ issues.commit_ref_at = `referenced this issue from a commit <a id="%[1]s" href="
 issues.poster = Poster
 issues.collaborator = Collaborator
 issues.owner = Owner
-issues.sign_in_require_desc = <a href="%s">Sign in to comment</a>
+issues.sign_in_require_desc = Sign in to comment
 issues.edit = Edit
 issues.cancel = Cancel
 issues.save = Save

--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -485,8 +485,7 @@ issues.commit_ref_at = `referenced this issue from a commit <a id="%[1]s" href="
 issues.poster = Poster
 issues.collaborator = Collaborator
 issues.owner = Owner
-issues.sign_up_for_free = Sign up for free
-issues.sign_in_require_desc = to join this conversation. Already have an account? <a href="%s">Sign in to comment</a>
+issues.sign_in_require_desc = <a href="%s">Sign in to comment</a>
 issues.edit = Edit
 issues.cancel = Cancel
 issues.save = Save

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -227,7 +227,7 @@
 				</div>
 			{{else}}
 				<div class="ui warning message">
-					{{.i18n.Tr "repo.issues.sign_in_require_desc" .SignInLink | Safe}}
+					<a href="{{ .SignInLink }}">{{.i18n.Tr "repo.issues.sign_in_require_desc" | Safe}}</a>
 				</div>
 			{{end}}
 		</ui>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -227,7 +227,7 @@
 				</div>
 			{{else}}
 				<div class="ui warning message">
-					<a href="{{ .SignInLink }}">{{.i18n.Tr "repo.issues.sign_in_require_desc" | Safe}}</a>
+					<a href="{{.SignInLink}}">{{.i18n.Tr "repo.issues.sign_in_require_desc" | Safe}}</a>
 				</div>
 			{{end}}
 		</ui>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -227,7 +227,6 @@
 				</div>
 			{{else}}
 				<div class="ui warning message">
-					<a href="{{AppSubUrl}}/user/sign_up" class="ui green button">{{.i18n.Tr "repo.issues.sign_up_for_free"}}</a>
 					{{.i18n.Tr "repo.issues.sign_in_require_desc" .SignInLink | Safe}}
 				</div>
 			{{end}}


### PR DESCRIPTION
The "Sign in to comment" link is good enough and will correctly
show or not show the "Sign Up" button link for those not having
an account already.

Fixes #3407 (link to nowhere when registration is disabled)