### PR TITLE
Feature #3398: Redefine global mirror interval

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -358,6 +358,10 @@ MIRROR = 300
 CLONE = 300
 PULL = 300
 
+[mirror]
+; Default interval in hours between each check
+DEFAULT_INTERVAL = 24
+
 [api]
 ; Max number of items will response in a page
 MAX_RESPONSE_ITEMS = 50

--- a/models/repo.go
+++ b/models/repo.go
@@ -724,9 +724,9 @@ func MigrateRepository(u *User, opts MigrateRepoOptions) (*Repository, error) {
 	if opts.IsMirror {
 		if _, err = x.InsertOne(&Mirror{
 			RepoID:      repo.ID,
-			Interval:    24,
+			Interval:    setting.Mirror.GlobalInterval,
 			EnablePrune: true,
-			NextUpdate:  time.Now().Add(24 * time.Hour),
+			NextUpdate:  time.Now().Add(time.Duration(setting.Mirror.GlobalInterval) * time.Hour),
 		}); err != nil {
 			return repo, fmt.Errorf("InsertOne: %v", err)
 		}

--- a/models/repo.go
+++ b/models/repo.go
@@ -724,9 +724,9 @@ func MigrateRepository(u *User, opts MigrateRepoOptions) (*Repository, error) {
 	if opts.IsMirror {
 		if _, err = x.InsertOne(&Mirror{
 			RepoID:      repo.ID,
-			Interval:    setting.Mirror.GlobalInterval,
+			Interval:    setting.Mirror.DefaultInterval,
 			EnablePrune: true,
-			NextUpdate:  time.Now().Add(time.Duration(setting.Mirror.GlobalInterval) * time.Hour),
+			NextUpdate:  time.Now().Add(time.Duration(setting.Mirror.DefaultInterval) * time.Hour),
 		}); err != nil {
 			return repo, fmt.Errorf("InsertOne: %v", err)
 		}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -207,6 +207,10 @@ var (
 		} `ini:"git.timeout"`
 	}
 
+	Mirror struct {
+		DefaultInterval int
+	}
+
 	// API settings
 	API struct {
 		MaxResponseItems int
@@ -498,6 +502,12 @@ func NewContext() {
 		log.Fatal(4, "Fail to map Git settings: %v", err)
 	} else if err = Cfg.Section("api").MapTo(&API); err != nil {
 		log.Fatal(4, "Fail to map API settings: %v", err)
+	} else if err = Cfg.Section("mirror").MapTo(&Mirror); err != nil {
+		log.Fatal(4, "Fail to map API settings: %v", err)
+	}
+
+	if Mirror.DefaultInterval <= 0 {
+		Mirror.DefaultInterval = 24
 	}
 
 	Langs = Cfg.Section("i18n").Key("LANGS").Strings(",")
@@ -521,10 +531,6 @@ var Service struct {
 	EnableReverseProxyAuth         bool
 	EnableReverseProxyAutoRegister bool
 	EnableCaptcha                  bool
-}
-
-var Mirror struct {
-	DefaultInterval int
 }
 
 func newService() {
@@ -720,14 +726,6 @@ func newWebhookService() {
 	Webhook.PagingNum = sec.Key("PAGING_NUM").MustInt(10)
 }
 
-func newMirrorService() {
-	sec := Cfg.Section("mirror")
-	Mirror.DefaultInterval = sec.Key("DEFAULT_INTERVAL").MustInt(24)
-	if Mirror.DefaultInterval <= 0 {
-		Mirror.DefaultInterval = 1
-	}
-}
-
 func NewServices() {
 	newService()
 	newLogService()
@@ -737,5 +735,4 @@ func NewServices() {
 	newRegisterMailService()
 	newNotifyMailService()
 	newWebhookService()
-	newMirrorService()
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -524,7 +524,7 @@ var Service struct {
 }
 
 var Mirror struct {
-	GlobalInterval int
+	DefaultInterval int
 }
 
 func newService() {
@@ -722,9 +722,9 @@ func newWebhookService() {
 
 func newMirrorService() {
 	sec := Cfg.Section("mirror")
-	Mirror.GlobalInterval = sec.Key("GLOBAL_INTERVAL").MustInt(24)
-	if Mirror.GlobalInterval <= 0 {
-		Mirror.GlobalInterval = 1
+	Mirror.DefaultInterval = sec.Key("DEFAULT_INTERVAL").MustInt(24)
+	if Mirror.DefaultInterval <= 0 {
+		Mirror.DefaultInterval = 1
 	}
 }
 

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -523,6 +523,10 @@ var Service struct {
 	EnableCaptcha                  bool
 }
 
+var Mirror struct {
+	GlobalInterval int
+}
+
 func newService() {
 	sec := Cfg.Section("service")
 	Service.ActiveCodeLives = sec.Key("ACTIVE_CODE_LIVE_MINUTES").MustInt(180)
@@ -716,6 +720,14 @@ func newWebhookService() {
 	Webhook.PagingNum = sec.Key("PAGING_NUM").MustInt(10)
 }
 
+func newMirrorService() {
+	sec := Cfg.Section("mirror")
+	Mirror.GlobalInterval = sec.Key("GLOBAL_INTERVAL").MustInt(24)
+	if Mirror.GlobalInterval <= 0 {
+		Mirror.GlobalInterval = 1
+	}
+}
+
 func NewServices() {
 	newService()
 	newLogService()
@@ -725,4 +737,5 @@ func NewServices() {
 	newRegisterMailService()
 	newNotifyMailService()
 	newWebhookService()
+	newMirrorService()
 }


### PR DESCRIPTION
This pull request add new key on `app.ini` to configure the mirror global interval (#3398).

By example, to set mirror global interval to 6 hours rather than 24 :
```
[mirror]
GLOBAL_INTERVAL = 6
```
