### PR TITLE
Updated Dockerfile for Raspberry Pi, based on the normal Dockerfile

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,19 +1,18 @@
-FROM hypriot/rpi-alpine-scratch:v3.2
-MAINTAINER jp@roemer.im, raxetul@gmail.com
+FROM armhf/alpine:3.5
 
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && echo "http://dl-4.alpinelinux.org/alpine/v3.3/main/"      | tee /etc/apk/repositories    \
- && echo "http://dl-4.alpinelinux.org/alpine/v3.3/community/" | tee -a /etc/apk/repositories \
- && apk -U --no-progress upgrade && rm -f /var/cache/apk/APKINDEX.* \
  && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
 
 ENV GOGS_CUSTOM /data/gogs
 
-COPY . /app/gogs/
-WORKDIR /app/gogs/
-RUN ./docker/build.sh
+COPY . /app/gogs/build
+WORKDIR /app/gogs/build
+
+RUN    ./docker/build-go.sh \
+    && ./docker/build.sh \
+    && ./docker/finalize.sh
 
 # Configure LibC Name Service
 COPY docker/nsswitch.conf /etc/nsswitch.conf
@@ -21,5 +20,5 @@ COPY docker/nsswitch.conf /etc/nsswitch.conf
 # Configure Docker Container
 VOLUME ["/data"]
 EXPOSE 22 3000
-ENTRYPOINT ["docker/start.sh"]
+ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
Helps with #4180, by making sure we can actually build the Docker image on the Pi.
Crazy shenanigans might happen soon™, in regards to the other portion of #4180.
Or I might volunteer to just upload images I build on my Pi. 