### PR TITLE
Pluralize "Statistic" for English locale to be consistent with others

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -887,7 +887,7 @@ first_page = First
 last_page = Last
 total = Total: %d
 
-dashboard.statistic = Statistic
+dashboard.statistic = Statistics
 dashboard.operations = Operations
 dashboard.system_status = System Monitor Status
 dashboard.statistic_info = Gogs database has <b>%d</b> users, <b>%d</b> organizations, <b>%d</b> public keys, <b>%d</b> repositories, <b>%d</b> watches, <b>%d</b> stars, <b>%d</b> actions, <b>%d</b> accesses, <b>%d</b> issues, <b>%d</b> comments, <b>%d</b> social accounts, <b>%d</b> follows, <b>%d</b> mirrors, <b>%d</b> releases, <b>%d</b> login sources, <b>%d</b> webhooks, <b>%d</b> milestones, <b>%d</b> labels, <b>%d</b> hook tasks, <b>%d</b> teams, <b>%d</b> update tasks, <b>%d</b> attachments.


### PR DESCRIPTION
Other locales appear to use the plural version, and the text is being associated with more than one statistic.
