### PR TITLE
More Issue-Comments API-endpoints

### DIFF
--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -115,13 +115,51 @@ func (c *Comment) AfterDelete() {
 	}
 }
 
+func (c *Comment) HTMLURL() string {
+	issue, err := GetIssueByID(c.IssueID)
+	if err != nil { // Silently dropping errors :unamused:
+		log.Error(4, "GetIssueByID(%d): %v", c.IssueID, err)
+		return ""
+	}
+	return fmt.Sprintf("%s#issuecomment-%d", issue.HTMLURL(), c.ID)
+}
+
+func (c *Comment) IssueURL() string {
+	issue, err := GetIssueByID(c.IssueID)
+	if err != nil { // Silently dropping errors :unamused:
+		log.Error(4, "GetIssueByID(%d): %v", c.IssueID, err)
+		return ""
+	}
+
+	if issue.IsPull {
+		return ""
+	}
+	return issue.HTMLURL()
+}
+
+func (c *Comment) PRURL() string {
+	issue, err := GetIssueByID(c.IssueID)
+	if err != nil { // Silently dropping errors :unamused:
+		log.Error(4, "GetIssueByID(%d): %v", c.IssueID, err)
+		return ""
+	}
+
+	if !issue.IsPull {
+		return ""
+	}
+	return issue.HTMLURL()
+}
+
 func (c *Comment) APIFormat() *api.Comment {
 	return &api.Comment{
-		ID:      c.ID,
-		Poster:  c.Poster.APIFormat(),
-		Body:    c.Content,
-		Created: c.Created,
-		Updated: c.Updated,
+		ID:       c.ID,
+		Poster:   c.Poster.APIFormat(),
+		HTMLURL:  c.HTMLURL(),
+		IssueURL: c.IssueURL(),
+		PRURL:    c.PRURL(),
+		Body:     c.Content,
+		Created:  c.Created,
+		Updated:  c.Updated,
 	}
 }
 

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -363,6 +363,15 @@ func getCommentsByIssueIDSince(e Engine, issueID, since int64) ([]*Comment, erro
 	return comments, sess.Find(&comments)
 }
 
+func getCommentsByRepoIDSince(e Engine, repoID, since int64) ([]*Comment, error) {
+	comments := make([]*Comment, 0, 10)
+	sess := e.Where("issue.repo_id = ?", repoID).Join("INNER", "issue", "issue.id = comment.issue_id", repoID).Asc("created_unix")
+	if since > 0 {
+		sess.And("updated_unix >= ?", since)
+	}
+	return comments, sess.Find(&comments)
+}
+
 func getCommentsByIssueID(e Engine, issueID int64) ([]*Comment, error) {
 	return getCommentsByIssueIDSince(e, issueID, -1)
 }
@@ -372,9 +381,14 @@ func GetCommentsByIssueID(issueID int64) ([]*Comment, error) {
 	return getCommentsByIssueID(x, issueID)
 }
 
