### PR TITLE
Produce a position independent executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LESS_FILES := $(wildcard public/less/gogs.less public/less/_*.less)
 GENERATED  := modules/bindata/bindata.go public/css/gogs.css
 
 TAGS = ""
-BUILD_FLAGS = "-v"
+BUILD_FLAGS = "-v -buildmode=pie"
 
 RELEASE_ROOT = "release"
 RELEASE_GOGS = "release/gogs"

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ DATA_FILES := $(shell find conf | sed 's/ /\\ /g')
 LESS_FILES := $(wildcard public/less/gogs.less public/less/_*.less)
 GENERATED  := modules/bindata/bindata.go public/css/gogs.css
 
+OS := $(shell uname)
+
 TAGS = ""
-BUILD_FLAGS = "-v -buildmode=pie"
+BUILD_FLAGS = "-v"
+ifeq ($(OS),Linux)
+	BUILD_FLAGS += " -buildmode=pie"
+endif
 
 RELEASE_ROOT = "release"
 RELEASE_GOGS = "release/gogs"

--- a/scripts/build_linux64.sh
+++ b/scripts/build_linux64.sh
@@ -5,7 +5,7 @@ outPath=./output_$outPlattform_$outArch
 rm -rf $outPath
 mkdir $outPath
 
-CGO_ENABLED=0 GOOS=$outPlattform GOARCH=$outArch go build ../gogs.go
+CGO_ENABLED=0 GOOS=$outPlattform GOARCH=$outArch go build -buildmode=pie ../gogs.go
 chmod +x gogs
 mv gogs $outPath/
 


### PR DESCRIPTION
This will output a position independent executable. A few benefits to this:

- While normally used as a hardening technique to better take advantage of ASLR (thus making exploits harder), this doesn't really have the same effect on Go binaries since everything is bounds checked and (hopefully) has no dangling pointers underneath. Still, this can help if any code calls out to unsafe code (C/C++) and can potentially help guard against situations where there may be a hole in the Go runtime (probably never the case).
- A lot of distros are now requiring packages to be shipped as PIE executables.

Note that this setting won't work on Windows or OS X so I'm assuming that the Makefile will never be used on Windows.