### PR TITLE
Feature #3492: Add option to hide footer load times

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -428,7 +428,7 @@ cs-CZ = cs-CZ
 
 [other]
 SHOW_FOOTER_BRANDING = false
-; Show version information about gogs and go in the footer
+; Show version information about Gogs and Go in the footer
 SHOW_FOOTER_VERSION = true
-; Show load times
-SHOW_FOOTER_LOAD_TIMES = true
+; Show time of template execution in the footer
+SHOW_FOOTER_TEMPLATE_LOAD_TIME = true

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -430,3 +430,5 @@ cs-CZ = cs-CZ
 SHOW_FOOTER_BRANDING = false
 ; Show version information about gogs and go in the footer
 SHOW_FOOTER_VERSION = true
+; Show load times
+SHOW_FOOTER_LOAD_TIMES = true

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -70,6 +70,7 @@ var (
 	StaticRootPath       string
 	EnableGzip           bool
 	LandingPageURL       LandingPage
+	ShowFooterLoadTimes  bool
 	UnixSocketPermission uint32
 
 	SSH struct {
@@ -571,6 +572,7 @@ func NewContext() {
 
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
 	ShowFooterVersion = Cfg.Section("other").Key("SHOW_FOOTER_VERSION").MustBool()
+	ShowFooterLoadTimes = Cfg.Section("other").Key("SHOW_FOOTER_LOAD_TIMES").MustBool()
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -70,7 +70,6 @@ var (
 	StaticRootPath       string
 	EnableGzip           bool
 	LandingPageURL       LandingPage
-	ShowFooterLoadTimes  bool
 	UnixSocketPermission uint32
 
 	SSH struct {
@@ -247,9 +246,10 @@ var (
 	// Highlight settings are loaded in modules/template/hightlight.go
 
 	// Other settings
-	ShowFooterBranding    bool
-	ShowFooterVersion     bool
-	SupportMiniWinService bool
+	ShowFooterBranding         bool
+	ShowFooterVersion          bool
+	ShowFooterTemplateLoadTime bool
+	SupportMiniWinService      bool
 
 	// Global setting objects
 	Cfg          *ini.File
@@ -572,7 +572,7 @@ func NewContext() {
 
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
 	ShowFooterVersion = Cfg.Section("other").Key("SHOW_FOOTER_VERSION").MustBool()
-	ShowFooterLoadTimes = Cfg.Section("other").Key("SHOW_FOOTER_LOAD_TIMES").MustBool()
+	ShowFooterTemplateLoadTime = Cfg.Section("other").Key("SHOW_FOOTER_TEMPLATE_LOAD_TIME").MustBool()
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -52,8 +52,8 @@ func NewFuncMap() []template.FuncMap {
 		"DisableGravatar": func() bool {
 			return setting.DisableGravatar
 		},
-		"ShowFooterLoadTimes": func() bool {
-			return setting.ShowFooterLoadTimes
+		"ShowFooterTemplateLoadTime": func() bool {
+			return setting.ShowFooterTemplateLoadTime
 		},
 		"LoadTimes": func(startTime time.Time) string {
 			return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -52,6 +52,9 @@ func NewFuncMap() []template.FuncMap {
 		"DisableGravatar": func() bool {
 			return setting.DisableGravatar
 		},
+		"ShowFooterLoadTimes": func() bool {
+			return setting.ShowFooterLoadTimes
+		},
 		"LoadTimes": func(startTime time.Time) string {
 			return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"
 		},

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -7,7 +7,7 @@
 	<footer>
 		<div class="ui container">
 			<div class="ui left">
-				© 2016 Gogs {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if eq ShowFooterLoadTimes true}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
+				© 2016 Gogs {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if ShowFooterTemplateLoadTime}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
 			</div>
 			<div class="ui right links">
 				{{if .ShowFooterBranding}}

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -7,7 +7,7 @@
 	<footer>
 		<div class="ui container">
 			<div class="ui left">
-				© 2016 Gogs {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>
+				© 2016 Gogs {{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}}{{end}} {{if eq ShowFooterLoadTimes true}}{{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
 			</div>
 			<div class="ui right links">
 				{{if .ShowFooterBranding}}
@@ -50,5 +50,5 @@
 {{end}}
 <script src="{{AppSubUrl}}/js/libs/emojify-1.1.0.min.js"></script>
 <script src="{{AppSubUrl}}/js/libs/clipboard-1.5.9.min.js"></script>
-	
+
 </html>


### PR DESCRIPTION
This pull request add a new option (`SHOW_FOOTER_LOAD_TIMES`) to toggle on/off the footer load times information (Issue #3492).

**Extract from app.ini**
```
[other]
SHOW_FOOTER_BRANDING = false
; Show version information about gogs and go in the footer
SHOW_FOOTER_VERSION = true
; Show load times
SHOW_FOOTER_LOAD_TIMES = true
```
