### PR TITLE
Fix #3420: Bad commit reference URL generation

### DIFF
--- a/modules/markdown/markdown.go
+++ b/modules/markdown/markdown.go
@@ -260,12 +260,9 @@ func RenderIssueIndexPattern(rawBytes []byte, urlPrefix string, metas map[string
 
 // RenderSha1CurrentPattern renders SHA1 strings to corresponding links that assumes in the same repository.
 func RenderSha1CurrentPattern(rawBytes []byte, urlPrefix string) []byte {
-	ms := Sha1CurrentPattern.FindAll(rawBytes, -1)
-	for _, m := range ms {
-		rawBytes = bytes.Replace(rawBytes, m, []byte(fmt.Sprintf(
-			`<a href="%s/commit/%s"><code>%s</code></a>`, urlPrefix, m, base.ShortSha(string(m)))), -1)
-	}
-	return rawBytes
+	return []byte(Sha1CurrentPattern.ReplaceAllStringFunc(string(rawBytes[:]), func(m string) string {
+		return fmt.Sprintf(`<a href="%s/commit/%s"><code>%s</code></a>`, urlPrefix, m, base.ShortSha(string(m)))
+	}))
 }
 
 // RenderSpecialLink renders mentions, indexes and SHA1 strings to corresponding links.


### PR DESCRIPTION
This pull request fix issue #3420: when the same commit tag is referenced more than one time on a single message, generated link are not valids.


## Test
```
2eb7f261c1502b6f8981267f6c142f4563da5f37 or 2eb7f261c1502b6f8981267f6c142f4563da5f37
```

![image](https://cloud.githubusercontent.com/assets/1005086/17552911/2b9d7e8c-5f03-11e6-800e-077c7e5ab279.png)
