### PR TITLE
Add Content-Disposition header for attachment downloads

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -325,6 +325,7 @@ func runWeb(ctx *cli.Context) error {
 			defer fr.Close()
 
 			ctx.Header().Set("Cache-Control", "public,max-age=86400")
+			ctx.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, attach.Name))
 			// Fix #312. Attachments with , in their name are not handled correctly by Google Chrome.
 			// We must put the name in " manually.
 			if err = repo.ServeData(ctx, "\""+attach.Name+"\"", fr); err != nil {


### PR DESCRIPTION
This HTTP header tells the browser the filename it should use for downloads.

Today, if you open an image attached in an issue and hit `CTRL+S` to save, the default name would be something like `3adb8e12-4df8-44d4-bba8-d989ea16e58f.jpg`.

With this change, it should be the original filename, something like `my-image-file.jpg`.