### PR TITLE
Fix for 3590: 404 on editing a draft release

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -497,10 +497,13 @@ func runWeb(ctx *cli.Context) error {
 		m.Group("/releases", func() {
 			m.Get("/new", repo.NewRelease)
 			m.Post("/new", bindIgnErr(auth.NewReleaseForm{}), repo.NewReleasePost)
+		}, reqRepoWriter, context.RepoRef())
+
+		m.Group("/releases", func() {
 			m.Get("/edit/*", repo.EditRelease)
 			m.Post("/edit/*", bindIgnErr(auth.EditReleaseForm{}), repo.EditReleasePost)
 			m.Post("/delete", repo.DeleteRelease)
-		}, reqRepoWriter, context.RepoRef())
+		}, reqRepoWriter, context.DefaultRepoRefOnDraftRelease())
 
 		m.Combo("/compare/*", repo.MustAllowPulls).Get(repo.CompareAndPullRequest).
 			Post(bindIgnErr(auth.CreateIssueForm{}), repo.CompareAndPullRequestPost)


### PR DESCRIPTION
This PR addresses #3590 by loading default repository references when a editing or deleting a release that is in draft state.