### PR TITLE
Support for choosing Preferred Licenses (#2901)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -425,3 +425,7 @@ cs-CZ = cs-CZ
 SHOW_FOOTER_BRANDING = false
 ; Show version information about gogs and go in the footer
 SHOW_FOOTER_VERSION = true
+; Preferred Licenses to place at the top of the List
+; example:
+; PREFERRED_LICENSES = MIT,BSD 3,GPL Lesser
+PREFERRED_LICENSES =

--- a/models/repo.go
+++ b/models/repo.go
@@ -60,6 +60,22 @@ var (
 	ItemsPerPage = 40
 )
 
+// FIXME: This should probably be done in-place instead of creating a new string-slice...
+func sortPreferredLicenses(licenses []string) []string {
+	output := make([]string, 0)
+	preferred := setting.PreferredLicenses
+	for i, l := range licenses {
+		for _, p := range preferred {
+			if strings.HasSuffix(l, p) {
+				output = append(output, l)
+				licenses = append(licenses[:i], licenses[i+1:])
+			}
+		}
+	}
+	output = append(output, licenses...)
+	return output
+}
+
 func LoadRepoConfig() {
 	// Load .gitignore and license files and readme templates.
 	types := []string{"gitignore", "license", "readme"}
@@ -91,6 +107,7 @@ func LoadRepoConfig() {
 	sort.Strings(Gitignores)
 	sort.Strings(Licenses)
 	sort.Strings(Readmes)
+	Licenses = sortPreferredLicenses(Licenses)
 }
 
 func NewRepoContext() {

--- a/models/repo.go
+++ b/models/repo.go
@@ -62,13 +62,22 @@ var (
 
 // FIXME: This should probably be done in-place instead of creating a new string-slice...
 func sortPreferredLicenses(licenses []string) []string {
-	output := make([]string, 0)
+	output := make([]string, 0, len(licenses))
 	preferred := setting.PreferredLicenses
-	for i, l := range licenses {
-		for _, p := range preferred {
-			if strings.HasSuffix(l, p) {
-				output = append(output, l)
-				licenses = append(licenses[:i], licenses[i+1:])
+	log.Info("%d preferred licenses, they are %#v", len(preferred), preferred)
+	for _, p := range preferred {
+		found := true
+		// run loop until we don't find anything...
+		for found {
+			found = false
+			for i, l := range licenses {
+				if strings.Contains(l, p) {
+					output = append(output, l)
+					log.Info("%s was preferred...", l)
+					licenses = append(licenses[:i], licenses[1+i:]...)
+					found = true
+					break
+				}
 			}
 		}
 	}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -247,6 +247,7 @@ var (
 	ShowFooterBranding    bool
 	ShowFooterVersion     bool
 	SupportMiniWinService bool
+	PreferredLicenses     []string
 
 	// Global setting objects
 	Cfg          *ini.File
@@ -569,6 +570,7 @@ func NewContext() {
 
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
 	ShowFooterVersion = Cfg.Section("other").Key("SHOW_FOOTER_VERSION").MustBool()
+	PreferredLicenses = Cfg.Section("other").Key("PREFERRED_LICENSES").Strings(",")
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }


### PR DESCRIPTION
Implements #2901.

Adding this to `app.ini` will make these Licenses show at the top of the List in the other they are listed.
```ini
[other]
PREFERRED_LICENSES = MIT,BSD,GPLv2
```

Stuff left to fix:
- [x] Should be in defined order instead of alphabetical
- [x] Add Example to default `app.ini`

More?