### PR TITLE
Verify repository is not bare before retrieving blob (Fixes #3992).

### DIFF
--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -19,6 +19,11 @@ func GetRawFile(ctx *context.APIContext) {
 		return
 	}
 
+	if ctx.Repo.Repository.IsBare {
+		ctx.Status(404)
+		return
+	}
+
 	blob, err := ctx.Repo.Commit.GetBlobByPath(ctx.Repo.TreePath)
 	if err != nil {
 		if git.IsErrNotExist(err) {


### PR DESCRIPTION
This pull request adds a simple check for bare repositories before retrieving raw files. If the repository is indeed bare (There are no branches or commits), just return a 404.

This fixes #3992.