### PR TITLE
Fix packaging

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -19,6 +19,8 @@ targets:
   centos-6: &el
     build_dependencies:
       - pam-devel
+      # required for go buildpack
+      - perl-Digest-SHA
     dependencies:
       - pam
       - git

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -26,7 +26,7 @@ targets:
     <<: *el
 before:
   - mv packager/Procfile .
-  - mv packager/.godir .
 after:
-  - mv bin/main gogs
+  - mv bin/gogs gogs
 after_install: ./packager/hooks/postinst
+buildpack: https://github.com/heroku/heroku-buildpack-go.git#v62

--- a/packager/Procfile
+++ b/packager/Procfile
@@ -1,1 +1,1 @@
-web: ./gogs web
+web: ./gogs web -p ${PORT:=3000}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -557,7 +557,7 @@
 		{
 			"checksumSHA1": "qM9ubEa57g4oNa6JLFQ+e1TCMno=",
 			"path": "gopkg.in/macaron.v1",
-			"revision": "8be5635c28f40a85ce8e8f65c6118b4ee4e548e9",
+			"revision": "a325110f8b392bce3e5cdeb8c44bf98078ada3be",
 			"revisionTime": "2017-02-19T20:49:11Z"
 		},
 		{


### PR DESCRIPTION
This pull request fixes the packaging for https://packager.io/gh/pkgr/gogs, which started to fail about 2 weeks ago. It switches to the newest version of the go buildpack and adjusts some configuration related to the packaging.

I also ran into an issue while running govendor, with the commit 8be5635c28f40a85ce8e8f65c6118b4ee4e548e9 not longer existing in the macaron repo, hence the change. Let me know if you think I'm doing something wrong here.

The package properly builds on my branch at https://packager.io/gh/pkgr/gogs/build_runs/604