### PR TITLE
Enable federated avatars by default

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -268,7 +268,7 @@ DISABLE_GRAVATAR = false
 ; Federated avatar lookup uses DNS to discover avatar associated
 ; with emails, see https://www.libravatar.org
 ; This value will be forced to be false in offline mode or Gravatar is disbaled.
-ENABLE_FEDERATED_AVATAR = false
+ENABLE_FEDERATED_AVATAR = true
 
 [attachment]
 ; Whether attachments are enabled. Defaults to `true`

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -532,7 +532,7 @@ func NewContext() {
 		GravatarSource = source
 	}
 	DisableGravatar = sec.Key("DISABLE_GRAVATAR").MustBool()
-	EnableFederatedAvatar = sec.Key("ENABLE_FEDERATED_AVATAR").MustBool()
+	EnableFederatedAvatar = sec.Key("ENABLE_FEDERATED_AVATAR").MustBool(true)
 	if OfflineMode {
 		DisableGravatar = true
 		EnableFederatedAvatar = false


### PR DESCRIPTION
Enabling federated avatars by default makes it easier to be nice with users who have their own avatar distribution setting.