### PR TITLE
[HIGH PRIORITY] Fixed Xorm V6 compile errors

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -34,7 +34,7 @@ type Engine interface {
 	InsertOne(interface{}) (int64, error)
 	Iterate(interface{}, xorm.IterFunc) error
 	Sql(string, ...interface{}) *xorm.Session
-	Where(string, ...interface{}) *xorm.Session
+	Where(interface{}, ...interface{}) *xorm.Session
 }
 
 func sessionRelease(sess *xorm.Session) {


### PR DESCRIPTION
# DO NOT CLOSE THIS. THIS FIXES XORM COMPILE ERRORS.
---
# Description
The newest version of xorm changes the xorm.Engine interface where the Where, is no longer `Where(string, ...interface{}) *xorm.Session` but instead `Where(interface{}, ...interface{}) *xorm.Session`. However, xorm _**[still supports string queries](https://github.com/go-xorm/xorm/blob/master/statement.go#L139-L162)**_.

I've read somewhere that the string query may be deprecated and removed soon, so this fix may or may not be a permanent solution, thus it is best to slowly convert existing database queries to use go-xorm/builder.