### PR TITLE
fix bug #1122 log.smtp receiver configure error

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -334,7 +334,7 @@ HOST =
 ; Mailer user name and password
 USER =
 PASSWD =
-; Receivers, can be one or more, e.g. ["1@example.com","2@example.com"]
+; Receivers, can be one or more, e.g. 1@example.com,2@example.com
 RECEIVERS =
 
 ; For "database" mode only

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -664,11 +664,11 @@ func newLogService() {
 				sec.Key("PROTOCOL").In("tcp", []string{"tcp", "unix", "udp"}),
 				sec.Key("ADDR").MustString(":7020"))
 		case "smtp":
-			LogConfigs[i] = fmt.Sprintf(`{"level":%s,"username":"%s","password":"%s","host":"%s","sendTos":"%s","subject":"%s"}`, level,
+			LogConfigs[i] = fmt.Sprintf(`{"level":%s,"username":"%s","password":"%s","host":"%s","sendTos":["%s"],"subject":"%s"}`, level,
 				sec.Key("USER").MustString("example@example.com"),
 				sec.Key("PASSWD").MustString("******"),
 				sec.Key("HOST").MustString("127.0.0.1:25"),
-				sec.Key("RECEIVERS").MustString("[]"),
+				strings.Replace(sec.Key("RECEIVERS").MustString("example@example.com"), ",", "\",\"", -1),
 				sec.Key("SUBJECT").MustString("Diagnostic message from serve"))
 		case "database":
 			LogConfigs[i] = fmt.Sprintf(`{"level":%s,"driver":"%s","conn":"%s"}`, level,


### PR DESCRIPTION
INI file doesn't support array format with bracket "[]",
It may be better to use ',' to split it.
