### PR TITLE
Forces a confirmation page on 'Forgot Password' page even if user does not exist

### DIFF
--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -341,8 +341,10 @@ func ForgotPasswdPost(ctx *context.Context) {
 	u, err := models.GetUserByEmail(email)
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
-			ctx.Data["Err_Email"] = true
-			ctx.RenderWithErr(ctx.Tr("auth.email_not_associate"), FORGOT_PASSWORD, nil)
+			ctx.Data["Hours"] = setting.Service.ActiveCodeLives / 60
+			ctx.Data["IsResetSent"] = true
+			ctx.HTML(200, FORGOT_PASSWORD)
+			return
 		} else {
 			ctx.Handle(500, "user.ResetPasswd(check existence)", err)
 		}


### PR DESCRIPTION
# TLDR; Closes #3639 
This small hot-fix is basically a very cheat way of showing a successful 'confirmation email' sent to the email even if it does not exists.

# Why?
Well, by allowing users to see if an email exists breaks a very fundamental law of security through obscurity. This small patch just forces Gogs to show a confirmation page even if the user does not exist.