### PR TITLE
Escaping '?' symbols in filenames

### DIFF
--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -97,7 +97,7 @@ func NewFuncMap() []template.FuncMap {
 		"MD5":               base.EncodeMD5,
 		"ActionContent2Commits": ActionContent2Commits,
 		"EscapePound": func(str string) string {
-			return strings.NewReplacer("%", "%25", "#", "%23", " ", "%20").Replace(str)
+			return strings.NewReplacer("%", "%25", "#", "%23", " ", "%20", "?", "%3F").Replace(str)
 		},
 		"RenderCommitMessage": RenderCommitMessage,
 		"ThemeColorMetaTag": func() string {

--- a/routers/repo/editor.go
+++ b/routers/repo/editor.go
@@ -264,7 +264,7 @@ func editFilePost(ctx *context.Context, form auth.EditRepoFileForm, isNewFile bo
 		return
 	}
 
-	ctx.Redirect(ctx.Repo.RepoLink + "/src/" + branchName + "/" + form.TreePath)
+	ctx.Redirect(ctx.Repo.RepoLink + "/src/" + branchName + "/" + strings.NewReplacer("%", "%25", "#", "%23", " ", "%20", "?", "%3F").Replace(form.TreePath))
 }
 
 func EditFilePost(ctx *context.Context, form auth.EditRepoFileForm) {

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -48,9 +48,9 @@
 			{{.title}}
 			{{if and .IsRepositoryWriter (not .Repository.IsMirror)}}
 				<div class="ui right">
-					<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
+					<a class="ui small button" href="{{.RepoLink}}/wiki/{{EscapePound .PageURL}}/_edit">{{.i18n.Tr "repo.wiki.edit_page_button"}}</a>
 					<a class="ui green small button" href="{{.RepoLink}}/wiki/_new">{{.i18n.Tr "repo.wiki.new_page_button"}}</a>
-					<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}/delete" data-id="{{.PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
+					<a class="ui red small button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{EscapePound .PageURL}}/delete" data-id="{{EscapePound .PageURL}}">{{.i18n.Tr "repo.wiki.delete_page_button"}}</a>
 				</div>
 			{{end}}
 			<div class="ui sub header">


### PR DESCRIPTION
Very simply, this pull request modifies certain files to escape symbols in filenames that may cause 404s unescaped.

This solves issues #3666 and #3674.
