### PR TITLE
Fix typo in LocalCopyPath's path string

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -468,7 +468,7 @@ func (repo *Repository) DescriptionHtml() template.HTML {
 }
 
 func (repo *Repository) LocalCopyPath() string {
-	return path.Join(setting.AppDataPath, "tmp/local-rpeo", com.ToStr(repo.ID))
+	return path.Join(setting.AppDataPath, "tmp/local-repo", com.ToStr(repo.ID))
 }
 
 // UpdateLocalCopy pulls latest changes of given branch from repoPath to localPath.


### PR DESCRIPTION
This won't fix any bugs, but a typo is a typo.