### PR TITLE
#3450: fix grammar + typo.

### DIFF
--- a/templates/admin/auth/new.tmpl
+++ b/templates/admin/auth/new.tmpl
@@ -168,8 +168,8 @@
 					{{.i18n.Tr "admin.auths.tips"}}
 				</h4>
 				<div class="ui attached segment">
-					<h5>GMail Setting:</h5>
-					<p>Host: smtp.gmail.com, Post: 587, Enable TLS Encryption: true</p>
+					<h5>GMail Settings:</h5>
+					<p>Host: smtp.gmail.com, Port: 587, Enable TLS Encryption: true</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fix #3450: For the "Tip" when adding Authentications it says "Post" 587 instead of "Port" 587

