### PR TITLE
Remove call to set GOMAXPROCS

### DIFF
--- a/gogs.go
+++ b/gogs.go
@@ -20,7 +20,6 @@ import (
 const APP_VER = "0.9.115.0103"
 
 func init() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	setting.AppVer = APP_VER
 }
 

--- a/gogs.go
+++ b/gogs.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/urfave/cli"
 


### PR DESCRIPTION
Since Go 1.5 GOMAXPROCS is already set to the number of CPUs in the system. This call will also be removed from Go in the near future (part of their plans once they feel the scheduler is good enough) so I thought it'd make sense to remove it here.