### PR TITLE
Fix #3437: Cannot connect to PostgreSQL via IPv6 address

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -114,15 +114,14 @@ func getEngine() (*xorm.Engine, error) {
 		}
 	case "postgres":
 		host, port := "127.0.0.1", "5432"
-		fields := strings.Split(DbCfg.Host, ":")
-		if len(fields) > 0 && len(strings.TrimSpace(fields[0])) > 0 {
-			host = fields[0]
-		}
-		if len(fields) > 1 && len(strings.TrimSpace(fields[1])) > 0 {
-			port = fields[1]
+		if strings.Contains(DbCfg.Host, ":") && !strings.HasSuffix(DbCfg.Host, "]") {
+			host = DbCfg.Host[0:strings.LastIndex(DbCfg.Host, ":")]
+			port = DbCfg.Host[strings.LastIndex(DbCfg.Host, ":")+1:]
+		} else if len(DbCfg.Host) > 0 {
+			host = DbCfg.Host
 		}
 
-		if host[0] == '/' { // looks like a unix socket
+		if DbCfg.Host[0] == '/' { // looks like a unix socket
 			connStr = fmt.Sprintf("postgres://%s:%s@:%s/%s%ssslmode=%s&host=%s",
 				url.QueryEscape(DbCfg.User), url.QueryEscape(DbCfg.Passwd), port, DbCfg.Name, Param, DbCfg.SSLMode, host)
 		} else {

--- a/models/models.go
+++ b/models/models.go
@@ -121,7 +121,7 @@ func getEngine() (*xorm.Engine, error) {
 			host = DbCfg.Host
 		}
 
-		if DbCfg.Host[0] == '/' { // looks like a unix socket
+		if host[0] == '/' { // looks like a unix socket
 			connStr = fmt.Sprintf("postgres://%s:%s@:%s/%s%ssslmode=%s&host=%s",
 				url.QueryEscape(DbCfg.User), url.QueryEscape(DbCfg.Passwd), port, DbCfg.Name, Param, DbCfg.SSLMode, host)
 		} else {

--- a/models/models.go
+++ b/models/models.go
@@ -115,8 +115,9 @@ func getEngine() (*xorm.Engine, error) {
 	case "postgres":
 		host, port := "127.0.0.1", "5432"
 		if strings.Contains(DbCfg.Host, ":") && !strings.HasSuffix(DbCfg.Host, "]") {
-			host = DbCfg.Host[0:strings.LastIndex(DbCfg.Host, ":")]
-			port = DbCfg.Host[strings.LastIndex(DbCfg.Host, ":")+1:]
+			idx := strings.LastIndex(DbCfg.Host, ":")
+			host = DbCfg.Host[:idx]
+			port = DbCfg.Host[idx+1:]
 		} else if len(DbCfg.Host) > 0 {
 			host = DbCfg.Host
 		}


### PR DESCRIPTION
This PR add ability to handle IPv6 address with PostgreSQL (issue #3437). Now `HOST` can be filled with:

- `HOST = 127.0.0.1:5432`
- `HOST = 127.0.0.1`  // Use default port
- `HOST = [::1]`
- `HOST = [::1]:5432`
- `HOST = /tmp/pg.sock`
- `HOST = /tmp/pg.sock:5342`


_Tested on CentOS 7 with PostgreSQL 9.5_