### PR TITLE
Add LibreJS support

### DIFF
--- a/public/assets/librejs/librejs.html
+++ b/public/assets/librejs/librejs.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>JavaScript license information</title>
+  </head>
+  <body>
+    <table id="jslicense-labels1">
+      <tr>
+        <td><a href="/js/libs/jquery.are-you-sure.js">jquery.are-you-sure.js</a></td>
+        <td>
+          <a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a>
+          <br>
+          <a href="http://www.gnu.org/licenses/gpl-2.0.html">GNU-GPL-2.0-or-later</a>
+        </td>
+        <td><a href="/js/libs/jquery.are-you-sure.js">jquery.are-you-sure.js</a></td>
+      </tr>
+      <tr>
+        <td><a href="/js/semantic-2.2.7.min.js">semantic-2.2.1.min.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="https://github.com/Semantic-Org/Semantic-UI/archive/2.2.1.tar.gz">semantic-UI-2.2.1.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/js/gogs.js">gogs.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="/js/gogs.js">gogs.js</a></td>
+      </tr>
+      <tr>
+        <td><a href="/js/libs/clipboard-1.5.9.min.js">clipboard-1.5.9.min.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="https://github.com/zenorocha/clipboard.js/archive/v1.5.9.tar.gz">clipboard-1.5.9.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/js/libs/emojify-1.1.0.min.js">emojify-1.1.0.min.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="https://github.com/Ranks/emojify.js/archive/1.1.0.tar.gz">emojify-1.1.0.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/dropzone-4.2.0/dropzone.js">dropzone.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="/plugins/dropzone-4.2.0/dropzone.js">dropzone.js</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/highlight-9.6.0/highlight.pack.js">highlight.pack.js</a></td>
+        <td><a href="https://github.com/isagalaev/highlight.js/blob/master/LICENSE">BSD 3 Clause</a></td>
+        <td><a href="https://github.com/isagalaev/highlight.js/archive/9.6.0.tar.gz">highlight.js-9.6.0.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/jquery.datetimepicker-2.4.5/jquery.datetimepicker.js">jquery.datetimepicker.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="/plugins/jquery.datetimepicker-2.4.5/jquery.datetimepicker.js">jquery.datetimepicker.js</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/jquery.minicolors-2.2.3/jquery.minicolors.min.js">jquery.minicolors.min.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="https://github.com/claviska/jquery-minicolors/archive/2.2.3.tar.gz">jquery.minicolors-2.2.3.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/simplemde-1.10.1/simplemde.min.js">simplemde.min.js</a></td>
+        <td><a href="http://www.freebsd.org/copyright/freebsd-license.html">Expat</a></td>
+        <td><a href="https://github.com/NextStepWebs/simplemde-markdown-editor/archive/1.10.1.tar.gz">simplemde-markdown-editor-1.10.1.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/marked-0.3.6/marked.min.js">marked.min.js</a></td>
+        <td><a href="/plugins/marked-0.3.6/LICENSE">Expat</a></td>
+        <td><a href="https://github.com/chjj/marked/archive/v0.3.6.tar.gz">marked-0.3.6.tar.gz</a></td>
+      </tr>
+      <tr>
+        <td><a href="/plugins/notebookjs-0.2.6/notebook.min.js">notebook.min.js</a></td>
+        <td><a href="/plugins/notebookjs-0.2.6/LICENSE.txt">Expat</a></td>
+        <td><a href="https://github.com/jsvine/notebookjs/archive/v0.2.6.tar.gz">notebookjs-0.2.6.tar.gz</a></td>
+      </tr>
+    </table>
+  </body>
+</html>
+

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -24,6 +24,7 @@
 						{{end}}
 					</div>
 				</div>
+				<a href="/assets/librejs/librejs.html" data-jslicense="1">Javascript licenses</a>
 				<a target="_blank" href="https://gogs.io">{{.i18n.Tr "website"}}</a>
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}<span class="version">{{GoVer}}</span>{{end}}
 			</div>


### PR DESCRIPTION
https://github.com/gogits/gogs/issues/4084 I've finished the librejs template file, but I need some help with routes. 

I'm not sure how do templates routes work and I don't want to make something wrong. I'm trying to make gogsbaseurl.com/librejs to contain the LibreJS page, but can make it work and I'm afraid to break something. Once that is done, I'll have no problem adding a link to the footer template. Could one active/experienced programmer in this project help me?

Sorry for my ignorance, I never programmed in Go and I'm having a hard time in understanding how the code works.