### PR TITLE
API endpoints for stars

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -1121,3 +1121,22 @@ func UnfollowUser(userID, followID int64) (err error) {
 	}
 	return sess.Commit()
 }
+
+func GetStarredRepos(userID int64) ([]*Repository, error) {
+	sess := x.NewSession()
+	defer sessionRelease(sess)
+	stars := make([]*Star, 0, 10)
+	err := sess.Find(&stars, &Star{UID: userID})
+	if err != nil {
+		return nil, err
+	}
+	repos := make([]*Repository, len(stars))
+	for i, star := range stars {
+		r, err := GetRepositoryByID(star.RepoID )
+		if err != nil {
+			return nil, err
+		}
+		repos[i] = r
+	}
+	return repos, nil
+}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -200,6 +200,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 					m.Get("", user.ListFollowing)
 					m.Get("/:target", user.CheckFollowing)
 				})
+
+				m.Get("/starred", user.GetStarredRepos)
 			})
 		}, reqToken())
 
@@ -220,6 +222,15 @@ func RegisterRoutes(m *macaron.Macaron) {
 					Post(bind(api.CreateKeyOption{}), user.CreatePublicKey)
 				m.Combo("/:id").Get(user.GetPublicKey).
 					Delete(user.DeletePublicKey)
+			})
+
+			m.Group("/starred", func() {
+				m.Get("", user.GetMyStarredRepos)
+				m.Group("/:username/:reponame", func() {
+					m.Get("", user.IsStarring)
+					m.Put("", user.Star)
+					m.Delete("", user.Unstar)
+				})
 			})
 		}, reqToken())
 

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -238,7 +238,7 @@ func Migrate(ctx *context.APIContext, form auth.MigrateRepoForm) {
 	ctx.JSON(201, repo.APIFormat(&api.Permission{true, true, true}))
 }
 
-func parseOwnerAndRepo(ctx *context.APIContext) (*models.User, *models.Repository) {
+func ParseOwnerAndRepo(ctx *context.APIContext) (*models.User, *models.Repository) {
 	owner, err := models.GetUserByName(ctx.Params(":username"))
 	if err != nil {
 		if models.IsErrUserNotExist(err) {
@@ -264,7 +264,7 @@ func parseOwnerAndRepo(ctx *context.APIContext) (*models.User, *models.Repositor
 
 // https://github.com/gogits/go-gogs-client/wiki/Repositories#get
 func Get(ctx *context.APIContext) {
-	_, repo := parseOwnerAndRepo(ctx)
+	_, repo := ParseOwnerAndRepo(ctx)
 	if ctx.Written() {
 		return
 	}
@@ -274,7 +274,7 @@ func Get(ctx *context.APIContext) {
 
 // https://github.com/gogits/go-gogs-client/wiki/Repositories#delete
 func Delete(ctx *context.APIContext) {
-	owner, repo := parseOwnerAndRepo(ctx)
+	owner, repo := ParseOwnerAndRepo(ctx)
 	if ctx.Written() {
 		return
 	}

--- a/routers/api/v1/user/star.go
+++ b/routers/api/v1/user/star.go
@@ -1,0 +1,84 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+	api "github.com/gogits/go-gogs-client"
+
+	"github.com/gogits/gogs/modules/context"
+	"github.com/gogits/gogs/models"
+	"fmt"
+	"github.com/gogits/gogs/routers/api/v1/repo"
+)
+
+func getStarredRepos(userID int64) ([]*api.Repository, error) {
+	starred_repos, err := models.GetStarredRepos(userID)
+	if err != nil {
+		return nil, err
+	}
+	repos := make([]*api.Repository, len(starred_repos))
+	for i, starred := range starred_repos {
+		repos[i] = starred.APIFormat(&api.Permission{true, true, true})
+	}
+	return repos, nil
+}
+
+func GetStarredRepos(ctx *context.APIContext) {
+	user := GetUserByParams(ctx)
+	repos, err := getStarredRepos(user.ID)
+	if err != nil {
+		ctx.Error(500, "getStarredRepos", err)
+	}
+	ctx.JSON(200, &repos)
+}
+
+func GetMyStarredRepos(ctx *context.APIContext) {
+	repos, err := getStarredRepos(ctx.User.ID)
+	if err != nil {
+		ctx.Error(500, "getStarredRepos", err)
+	}
+	ctx.JSON(200, &repos)
+}
+
+func IsStarring(ctx *context.APIContext) {
+	fmt.Print("IsStarring called\n")
+	_, repository := repo.ParseOwnerAndRepo(ctx)
+	if ctx.Written() {
+		return;
+	}
+	repoID := repository.ID;
+	starred, err := models.GetStarredRepos(ctx.User.ID);
+	if err != nil {
+		ctx.Error(500, "IsStarring", err)
+	}
+	for _, repository := range starred {
+		if repository.ID == repoID {
+			ctx.Status(204);
+		}
+	}
+	ctx.Status(404);
+}
+
+func Star(ctx *context.APIContext) {
+    _, repository := repo.ParseOwnerAndRepo(ctx);
+	if ctx.Written() {
+		return
+	}
+	userID := ctx.User.ID
+	repoID := repository.ID
+	models.StarRepo(userID, repoID, true)
+	ctx.Status(204)
+}
+
+func Unstar(ctx *context.APIContext) {
+	_, repository := repo.ParseOwnerAndRepo(ctx)
+	if ctx.Written() {
+		return
+	}
+	userID := ctx.User.ID
+	repoID := repository.ID
+	models.StarRepo(userID, repoID, false)
+	ctx.Status(204)
+}


### PR DESCRIPTION
This pull request adds the following API endpoints:
- `GET /users/:username/starred`: List repositories starred by a user
- `GET /user/starred`: List repositories starred by authenticated user
- `GET /user/starred/:owner/:repo`: If authenticated user is starring a repository
- `PUT /user/starred/:owner/:repo`: Star a repository (as authenticated user)
- `DELETE /user/starred/:owner/:repo`: Unstar a repository (as authenticated user)

Each of these endpoints exists in [the Github API](https://developer.github.com/v3/activity/starring/).
