### PR TITLE
Fix #3430: Typo on cache interval setting key

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -157,7 +157,7 @@ func newMacaron() *macaron.Macaron {
 	m.Use(cache.Cacher(cache.Options{
 		Adapter:       setting.CacheAdapter,
 		AdapterConfig: setting.CacheConn,
-		Interval:      setting.CacheInternal,
+		Interval:      setting.CacheInterval,
 	}))
 	m.Use(captcha.Captchaer(captcha.Options{
 		SubURL: setting.AppSubUrl,

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -164,7 +164,7 @@ var (
 
 	// Cache settings
 	CacheAdapter  string
-	CacheInternal int
+	CacheInterval int
 	CacheConn     string
 
 	// Session settings
@@ -645,7 +645,7 @@ func newCacheService() {
 	CacheAdapter = Cfg.Section("cache").Key("ADAPTER").In("memory", []string{"memory", "redis", "memcache"})
 	switch CacheAdapter {
 	case "memory":
-		CacheInternal = Cfg.Section("cache").Key("INTERVAL").MustInt(60)
+		CacheInterval = Cfg.Section("cache").Key("INTERVAL").MustInt(60)
 	case "redis", "memcache":
 		CacheConn = strings.Trim(Cfg.Section("cache").Key("HOST").String(), "\" ")
 	default:

--- a/routers/admin/admin.go
+++ b/routers/admin/admin.go
@@ -216,7 +216,7 @@ func Config(ctx *context.Context) {
 	}
 
 	ctx.Data["CacheAdapter"] = setting.CacheAdapter
-	ctx.Data["CacheInternal"] = setting.CacheInternal
+	ctx.Data["CacheInterval"] = setting.CacheInterval
 	ctx.Data["CacheConn"] = setting.CacheConn
 
 	ctx.Data["SessionConfig"] = setting.SessionConfig

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -178,7 +178,7 @@
 						<dt>{{.i18n.Tr "admin.config.cache_adapter"}}</dt>
 						<dd>{{.CacheAdapter}}</dd>
 						<dt>{{.i18n.Tr "admin.config.cache_interval"}}</dt>
-						<dd>{{.CacheInternal}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
+						<dd>{{.CacheInterval}} {{.i18n.Tr "tool.raw_seconds"}}</dd>
 						{{if .CacheConn}}
 						<dt>{{.i18n.Tr "admin.config.cache_conn"}}</dt>
 						<dd><code>{{.CacheConn}}</code></dd>


### PR DESCRIPTION
Rename key `CacheInternal` with `CacheInterval` (issue #3430).