### PR TITLE
#3535 : Add in plumbing for new setting (ArchiveFullPath)

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -112,6 +112,7 @@ var (
 	Repository struct {
 		AnsiCharset            string
 		ForcePrivate           bool
+		ArchiveFullPath        bool
 		MaxCreationLimit       int
 		PullRequestQueueLength int
 		PreferredLicenses      []string
@@ -131,9 +132,9 @@ var (
 			MaxFiles     int
 		} `ini:"-"`
 	}
-	RepoRootPath string
-	ScriptType   string
-
+	RepoRootPath    string
+	ScriptType      string
+	ArchiveFullPath bool
 	// UI settings
 	UI struct {
 		ExplorePagingNum   int
@@ -489,6 +490,7 @@ func NewContext() {
 	// Determine and create root git repository path.
 	sec = Cfg.Section("repository")
 	RepoRootPath = sec.Key("ROOT").MustString(path.Join(homeDir, "gogs-repositories"))
+	ArchiveFullPath = sec.Key("ARCHIVE_FULL_PATH").MustBool(true)
 	forcePathSeparator(RepoRootPath)
 	if !filepath.IsAbs(RepoRootPath) {
 		RepoRootPath = path.Join(workDir, RepoRootPath)

--- a/routers/repo/repo.go
+++ b/routers/repo/repo.go
@@ -324,7 +324,7 @@ func Download(ctx *context.Context) {
 
 	archivePath = path.Join(archivePath, base.ShortSha(commit.ID.String())+ext)
 	if !com.IsFile(archivePath) {
-		if err := commit.CreateArchive(archivePath, archiveType); err != nil {
+		if err := commit.CreateArchive(archivePath, archiveType, setting.ArchiveFullPath); err != nil {
 			ctx.Handle(500, "Download -> CreateArchive "+archivePath, err)
 			return
 		}


### PR DESCRIPTION
#3535 : Add plumbing for new settings flag (ArchiveFullPath) which will dictate the prefix flag when generation an archive for ( Tag|Branch|Commit|Release ) 
(this is one of the requests other is : [https://github.com/gogits/git-module/pull/16])