### PR TITLE
Fix for #3410 overall issues for organisations is limited to num_repo…

### DIFF
--- a/routers/user/home.go
+++ b/routers/user/home.go
@@ -202,7 +202,7 @@ func Issues(ctx *context.Context) {
 	var err error
 	var repos []*models.Repository
 	if ctxUser.IsOrganization() {
-		repos, _, err = ctxUser.GetUserRepositories(ctx.User.ID, 1, ctx.User.NumRepos)
+		repos, _, err = ctxUser.GetUserRepositories(ctx.User.ID, 1, ctxUser.NumRepos)
 		if err != nil {
 			ctx.Handle(500, "GetRepositories", err)
 			return


### PR DESCRIPTION
Changed a reference to RepoNum so it is based on the org's repo count instead of the user's.

See #3410