### PR TITLE
Always set redirect_to on header-provided sign-in

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -139,7 +139,7 @@
 												<i class="octicon octicon-person"></i> {{.i18n.Tr "register"}}
 											</a>
 										{{end}}
-										<a class="item{{if .PageIsSignIn}} active{{end}}" href="{{AppSubUrl}}/user/login">
+										<a class="item{{if .PageIsSignIn}} active{{end}}" href="{{AppSubUrl}}/user/login?redirect_to={{.Link}}">
 											<i class="octicon octicon-sign-in"></i> {{.i18n.Tr "sign_in"}}
 										</a>
 									</div><!-- end anonymous right menu -->


### PR DESCRIPTION
WIP

This is an attempt to fix #3089 following the strategy introduced
in d625e41c6c4d40fadbeaf99dd97e77aa0c9085ae, although that strategy
by itself does not seem to be sufficient.

What needs be done is honouring the redirect_url query parameter
from the auth router.

\cc @Unknwon 