### PR TITLE
Fix problem with es-ES locale in years translation

### DIFF
--- a/conf/locale/locale_es-ES.ini
+++ b/conf/locale/locale_es-ES.ini
@@ -1188,7 +1188,7 @@ hours=%[2]s %[1]d horas
 days=%[2]s %[1]d días
 weeks=%[2]s %[1]d semanas
 months=%[2]s %[1]d meses
-years=%s %d años
+years=%[2]s %[1]d años
 raw_seconds=segundos
 raw_minutes=minutos
 


### PR DESCRIPTION
This fix a small issue with es-ES translation.

Now the string appears broken as `%!s(int64=2) %!d(string=hace) años` but this small PR fix to `hace 2 años`