### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,17 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
 
-[*.yml]
+[*.{go,tmpl}]
+indent_style = tab
+indent_size = 4
+
+[*.{less,yml}]
 indent_style = space
 indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
The primary motivation is documenting `.less`, `.js` and `.tmpl` extensions, conform existing conventions.
