### PR TITLE
[WIP] mirror update button #2018

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -744,6 +744,11 @@ settings.add_key_success = New deploy key '%s' has been added successfully!
 settings.deploy_key_deletion = Delete Deploy Key
 settings.deploy_key_deletion_desc = Deleting this deploy key will remove all related accesses for this repository. Do you want to continue?
 settings.deploy_key_deletion_success = Deploy key has been deleted successfully!
+settings.mirror_settings = Mirror Settings
+settings.mirror_update = Update Mirror
+settings.mirror_update_notice = This will update this mirror now!
+settings.mirror_update_success = Mirror updated successfully
+settings.not_a_mirror = This is not a mirror repository
 
 diff.browse_source = Browse Source
 diff.parent = parent

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -75,6 +75,20 @@
 						</div>
 					</form>
 				</div>
+				{{if .Repository.IsMirror}}
+				<h4 class="ui top attached header">
+					{{.i18n.Tr "repo.settings.mirror_settings"}}
+				</h4>
+				<div class="ui attached segment">
+					<form class="ui form" action="{{.Link}}" method="post">
+						<input type="hidden" name="action" value="mirror-update">
+						{{.CsrfTokenHtml}}
+						<div class="field">
+							<button class="ui green button">{{.i18n.Tr "repo.settings.mirror_update"}}</button>
+						</div>
+					</form>
+				</div>
+				{{end}}
 
 				<h4 class="ui top attached header">
 					{{.i18n.Tr "repo.settings.advanced_settings"}}


### PR DESCRIPTION
Fixes #2018 

Stuff left to do:
- [ ] Don't use `models.MirrorUpdate()`...

Another PR should move all existing mirror-settings to the new panel. Though I don't wanna bloat this PR with that...

Obligatory image for UI-changes:
![gogs-mirror-update-button](https://cloud.githubusercontent.com/assets/4726179/17912072/a807fda6-6991-11e6-9c00-26f01684b3a7.png)
