### PR TITLE
Fix #3379: syntax error at or near

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -414,8 +414,11 @@ func RemoveOrgUser(orgID, userID int64) error {
 			return err
 		}
 	}
-	if _, err = sess.Where("user_id = ?", user.ID).In("repo_id", repoIDs).Delete(new(Access)); err != nil {
-		return err
+
+	if len(repoIDs) > 0 {
+		if _, err = sess.Where("user_id = ?", user.ID).In("repo_id", repoIDs).Delete(new(Access)); err != nil {
+			return err
+		}
 	}
 
 	// Delete member in his/her teams.


### PR DESCRIPTION
Fix issue when user want leave an organization (issue #3379) and don't have repositories.

Fixed by just adding a check before using the SQL statement IN who can't be used with empty list.