### PR TITLE
Dockerfile for aarch64 (odroid c2 & pine64)

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,22 @@
+FROM aarch64/alpine:3.5
+MAINTAINER atzoum@gmail.com
+
+# Install system utils & Gogs runtime dependencies
+ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-arm64 /usr/sbin/gosu
+RUN chmod +x /usr/sbin/gosu \
+ && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
+
+ENV GOGS_CUSTOM /data/gogs
+
+COPY . /app/gogs/
+WORKDIR /app/gogs/
+RUN ./docker/build.sh
+
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+
+# Configure Docker Container
+VOLUME ["/data"]
+EXPOSE 22 3000
+ENTRYPOINT ["docker/start.sh"]
+CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
Minimal changes compared to `Dockerfile.rpi`, you may find and test an already built docker image
 [here](https://hub.docker.com/r/atzoum/aarch64-gogs/).
