### PR TITLE
 [ #4145 ] Provide an updated Dockerfile and docker/build.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-FROM alpine:3.3
-MAINTAINER jp@roemer.im
+FROM alpine:3.5
+
+# Components versions
+ENV GOLANG_VERSION 1.8
+ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
+ENV GOLANG_SRC_SHA256 406865f587b44be7092f206d73fc1de252600b79b3cacc587b74b5ef5c623596
+
+# Branch name
+#ENV GOGS_VERSION v0.9.141
+ENV GOGS_VERSION develop
+
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64 /usr/sbin/gosu
@@ -8,15 +17,57 @@ RUN chmod +x /usr/sbin/gosu \
 
 ENV GOGS_CUSTOM /data/gogs
 
-COPY . /app/gogs/
-WORKDIR /app/gogs/
-RUN ./docker/build.sh
-
 # Configure LibC Name Service
 COPY docker/nsswitch.conf /etc/nsswitch.conf
 
 # Configure Docker Container
 VOLUME ["/data"]
 EXPOSE 22 3000
-ENTRYPOINT ["docker/start.sh"]
+ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]
+
+
+
+## Build Golang & Gogs
+
+
+# https://golang.org/issue/14851
+#COPY no-pic.patch /
+
+
+COPY docker /app/gogs/docker
+
+RUN set -ex \
+	&& apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+		build-base \
+		linux-pam-dev \
+	\
+	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+	\
+	&& wget -q "$GOLANG_SRC_URL" -O golang.tar.gz \
+	&& echo "$GOLANG_SRC_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz \
+	&& cd /usr/local/go/src \
+	&& patch -p2 -i /app/gogs/docker/no-pic.patch \
+	&& ./make.bash \
+	\
+	&& rm /app/gogs/docker/*.patch \
+	&& git config --global http.https://gopkg.in.followRedirects true \
+	&& cd /app/gogs/docker/ \
+	&& sh /app/gogs/docker/build.sh \
+	&& rm /app/gogs/docker/build.sh \
+	&& rm /app/gogs/docker/nsswitch.conf \
+	&& rm /app/gogs/docker/README.md \
+	&& apk del .build-deps  \
+	&& mv /go/src/github.com/gogits/gogs/gogs /app/gogs/ \
+	&& mv /go/src/github.com/gogits/gogs/templates /app/gogs/ \
+	&& mv /go/src/github.com/gogits/gogs/scripts /app/gogs/ \
+	&& mv /go/src/github.com/gogits/gogs/public /app/gogs/ \
+	&& rm -rf /go \
+	&& rm -rf /usr/local/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,45 +29,8 @@ CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]
 
 
 ## Build Golang & Gogs
-
-
-# https://golang.org/issue/14851
-#COPY no-pic.patch /
-
-
 COPY docker /app/gogs/docker
 
 RUN set -ex \
