### PR TITLE
Fixes possible vulnerabilities with keyword hijacking

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -493,7 +493,7 @@ var (
 )
 
 // isUsableName checks if name is reserved or pattern of name is not allowed
-// based on given reversed names and patterns.
+// based on given reserved names and patterns.
 // Names are exact match, patterns can be prefix or suffix match with placeholder '*'.
 func isUsableName(names, patterns []string, name string) error {
 	name = strings.TrimSpace(strings.ToLower(name))

--- a/models/user.go
+++ b/models/user.go
@@ -488,7 +488,7 @@ func NewGhostUser() *User {
 }
 
 var (
-	reversedUsernames    = []string{"debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
+	reversedUsernames    = []string{"assets", "css", "img", "js", "less", "plugins", "debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
 	reversedUserPatterns = []string{"*.keys"}
 )
 

--- a/models/user.go
+++ b/models/user.go
@@ -488,8 +488,8 @@ func NewGhostUser() *User {
 }
 
 var (
-	reversedUsernames    = []string{"assets", "css", "img", "js", "less", "plugins", "debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
-	reversedUserPatterns = []string{"*.keys"}
+	reservedUsernames    = []string{"assets", "css", "img", "js", "less", "plugins", "debug", "raw", "install", "api", "avatar", "user", "org", "help", "stars", "issues", "pulls", "commits", "repo", "template", "admin", "new", ".", ".."}
+	reservedUserPatterns = []string{"*.keys"}
 )
 
 // isUsableName checks if name is reserved or pattern of name is not allowed
@@ -518,7 +518,7 @@ func isUsableName(names, patterns []string, name string) error {
 }
 
 func IsUsableUsername(name string) error {
-	return isUsableName(reversedUsernames, reversedUserPatterns, name)
+	return isUsableName(reservedUsernames, reservedUserPatterns, name)
 }
 
 // CreateUser creates record of a new user.


### PR DESCRIPTION
This fixes #3700. Apparently nothing in the `public/` directory is actually filtered out from possible usernames, which means we can have `try.gogs.io/css` as a possible username. This could be quite dangerous in terms of XSS or some other exploit.

Also @Unknwon, how did you derp so hard in variable naming? `reversed`? really?
