### PR TITLE
Fix notification E-mails

### DIFF
--- a/models/mail.go
+++ b/models/mail.go
@@ -160,7 +160,7 @@ func composeIssueMessage(issue *Issue, doer *User, tplName base.TplName, tos []s
 	if err != nil {
 		log.Error(3, "HTMLString (%s): %v", tplName, err)
 	}
-	msg := mailer.NewMessageFrom(tos, fmt.Sprintf(`"%s" <%s>`, doer.DisplayName(), setting.MailService.User), subject, content)
+	msg := mailer.NewMessageFrom(tos, fmt.Sprintf(`"%s" <%s>`, doer.DisplayName(), setting.MailService.From), subject, content)
 	msg.Info = fmt.Sprintf("Subject: %s, %s", subject, info)
 	return msg
 }


### PR DESCRIPTION
setting.MailService.User is for authentication, setting.MailService.From should be used as the sender E-mail address. Otherwise notification will fail with errors like:

```
2016/12/14 16:49:52 [...les/mailer/mailer.go:201 processMailQueue()] [E] Fail to send emails [user@example.com]: Subject: [myrepo] push2Info: no confs (#1), issue comment - gomail: could not send email 1: gomail: invalid address "\"John Doe\" <>": mail: invalid string
```

closes #3659, closes #3856, closes #3714, closes #3615