### PR TITLE
Fixed tab indentation in file viewer

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1431,7 +1431,7 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view .lines-code .hljs {
   background-color: white;
   margin: 0;
-  padding: 0 !important;
+  padding: 0 0 0 2px !important;
 }
 .repository.file.list #file-content .code-view .lines-num pre li,
 .repository.file.list #file-content .code-view .lines-code pre li,
@@ -1449,14 +1449,6 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view .lines-num .hljs li.active,
 .repository.file.list #file-content .code-view .lines-code .hljs li.active {
   background: #ffffdd;
-}
-.repository.file.list #file-content .code-view .lines-num pre li:before,
-.repository.file.list #file-content .code-view .lines-code pre li:before,
-.repository.file.list #file-content .code-view .lines-num ol li:before,
-.repository.file.list #file-content .code-view .lines-code ol li:before,
-.repository.file.list #file-content .code-view .lines-num .hljs li:before,
-.repository.file.list #file-content .code-view .lines-code .hljs li:before {
-  content: ' ';
 }
 .repository.file.list .sidebar {
   padding-left: 0;


### PR DESCRIPTION
In code viewer, for some reason code container's left padding was implemented not with padding, but with ```:before { content: ' ' }```.
Adding a space character at the beginning of each line is harmful, because it's an actual space character and it messes up indentation.
This doesn't matter in space-indented files, but it matters in tab-indented ones (the first tab appears shorter than the following tabs, because there's already a space in front of it), and especially in files with mixed tabs and spaces (space-indented lines get indented one space further than tab-indented ones).

This fix replaces the spaces with a 2px left padding, which fixes the indentation issue.