### PR TITLE
Fix #3714

### DIFF
--- a/models/mail.go
+++ b/models/mail.go
@@ -160,7 +160,8 @@ func composeIssueMessage(issue *Issue, doer *User, tplName base.TplName, tos []s
 	if err != nil {
 		log.Error(3, "HTMLString (%s): %v", tplName, err)
 	}
-	msg := mailer.NewMessageFrom(tos, fmt.Sprintf(`"%s" <%s>`, doer.DisplayName(), setting.MailService.FromEmail), subject, content)
+	from := gomail.NewMessage().FormatAddress(setting.MailService.FromEmail, doer.DisplayName())
+	msg := mailer.NewMessageFrom(tos, from, subject, content)
 	msg.Info = fmt.Sprintf("Subject: %s, %s", subject, info)
 	return msg
 }


### PR DESCRIPTION
After several tests, this simple commit fixes #3714 and now can send mails with UTF-8 characters in FROM. :smiley: 
