### PR TITLE
Enable Ubuntu 16.04 build at packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -7,10 +7,15 @@ targets:
       - git
   debian-8:
     <<: *debian
-  ubuntu-14.04:
-    <<: *debian
   ubuntu-12.04:
     <<: *debian
+  ubuntu-14.04:
+    <<: *debian
+  ubuntu-16.04:
+    <<: *debian
+    build_dependencies:
+      - bzr
+      - mercurial
   centos-6: &el
     build_dependencies:
       - pam-devel


### PR DESCRIPTION
This enables building a package for Ubuntu 16.04 LTS (Xenial) as suggested in #1263. I seriously have no idea why bzr and mercurial are needed as build dependencies, but the build only proceeds with them; I got the idea from the packager.io go example project.

The build succeeds: https://packager.io/gh/gianperrone/gogs/build_runs/8#71773
I have a test installation running and found no problems.
