### PR TITLE
Fix PR-webhook issue where Label-data is stale (#3486)

### DIFF
--- a/models/issue.go
+++ b/models/issue.go
@@ -233,9 +233,17 @@ func (i *Issue) HasLabel(labelID int64) bool {
 }
 
 func (issue *Issue) sendLabelUpdatedWebhook(doer *User) {
-	var err error
+	var (
+		new_issue *Issue
+		err       error
+	)
 	if issue.IsPull {
-		issue.PullRequest.Issue = issue
+		new_issue, err = GetIssueByID(issue.ID)
+		if err != nil {
+			log.Error(4, "GetIssueByID(%d): %v", issue.ID, err)
+			return
+		}
+		issue.PullRequest.Issue = new_issue
 		err = PrepareWebhooks(issue.Repo, HOOK_EVENT_PULL_REQUEST, &api.PullRequestPayload{
 			Action:      api.HOOK_ISSUE_LABEL_UPDATED,
 			Index:       issue.Index,
@@ -335,7 +343,13 @@ func (issue *Issue) ClearLabels(doer *User) (err error) {
 	}
 
 	if issue.IsPull {
-		issue.PullRequest.Issue = issue
+		var new_issue *Issue
+		new_issue, err = GetIssueByID(issue.ID)
+		if err != nil {
+			log.Error(4, "GetIssueByID(%d): %v", issue.ID, err)
+			return
+		}
+		issue.PullRequest.Issue = new_issue
 		err = PrepareWebhooks(issue.Repo, HOOK_EVENT_PULL_REQUEST, &api.PullRequestPayload{
 			Action:      api.HOOK_ISSUE_LABEL_CLEARED,
 			Index:       issue.Index,

--- a/models/issue.go
+++ b/models/issue.go
@@ -233,17 +233,13 @@ func (i *Issue) HasLabel(labelID int64) bool {
 }
 
 func (issue *Issue) sendLabelUpdatedWebhook(doer *User) {
-	var (
-		new_issue *Issue
-		err       error
-	)
+	var err error
 	if issue.IsPull {
-		new_issue, err = GetIssueByID(issue.ID)
+		err = issue.PullRequest.LoadIssue()
 		if err != nil {
-			log.Error(4, "GetIssueByID(%d): %v", issue.ID, err)
+			log.Error(4, "LoadIssue: %v", err)
 			return
 		}
-		issue.PullRequest.Issue = new_issue
 		err = PrepareWebhooks(issue.Repo, HOOK_EVENT_PULL_REQUEST, &api.PullRequestPayload{
 			Action:      api.HOOK_ISSUE_LABEL_UPDATED,
 			Index:       issue.Index,
@@ -343,13 +339,11 @@ func (issue *Issue) ClearLabels(doer *User) (err error) {
 	}
 
 	if issue.IsPull {
-		var new_issue *Issue
-		new_issue, err = GetIssueByID(issue.ID)
+		err = issue.PullRequest.LoadIssue()
 		if err != nil {
 			log.Error(4, "GetIssueByID(%d): %v", issue.ID, err)
 			return
 		}
-		issue.PullRequest.Issue = new_issue
 		err = PrepareWebhooks(issue.Repo, HOOK_EVENT_PULL_REQUEST, &api.PullRequestPayload{
 			Action:      api.HOOK_ISSUE_LABEL_CLEARED,
 			Index:       issue.Index,

--- a/models/issue.go
+++ b/models/issue.go
@@ -341,7 +341,7 @@ func (issue *Issue) ClearLabels(doer *User) (err error) {
 	if issue.IsPull {
 		err = issue.PullRequest.LoadIssue()
 		if err != nil {
-			log.Error(4, "GetIssueByID(%d): %v", issue.ID, err)
+			log.Error(4, "LoadIssue: %v", err)
 			return
 		}
 		err = PrepareWebhooks(issue.Repo, HOOK_EVENT_PULL_REQUEST, &api.PullRequestPayload{


### PR DESCRIPTION
Fixes #3486 

Label-data is stale, so we have to fetch Issue-data again before sending it...

(Please feel free to suggest a better idea :laughing: )