### PR TITLE
Fixed typo

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -877,7 +877,7 @@ func initRepoCommit(tmpPath string, sig *git.Signature) (err error) {
 	if _, stderr, err = process.ExecDir(-1,
 		tmpPath, fmt.Sprintf("initRepoCommit (git commit): %s", tmpPath),
 		"git", "commit", fmt.Sprintf("--author='%s <%s>'", sig.Name, sig.Email),
-		"-m", "initial commit"); err != nil {
+		"-m", "Initial commit"); err != nil {
 		return fmt.Errorf("git commit: %s", stderr)
 	}
 


### PR DESCRIPTION
Git convention has it capitalised, this triggers a lot of OCD in some people.