### PR TITLE
added support to set pull_request event from api

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -165,12 +165,15 @@ func (w *Webhook) HasPullRequestEvent() bool {
 }
 
 func (w *Webhook) EventsArray() []string {
-	events := make([]string, 0, 2)
+	events := make([]string, 0, 3)
 	if w.HasCreateEvent() {
 		events = append(events, "create")
 	}
 	if w.HasPushEvent() {
 		events = append(events, "push")
+	}
+	if w.HasPullRequestEvent() {
+		events = append(events, "pull_request")
 	}
 	return events
 }

--- a/routers/api/v1/repo/hook.go
+++ b/routers/api/v1/repo/hook.go
@@ -59,8 +59,9 @@ func CreateHook(ctx *context.APIContext, form api.CreateHookOption) {
 		HookEvent: &models.HookEvent{
 			ChooseEvents: true,
 			HookEvents: models.HookEvents{
-				Create: com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_CREATE)),
-				Push:   com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_PUSH)),
+				Create:      com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_CREATE)),
+				Push:        com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_PUSH)),
+				PullRequest: com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_PULL_REQUEST)),
 			},
 		},
 		IsActive:     form.Active,
@@ -146,6 +147,7 @@ func EditHook(ctx *context.APIContext, form api.EditHookOption) {
 	w.ChooseEvents = true
 	w.Create = com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_CREATE))
 	w.Push = com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_PUSH))
+	w.PullRequest = com.IsSliceContainsStr(form.Events, string(models.HOOK_EVENT_PULL_REQUEST))
 	if err = w.UpdateEvent(); err != nil {
 		ctx.Error(500, "UpdateEvent", err)
 		return


### PR DESCRIPTION
The pull_request event for webhooks was not supported when creating/updating webhooks via the API, this is a fix for that.

