### PR TITLE
Fix for #3396 - Pull request conflict status not updating properly

### DIFF
--- a/models/pull.go
+++ b/models/pull.go
@@ -253,6 +253,7 @@ func (pr *PullRequest) Merge(doer *User, baseGitRepo *git.Repository) (err error
 		return fmt.Errorf("PrepareWebhooks: %v", err)
 	}
 	go HookQueue.Add(pr.BaseRepo.ID)
+	go AddTestPullRequestTask(pr.BaseRepo.ID, pr.BaseBranch)
 	return nil
 }
 


### PR DESCRIPTION
Fix for #3396.  AddTestPullRequestTask needed to be called from PullRequest.Merge.