### PR TITLE
Fix #3314: Cannot edit release with tag name contains slash

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -485,8 +485,8 @@ func runWeb(ctx *cli.Context) error {
 		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)
-			m.Get("/edit/:tagname", repo.EditRelease)
-			m.Post("/edit/:tagname", bindIgnErr(auth.EditReleaseForm{}), repo.EditReleasePost)
+			m.Get("/edit/*", repo.EditRelease)
+			m.Post("/edit/*", bindIgnErr(auth.EditReleaseForm{}), repo.EditReleasePost)
 			m.Post("/delete", repo.DeleteRelease)
 		}, reqRepoWriter, context.RepoRef())
 

--- a/routers/repo/release.go
+++ b/routers/repo/release.go
@@ -214,7 +214,7 @@ func EditRelease(ctx *context.Context) {
 	ctx.Data["PageIsReleaseList"] = true
 	ctx.Data["PageIsEditRelease"] = true
 
-	tagName := ctx.Params(":tagname")
+	tagName := ctx.Params("*")
 	rel, err := models.GetRelease(ctx.Repo.Repository.ID, tagName)
 	if err != nil {
 		if models.IsErrReleaseNotExist(err) {
@@ -239,7 +239,7 @@ func EditReleasePost(ctx *context.Context, form auth.EditReleaseForm) {
 	ctx.Data["PageIsReleaseList"] = true
 	ctx.Data["PageIsEditRelease"] = true
 
-	tagName := ctx.Params(":tagname")
+	tagName := ctx.Params("*")
 	rel, err := models.GetRelease(ctx.Repo.Repository.ID, tagName)
 	if err != nil {
 		if models.IsErrReleaseNotExist(err) {


### PR DESCRIPTION
This pull request aim to fix issue #3314 with non flat tagname (ie: release/x.x.x) leading to a 404 error when user trying to edit it.

EDIT: @Unknwon  I have re-created Pull Request because used CLA system don't accept misconfigured email on commit.