### PR TITLE
Handle user ssh key input better

### DIFF
--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -106,6 +106,8 @@ func extractTypeFromBase64Key(key string) (string, error) {
 func parseKeyString(content string) (string, error) {
 	// Transform all legal line endings to a single "\n".
 	content = strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(content)
+        // remove trailing newline (and beginning spaces too)
+        content = strings.TrimSpace(content)
 	lines := strings.Split(content, "\n")
 
 	var keyType, keyContent, keyComment string

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -106,8 +106,8 @@ func extractTypeFromBase64Key(key string) (string, error) {
 func parseKeyString(content string) (string, error) {
 	// Transform all legal line endings to a single "\n".
 	content = strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(content)
-        // remove trailing newline (and beginning spaces too)
-        content = strings.TrimSpace(content)
+	// remove trailing newline (and beginning spaces too)
+	content = strings.TrimSpace(content)
 	lines := strings.Split(content, "\n")
 
 	var keyType, keyContent, keyComment string


### PR DESCRIPTION
Fixes #3780.

ssh_key: when user submitted keys had a newline at the end, strings.Split
would have created a slice with an empty last element, and the key type
check would be incorrect. Perhaps a better way is to look for 'ssh-rsa' or
'ssh-dsa' at the beginning of the string, but this is simple.
