### PR TITLE
Fix repo list display on Safari (fixes #2875)

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2741,6 +2741,10 @@ footer .ui.language .menu {
 .dashboard.issues .ui.right .head.menu .item.active {
   color: #d9453d;
 }
+.feeds .news > .ui.grid {
+  margin-left: auto;
+  margin-right: auto;
+}
 .feeds .news .ui.avatar {
   margin-top: 13px;
 }

--- a/public/less/_dashboard.less
+++ b/public/less/_dashboard.less
@@ -52,6 +52,10 @@
 
 &.feeds {
 	.news {
+		> .ui.grid {
+			margin-left: auto;
+			margin-right: auto;
+		}
 		.ui.avatar {
 			margin-top: 13px;
 		}


### PR DESCRIPTION
I'm not totally sure whether this is the best way to tackle this issue. However, this PR fixes repo list displays for OSX on Safari, making them consistent with other browsers (issue #2875).

Dashboard without fix:
<img width="1298" alt="gogs-dash-fail" src="https://cloud.githubusercontent.com/assets/251281/18165880/323f2d78-708b-11e6-8f35-e01d3eac1c6d.png">

Dashboard with fix:
<img width="1280" alt="gogs-dash-success" src="https://cloud.githubusercontent.com/assets/251281/18165885/364f163a-708b-11e6-9cc9-31047666fbbe.png">

Profile without fix:
<img width="1267" alt="gogs-profile-fail" src="https://cloud.githubusercontent.com/assets/251281/18165891/3c3c5c74-708b-11e6-952c-2a9f99436b0f.png">

Profile with fix:
<img width="1281" alt="gogs-profile-success" src="https://cloud.githubusercontent.com/assets/251281/18165893/3fd71cc0-708b-11e6-9ead-303c8ee06142.png">