### PR TITLE
Assignee menu text is overwritten when typing name #3963

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1233,10 +1233,11 @@ $(document).ready(function () {
 
     // Semantic UI modules.
     $('.ui.dropdown').dropdown({
-        forceSelection: false
+        forceSelection: false,
+        action:'select'
     });
     $('.jump.dropdown').dropdown({
-        action: 'hide',
+        action: 'select',
         onShow: function () {
             $('.poping.up').popup('hide');
         }


### PR DESCRIPTION
Added the select attribute to the dropdown settings. This prevents the selected option from changing the main label text when typing to select the label. 