### PR TITLE
Check for zero length passwords in LDAP module.

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -150,6 +150,11 @@ func bindUser(l *ldap.Conn, userDN, passwd string) error {
 
 // searchEntry : search an LDAP source if an entry (name, passwd) is valid and in the specific filter
 func (ls *Source) SearchEntry(name, passwd string, directBind bool) (string, string, string, string, bool, bool) {
+	// See https://tools.ietf.org/search/rfc4513#section-5.1.2
+	if len(passwd) == 0 {
+		log.Debug("Auth. failed for %s, password cannot be empty")
+		return "", "", "", "", false, false
+	}
 	l, err := dial(ls)
 	if err != nil {
 		log.Error(4, "LDAP Connect error, %s:%v", ls.Host, err)


### PR DESCRIPTION
According to https://tools.ietf.org/search/rfc4513#section-5.1.2 LDAP client should always check before bind whether a password is an empty value. There are at least one LDAP implementation which does not return error if you try to bind with DN set and empty password - AD.
