### PR TITLE
#3791 update LDAP username check

### DIFF
--- a/modules/auth/ldap/ldap.go
+++ b/modules/auth/ldap/ldap.go
@@ -59,8 +59,8 @@ func (ls *Source) sanitizedUserQuery(username string) (string, bool) {
 
 func (ls *Source) sanitizedUserDN(username string) (string, bool) {
 	// See http://tools.ietf.org/search/rfc4514: "special characters"
-	badCharacters := "\x00()*\\,='\"#+;<> "
-	if strings.ContainsAny(username, badCharacters) {
+	badCharacters := "\x00()*\\,='\"#+;<>"
+	if strings.ContainsAny(username, badCharacters) || strings.HasPrefix(username, " ") || strings.HasSuffix(username, " ") {
 		log.Debug("'%s' contains invalid DN characters. Aborting.", username)
 		return "", false
 	}


### PR DESCRIPTION
TGis request try to fix #3791 
As https://msdn.microsoft.com/en-us/library/aa366101(v=vs.85).aspx describe spaces should not be in start or at the end of username but they can be inside the username. So please check my solution for it.