-// GetCommentsByIssueID returns a list of comments of an issue since a given time point.
+// GetCommentsByIssueIDSince returns a list of comments of an issue since a given time point.
 func GetCommentsByIssueIDSince(issueID, since int64) ([]*Comment, error) {
 	return getCommentsByIssueIDSince(x, issueID, since)
+}
+
+// GetCommentsByRepoIDSince returns a list of comments for all issues in a repo since a given time point.
+func GetCommentsByRepoIDSince(repoID, since int64) ([]*Comment, error) {
+	return getCommentsByRepoIDSince(x, repoID, since)
 }
 
 // UpdateComment updates information of comment.

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -259,12 +259,17 @@ func RegisterRoutes(m *macaron.Macaron) {
 				})
 				m.Group("/issues", func() {
 					m.Combo("").Get(repo.ListIssues).Post(bind(api.CreateIssueOption{}), repo.CreateIssue)
+					m.Group("/comments", func() {
+						m.Get("", repo.ListRepoIssueComments)
+						m.Combo("/:id").Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment)
+					})
 					m.Group("/:index", func() {
 						m.Combo("").Get(repo.GetIssue).Patch(bind(api.EditIssueOption{}), repo.EditIssue)
 
 						m.Group("/comments", func() {
 							m.Combo("").Get(repo.ListIssueComments).Post(bind(api.CreateIssueCommentOption{}), repo.CreateIssueComment)
-							m.Combo("/:id").Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment)
+							m.Combo("/:id").Patch(bind(api.EditIssueCommentOption{}), repo.EditIssueComment).
+								Delete(repo.DeleteIssueComment)
 						})
 
 						m.Group("/labels", func() {

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -38,6 +38,25 @@ func ListIssueComments(ctx *context.APIContext) {
 	ctx.JSON(200, &apiComments)
 }
 
+func ListRepoIssueComments(ctx *context.APIContext) {
+	var since time.Time
+	if len(ctx.Query("since")) > 0 {
+		since, _ = time.Parse(time.RFC3339, ctx.Query("since"))
+	}
+
+	comments, err := models.GetCommentsByRepoIDSince(ctx.Repo.Repository.ID, since.Unix())
+	if err != nil {
+		ctx.Error(500, "GetCommentsByRepoIDSince", err)
+		return
+	}
+
+	apiComments := make([]*api.Comment, len(comments))
+	for i := range comments {
+		apiComments[i] = comments[i].APIFormat()
+	}
+	ctx.JSON(200, &apiComments)
+}
+
 func CreateIssueComment(ctx *context.APIContext, form api.CreateIssueCommentOption) {
 	issue, err := models.GetIssueByIndex(ctx.Repo.Repository.ID, ctx.ParamsInt64(":index"))
 	if err != nil {
@@ -79,4 +98,30 @@ func EditIssueComment(ctx *context.APIContext, form api.EditIssueCommentOption) 
 		return
 	}
 	ctx.JSON(200, comment.APIFormat())
+}
+
+func DeleteIssueComment(ctx *context.APIContext) {
+	comment, err := models.GetCommentByID(ctx.ParamsInt64(":id"))
+	if err != nil {
+		if models.IsErrCommentNotExist(err) {
+			ctx.Error(404, "GetCommentByID", err)
+		} else {
+			ctx.Error(500, "GetCommentByID", err)
+		}
+		return
+	}
+
+	if !ctx.IsSigned || (ctx.User.ID != comment.PosterID && !ctx.Repo.IsAdmin()) {
+		ctx.Status(403)
+		return
+	} else if comment.Type != models.COMMENT_TYPE_COMMENT {
+		ctx.Status(204)
+		return
+	}
+
+	if err = models.DeleteCommentByID(comment.ID); err != nil {
+		ctx.Error(500, "DeleteCommentByID", err)
+		return
+	}
+	ctx.Status(204)
 }


### PR DESCRIPTION
This implements Deletion of Issue-comments and Listing all issue-comments in a Repo
https://developer.github.com/v3/issues/comments/#delete-a-comment
https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository

Edit: Closes #3673 

See gogits/go-gogs-client#48

Adds 2 new Endpoints:
## List all issue-comments for a given Repository

Issue Comments are ordered by ascending ID.

```
GET /repos/:username/:reponame/issues/comments
```
##### Parameters

| Name | Type | Description |
| --- | --- | --- |
| since | string | Only comments updated at or after this time are returned. This is a timestamp in RFC3339 format: `2006-01-02T15:04:05Z07:00` |
##### Response

```
Status: 200 OK
Content-Type: application/json
```

``` json
[
  {
    "id": 74,
    "user": {
      "id": 1,
      "username": "unknwon",
      "full_name": "无闻",
      "email": "u@gogs.io",
      "avatar_url": "http://localhost:3000/avatars/1"
    },
    "body": "what?",
    "created_at": "2016-08-26T11:58:18-07:00",
    "updated_at": "2016-08-26T11:58:18-07:00"
  }
]
```
## Delete a Issue-comment

```
DELETE /repos/:username/:reponame/issues/:index/comments/:id
```
#### Response

```
Status: 204 No Content
```
