### PR TITLE
Add committer information to API and Webhooks. Also fixes #3271

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -234,11 +234,13 @@ func issueIndexTrimRight(c rune) bool {
 }
 
 type PushCommit struct {
-	Sha1        string
-	Message     string
-	AuthorEmail string
-	AuthorName  string
-	Timestamp   time.Time
+	Sha1           string
+	Message        string
+	AuthorEmail    string
+	AuthorName     string
+	CommitterEmail string
+	CommitterName  string
+	Timestamp      time.Time
 }
 
 type PushCommits struct {
@@ -263,6 +265,12 @@ func (pc *PushCommits) ToApiPayloadCommits(repoLink string) []*api.PayloadCommit
 		if err == nil {
 			authorUsername = author.Name
 		}
+		committerUsername := ""
+		committer, err := GetUserByEmail(commit.CommitterEmail)
+		if err == nil {
+			// TODO: check errors other than email not found.
+			committerUsername = committer.Name
+		}
 		commits[i] = &api.PayloadCommit{
 			ID:      commit.Sha1,
 			Message: commit.Message,
@@ -271,6 +279,11 @@ func (pc *PushCommits) ToApiPayloadCommits(repoLink string) []*api.PayloadCommit
 				Name:     commit.AuthorName,
 				Email:    commit.AuthorEmail,
 				UserName: authorUsername,
+			},
+			Committer: &api.PayloadCommitter{
+				Name:     commit.CommitterName,
+				Email:    commit.CommitterEmail,
+				UserName: committerUsername,
 			},
 			Timestamp: commit.Timestamp,
 		}

--- a/models/update.go
+++ b/models/update.go
@@ -57,11 +57,13 @@ func ListToPushCommits(l *list.List) *PushCommits {
 		}
 		commits = append(commits,
 			&PushCommit{
-				Sha1:        commit.ID.String(),
-				Message:     commit.Message(),
-				AuthorEmail: commit.Author.Email,
-				AuthorName:  commit.Author.Name,
-				Timestamp:   commit.Author.When,
+				Sha1:           commit.ID.String(),
+				Message:        commit.Message(),
+				AuthorEmail:    commit.Author.Email,
+				AuthorName:     commit.Author.Name,
+				CommitterEmail: commit.Committer.Email,
+				CommitterName:  commit.Committer.Name,
+				Timestamp:      commit.Author.When,
 			})
 	}
 	return &PushCommits{l.Len(), commits, "", nil}

--- a/routers/api/v1/convert/convert.go
+++ b/routers/api/v1/convert/convert.go
@@ -69,15 +69,31 @@ func ToBranch(b *models.Branch, c *git.Commit) *api.Branch {
 }
 
 func ToCommit(c *git.Commit) *api.PayloadCommit {
+	authorUsername := ""
+	author, err := models.GetUserByEmail(c.Author.Email)
+	if err == nil {
+		authorUsername = author.Name
+	}
+	committerUsername := ""
+	committer, err := models.GetUserByEmail(c.Committer.Email)
+	if err == nil {
+		committerUsername = committer.Name
+	}
 	return &api.PayloadCommit{
 		ID:      c.ID.String(),
 		Message: c.Message(),
 		URL:     "Not implemented",
 		Author: &api.PayloadAuthor{
-			Name:  c.Committer.Name,
-			Email: c.Committer.Email,
-			/* UserName: c.Committer.UserName, */
+			Name:     c.Author.Name,
+			Email:    c.Author.Email,
+			UserName: authorUsername,
 		},
+		Committer: &api.PayloadCommitter{
+			Name:     c.Committer.Name,
+			Email:    c.Committer.Email,
+			UserName: committerUsername,
+		},
+		Timestamp: c.Author.When,
 	}
 }
 

--- a/routers/repo/webhook.go
+++ b/routers/repo/webhook.go
@@ -359,6 +359,10 @@ func TestWebhook(ctx *context.Context) {
 					Name:  ctx.Repo.Commit.Author.Name,
 					Email: ctx.Repo.Commit.Author.Email,
 				},
+				Committer: &api.PayloadCommitter{
+					Name:  ctx.Repo.Commit.Committer.Name,
+					Email: ctx.Repo.Commit.Committer.Email,
+				},
 			},
 		},
 		Repo: ctx.Repo.Repository.ComposePayload(),


### PR DESCRIPTION
This PR contains the following changes:
-Fixes the bug mentioned in #3271 where the committer is listed in the author information on API calls
-Expands both the API and Webhooks to include committer user information
-Include usernames for both authors and committers (this was enabled for Webhooks, but not for the API)

This PR depends on gogits/go-gogs-client#40