### PR TITLE
New settings option for a custom SSH host

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -101,6 +101,8 @@ DISABLE_SSH = false
 START_SSH_SERVER = false
 ; Domain name to be exposed in clone URL
 SSH_DOMAIN = %(DOMAIN)s
+; Network interface builtin SSH server listens on
+SSH_LISTEN_HOST = 0.0.0.0
 ; Port number to be exposed in clone URL
 SSH_PORT = 22
 ; Port number builtin SSH server listens on

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -77,6 +77,7 @@ var (
 		StartBuiltinServer  bool           `ini:"START_SSH_SERVER"`
 		Domain              string         `ini:"SSH_DOMAIN"`
 		Port                int            `ini:"SSH_PORT"`
+		ListenHost          string         `ini:"SSH_LISTEN_HOST"`
 		ListenPort          int            `ini:"SSH_LISTEN_PORT"`
 		RootPath            string         `ini:"SSH_ROOT_PATH"`
 		KeyTestPath         string         `ini:"SSH_KEY_TEST_PATH"`

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -110,10 +110,10 @@ func handleServerConn(keyID string, chans <-chan ssh.NewChannel) {
 	}
 }
 
-func listen(config *ssh.ServerConfig, port int) {
-	listener, err := net.Listen("tcp", "0.0.0.0:"+com.ToStr(port))
+func listen(config *ssh.ServerConfig, host string, port int) {
+	listener, err := net.Listen("tcp", host+":"+com.ToStr(port))
 	if err != nil {
-		panic(err)
+		log.Fatal(4, "Fail to start SSH server: %v", err)
 	}
 	for {
 		// Once a ServerConfig has been configured, connections can be accepted.
@@ -148,7 +148,7 @@ func listen(config *ssh.ServerConfig, port int) {
 }
 
 // Listen starts a SSH server listens on given port.
-func Listen(port int) {
+func Listen(host string, port int) {
 	config := &ssh.ServerConfig{
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			pkey, err := models.SearchPublicKeyByContent(strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key))))
@@ -180,5 +180,5 @@ func Listen(port int) {
 	}
 	config.AddHostKey(private)
 
-	go listen(config, port)
+	go listen(config, host, port)
 }

--- a/routers/install.go
+++ b/routers/install.go
@@ -92,8 +92,8 @@ func GlobalInit() {
 	checkRunMode()
 
 	if setting.InstallLock && setting.SSH.StartBuiltinServer {
-		ssh.Listen(setting.SSH.ListenPort)
-		log.Info("SSH server started on :%v", setting.SSH.ListenPort)
+		ssh.Listen(setting.SSH.ListenHost, setting.SSH.ListenPort)
+		log.Info("SSH server started on %s:%v", setting.SSH.ListenHost, setting.SSH.ListenPort)
 	}
 }
 


### PR DESCRIPTION
Mostly security reasons.

There should be an option to make a builtin SSH server listen on the specified network interface. Currently it uses **0.0.0.0** only. If somebody has several network interfaces: to the Internet, to the intranet, to the localhost etc. - Gogs shouldn't open a service to the Internet without any options.

You could say "There is no shell", but it is still a service and every service potentially is vulnerable.

I've added some code changes to make it configurable and **0.0.0.0** by default like HTTP server.