-	&& apk add --no-cache --virtual .build-deps \
-		bash \
-		gcc \
-		musl-dev \
-		openssl \
-		go \
-		build-base \
-		linux-pam-dev \
-	\
-	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-	\
-	&& wget -q "$GOLANG_SRC_URL" -O golang.tar.gz \
-	&& echo "$GOLANG_SRC_SHA256  golang.tar.gz" | sha256sum -c - \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src \
-	&& patch -p2 -i /app/gogs/docker/no-pic.patch \
-	&& ./make.bash \
-	\
-	&& rm /app/gogs/docker/*.patch \
-	&& git config --global http.https://gopkg.in.followRedirects true \
-	&& cd /app/gogs/docker/ \
-	&& sh /app/gogs/docker/build.sh \
-	&& rm /app/gogs/docker/build.sh \
-	&& rm /app/gogs/docker/nsswitch.conf \
-	&& rm /app/gogs/docker/README.md \
-	&& apk del .build-deps  \
-	&& mv /go/src/github.com/gogits/gogs/gogs /app/gogs/ \
-	&& mv /go/src/github.com/gogits/gogs/templates /app/gogs/ \
-	&& mv /go/src/github.com/gogits/gogs/scripts /app/gogs/ \
-	&& mv /go/src/github.com/gogits/gogs/public /app/gogs/ \
-	&& rm -rf /go \
-	&& rm -rf /usr/local/go
+	&& sh /app/gogs/docker/build-go.sh \
+	&& sh /app/gogs/docker/build.sh

--- a/docker/build-go.sh
+++ b/docker/build-go.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Build GO version as specified in Dockerfile
+
+# Install build tools
+apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go build-base linux-pam-dev
+
+export GOROOT_BOOTSTRAP="$(go env GOROOT)"
+
+# Download Go
+wget -q "$GOLANG_SRC_URL" -O golang.tar.gz
+echo "$GOLANG_SRC_SHA256  golang.tar.gz" | sha256sum -c -
+tar -C /usr/local -xzf golang.tar.gz
+rm golang.tar.gz
+
+# Build
+cd /usr/local/go/src
+# see https://golang.org/issue/14851
+patch -p2 -i /app/gogs/docker/no-pic.patch
+./make.bash
+
+# Clean
+rm /app/gogs/docker/*.patch

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,27 +1,17 @@
 #!/bin/sh
-set -x
-set -e
+export GOPATH=/go
+export PATH=$GOPATH/bin:/usr/local/go/bin:/$PATH
 
-# Set temp environment vars
-export GOPATH=/tmp/go
-export PATH=${PATH}:${GOPATH}/bin
-export GO15VENDOREXPERIMENT=1
+mkdir -p "$GOPATH/src" "$GOPATH/bin"
+chmod -R 777 "$GOPATH"
 
-# Install build deps
-apk --no-cache --no-progress add --virtual build-deps build-base linux-pam-dev go
+cd $GOPATH
 
-# Build Gogs
-mkdir -p ${GOPATH}/src/github.com/gogits/
-ln -s /app/gogs/ ${GOPATH}/src/github.com/gogits/gogs
+git config --global http.https://gopkg.in.followRedirects true
+
+git clone --single-branch --branch ${GOGS_VERSION} --depth 1 https://github.com/gogits/gogs ${GOPATH}/src/github.com/gogits/gogs
 cd ${GOPATH}/src/github.com/gogits/gogs
-go get -v -tags "sqlite cert pam" ./...
 make build TAGS="sqlite cert pam"
-
-# Cleanup GOPATH
-rm -r $GOPATH
-
-# Remove build deps
-apk --no-progress del build-deps
 
 # Create git user for Gogs
 adduser -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && passwd -u git

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,3 +16,19 @@ make build TAGS="sqlite cert pam"
 # Create git user for Gogs
 adduser -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && passwd -u git
 echo "export GOGS_CUSTOM=${GOGS_CUSTOM}" >> /etc/profile
+
+# Move to final place
+mv /go/src/github.com/gogits/gogs/gogs /app/gogs/
+mv /go/src/github.com/gogits/gogs/templates /app/gogs/
+mv /go/src/github.com/gogits/gogs/scripts /app/gogs/
+mv /go/src/github.com/gogits/gogs/public /app/gogs/
+
+# Final cleaning
+rm /app/gogs/docker/build.sh
+rm /app/gogs/docker/build-go.sh
+rm /app/gogs/docker/nsswitch.conf
+rm /app/gogs/docker/README.md
+rm -rf /go
+rm -rf /usr/local/go
+
+apk del .build-deps

--- a/docker/no-pic.patch
+++ b/docker/no-pic.patch
@@ -1,0 +1,16 @@
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 14f4fa9..5599307 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1272,6 +1272,11 @@ func hostlink() {
+ 		argv = append(argv, peimporteddlls()...)
+ 	}
+ 
++	// The Go linker does not currently support building PIE
++	// executables when using the external linker. See:
++	// https://github.com/golang/go/issues/6940
++	argv = append(argv, "-fno-PIC")
++
+ 	if l.Debugvlog != 0 {
+ 		l.Logf("%5.2f host link:", obj.Cputime())
+ 		for _, v := range argv {


### PR DESCRIPTION
Provide an updated Dockerfile and docker/build.sh so that the resulting
Docker image is based on up to date versions.


In order to have an up to date Docker image based on alpine 3.5
  and having Gogs built with Go 1.8

Refs: [ #4145 ]


The Gogs version (tag / branch name) to build can be selected by editing the following block in Dockerfile:

```
# Branch name
#ENV GOGS_VERSION v0.9.141
ENV GOGS_VERSION develop

```