### PR TITLE
Fix #3361: Dumps are created world readable

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -97,7 +97,7 @@ func runDump(ctx *cli.Context) error {
 	}
 
 	if err := os.Chmod(fileName, 0600); err != nil {
-		log.Printf("Can't change file access permission to 0600: %v", err)
+		log.Printf("Can't change file access permissions mask to 0600: %v", err)
 	}
 
 	log.Printf("Removing tmp work dir: %s", TmpWorkDir)

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -96,6 +96,10 @@ func runDump(ctx *cli.Context) error {
 		log.Fatalf("Fail to save %s: %v", fileName, err)
 	}
 
+	if err := os.Chmod(fileName, 0600); err != nil {
+		log.Printf("Can't change file access permission to 0600: %v", err)
+	}
+
 	log.Printf("Removing tmp work dir: %s", TmpWorkDir)
 	os.RemoveAll(TmpWorkDir)
 	log.Printf("Finish dumping in file %s", fileName)


### PR DESCRIPTION
Permission mask of created dumps are now 0600 (-rw-------) rather than 0644 (-rw-rw-r--). As @waldiTM say on the issue #3361,  dump files include private information like database credentials and repositories, access must be limited.