### PR TITLE
init.d script for Gentoo Linux

### DIFF
--- a/scripts/init/gentoo/gogs
+++ b/scripts/init/gentoo/gogs
@@ -1,0 +1,16 @@
+#!/sbin/openrc-run
+
+DIR=/home/git/gogs
+USER=git
+PORT=3000
+
+start_stop_daemon_args="--user ${USER} --chdir ${DIR}"
+command="${DIR}/gogs"
+command_args="web -port ${PORT}"
+command_background=yes
+pidfile=/var/run/gogs.pid
+
+depend()
+{
+    need net
+}


### PR DESCRIPTION
init script for gentoo

place it into `/etc/init.d` directory
then run `service gogs start` or `/etc/init.d/gogs start`
