### PR TITLE
Fix wrong anchors for non-latin headings

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1347,7 +1347,7 @@ $(document).ready(function () {
         var headers = {};
         $(this).find('h1, h2, h3, h4, h5, h6').each(function () {
             var node = $(this);
-            var val = encodeURIComponent(node.text().toLowerCase().replace(/[^\w\- ]/g, '').replace(/[ ]/g, '-'));
+            var val = encodeURIComponent(node.text().toLowerCase().replace(/[^\u00C0-\u1FFF\u2C00-\uD7FF\w\- ]/g, '').replace(/[ ]/g, '-'));
             var name = val;
             if (headers[val] > 0) {
                 name = val + '-' + headers[val];


### PR DESCRIPTION
Change Javascript regular expression to match non-latin characters
The regex comes from here: http://stackoverflow.com/questions/150033/regular-expression-to-match-non-english-characters#comment22322603_150078

And this patch should fixed these two issues: #3919 #3843

