### PR TITLE
Checking if protocol is FCGI for suburl is removed

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -118,9 +118,7 @@ func newMacaron() *macaron.Macaron {
 	if setting.EnableGzip {
 		m.Use(gzip.Gziper())
 	}
-	if setting.Protocol == setting.SCHEME_FCGI {
-		m.SetURLPrefix(setting.AppSubUrl)
-	}
+	m.SetURLPrefix(setting.AppSubUrl)
 	m.Use(macaron.Static(
 		path.Join(setting.StaticRootPath, "public"),
 		macaron.StaticOptions{


### PR DESCRIPTION
Checking if protocol is FCGI for suburl is removed to support reverse proxies with suburls.

The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Please make sure you are targeting the `develop` branch.
2. Please read contributing guidelines:
https://github.com/gogits/gogs/wiki/Contributing-Code
3. Please describe what your pull request does and which issue you're targeting
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.

**You MUST delete above content including this line before posting; too lazy to take this action considered invalid pull request.**
