### PR TITLE
Repositories panel in personal settings

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -255,7 +255,10 @@ func runWeb(ctx *cli.Context) error {
 			m.Get("", user.SettingsOrganizations)
 			m.Post("/leave", user.SettingsLeaveOrganization)
 		})
-
+		m.Group("/repos", func() {
+			m.Get("", user.SettingsRepos)
+			m.Post("/delete", user.SettingsDeleteRepo)
+		})
 		m.Route("/delete", "GET,POST", user.SettingsDelete)
 	}, reqSignIn, func(ctx *context.Context) {
 		ctx.Data["PageIsUserSettings"] = true

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -456,6 +456,7 @@ func SettingsLeaveOrganization(ctx *context.Context) {
 func SettingsRepos(ctx *context.Context) {
 
 	ctx.Data["Title"] = ctx.Tr("admin.repositories")
+	ctx.Data["PageIsSettingsRepositories"] = true
 
 	keyword := ctx.Query("q")
 	page := ctx.QueryInt("page")
@@ -465,10 +466,8 @@ func SettingsRepos(ctx *context.Context) {
 
 	repos, count, err := models.SearchRepositoryByName(&models.SearchRepoOptions{
 		Keyword:  keyword,
-		UserID:   -1,
-		OwnerID:  ctx.User.ID,
+		UserID:   ctx.User.ID,
 		OrderBy:  "lower_name",
-		Private:  true,
 		Page:     page,
 		PageSize: setting.UI.Admin.RepoPagingNum,
 	})

--- a/routers/user/setting.go
+++ b/routers/user/setting.go
@@ -7,9 +7,11 @@ package user
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"strings"
 
 	"github.com/Unknwon/com"
+	"github.com/Unknwon/paginater"
 	log "gopkg.in/clog.v1"
 
 	"github.com/gogits/gogs/models"
@@ -30,6 +32,7 @@ const (
 	SETTINGS_SOCIAL        base.TplName = "user/settings/social"
 	SETTINGS_APPLICATIONS  base.TplName = "user/settings/applications"
 	SETTINGS_ORGANIZATIONS base.TplName = "user/settings/organizations"
+	SETTINGS_REPOS         base.TplName = "user/settings/repos"
 	SETTINGS_DELETE        base.TplName = "user/settings/delete"
 	NOTIFICATION           base.TplName = "user/notification"
 	SECURITY               base.TplName = "user/security"
@@ -448,6 +451,67 @@ func SettingsLeaveOrganization(ctx *context.Context) {
 	ctx.JSON(200, map[string]interface{}{
 		"redirect": setting.AppSubUrl + "/user/settings/organizations",
 	})
+}
+
+func SettingsRepos(ctx *context.Context) {
+
+	ctx.Data["Title"] = ctx.Tr("admin.repositories")
+
+	keyword := ctx.Query("q")
+	page := ctx.QueryInt("page")
+	if page <= 0 {
+		page = 1
+	}
+
+	repos, count, err := models.SearchRepositoryByName(&models.SearchRepoOptions{
+		Keyword:  keyword,
+		UserID:   -1,
+		OwnerID:  ctx.User.ID,
+		OrderBy:  "lower_name",
+		Private:  true,
+		Page:     page,
+		PageSize: setting.UI.Admin.RepoPagingNum,
+	})
+	if err != nil {
+		ctx.Handle(500, "SearchRepositoryByName", err)
+		return
+	}
+	if err = models.RepositoryList(repos).LoadAttributes(); err != nil {
+		ctx.Handle(500, "LoadAttributes", err)
+		return
+	}
+
+	ctx.Data["Keyword"] = keyword
+	ctx.Data["Total"] = count
+	ctx.Data["Page"] = paginater.New(int(count), setting.UI.Admin.RepoPagingNum, page, 5)
+	ctx.Data["Repos"] = repos
+	ctx.HTML(200, SETTINGS_REPOS)
+}
+
+func SettingsDeleteRepo(ctx *context.Context) {
+	repo, err := models.GetRepositoryByID(ctx.QueryInt64("id"))
+	if err != nil {
+		ctx.Handle(500, "GetRepositoryByID", err)
+		return
+	}
+	// make sure the user owns the repository or is an admin before allowing them to delete it
+	if repo.OwnerID == ctx.User.ID || ctx.User.IsAdmin {
+		if err := models.DeleteRepository(repo.MustOwner().ID, repo.ID); err != nil {
+			ctx.Handle(500, "DeleteRepository", err)
+			return
+		}
+		log.Trace("Repository deleted: %s/%s", repo.MustOwner().Name, repo.Name)
+
+		ctx.Flash.Success(ctx.Tr("repo.settings.deletion_success"))
+		ctx.JSON(200, map[string]interface{}{
+			"redirect": setting.AppSubUrl + "/user/settings/repos?page=" + ctx.Query("page") + "&q=" + url.QueryEscape(ctx.Query("q")),
+		})
+	} else {
+		// logged in user doesn't have rights to delete this repository
+		err := errors.New("You do not have rights to delete repository '" + repo.FullName() + "'")
+		ctx.Handle(403, "SettingsDeleteRepo", err)
+	}
+
 }
 
 func SettingsDelete(ctx *context.Context) {

--- a/templates/user/settings/navbar.tmpl
+++ b/templates/user/settings/navbar.tmpl
@@ -22,6 +22,9 @@
 		<a class="{{if .PageIsSettingsOrganizations}}active{{end}} item" href="{{AppSubUrl}}/user/settings/organizations">
 			{{.i18n.Tr "settings.orgs"}}
 		</a>
+		<a class="{{if .PageIsSettingsRepositories}}active{{end}} item" href="{{AppSubUrl}}/user/settings/repos">
+			{{.i18n.Tr "admin.repositories"}} 
+		</a>
 		<a class="{{if .PageIsSettingsDelete}}active{{end}} item" href="{{AppSubUrl}}/user/settings/delete">
 			{{.i18n.Tr "settings.delete"}}
 		</a>

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -1,0 +1,67 @@
+{{template "base/head" .}}
+<div class="user">
+	<div class="ui container">
+		<div class="ui grid">
+			{{template "user/settings/navbar" .}}
+			<div class="twelve wide column content">
+				{{template "base/alert" .}}
+				<h4 class="ui top attached header">
+					{{.i18n.Tr "admin.repos.repo_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+				</h4>
+				<div class="ui attached segment">
+					{{template "admin/base/search" .}}
+				</div>
+				<div class="ui attached table segment">
+					<table class="ui very basic striped table">
+						<thead>
+							<tr>
+								<th>ID</th>
+								<th>{{.i18n.Tr "admin.repos.owner"}}</th>
+								<th>{{.i18n.Tr "admin.repos.name"}}</th>
+								<th>{{.i18n.Tr "admin.repos.private"}}</th>
+								<th>{{.i18n.Tr "admin.repos.watches"}}</th>
+								<th>{{.i18n.Tr "admin.repos.stars"}}</th>
+								<th>{{.i18n.Tr "admin.repos.issues"}}</th>
+								<th>{{.i18n.Tr "admin.repos.size"}}</th>
+								<th>{{.i18n.Tr "admin.users.created"}}</th>
+								<th>{{.i18n.Tr "admin.notices.op"}}</th>
+							</tr>
+						</thead>
+						<tbody>
+							{{range .Repos}}
+								<tr>
+									<td>{{.ID}}</td>
+									<td><a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a></td>
+									<td><a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>
+									<td><i class="fa fa{{if .IsPrivate}}-check{{end}}-square-o"></i></td>
+									<td>{{.NumWatches}}</td>
+									<td>{{.NumStars}}</td>
+									<td>{{.NumIssues}}</td>
+									<td>{{.Size | FileSize}}</td>
+									<td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>
+									<td><a class="delete-button" href="" data-url="{{$.Link}}/delete?page={{$.Page.Current}}" data-id="{{.ID}}"><i class="trash icon text red"></i></a></td>
+								</tr>
+							{{end}}
+						</tbody>
+					</table>
+				</div>
+
+				{{template "admin/base/page" .}}
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="ui small basic delete modal">
+	<div class="ui icon header">
+		<i class="trash icon"></i>
+		{{.i18n.Tr "repo.settings.delete"}}
+	</div>
+	<div class="content">
+		<p>{{.i18n.Tr "repo.settings.delete_desc"}}</p>
+		{{.i18n.Tr "repo.settings.delete_notices_2"}}<br>
+		{{.i18n.Tr "repo.settings.delete_notices_fork_1"}}<br>
+	</div>
+	{{template "base/delete_modal_actions" .}}
+</div>
+{{template "base/footer" .}}

--- a/templates/user/settings/repos.tmpl
+++ b/templates/user/settings/repos.tmpl
@@ -6,45 +6,30 @@
 			<div class="twelve wide column content">
 				{{template "base/alert" .}}
 				<h4 class="ui top attached header">
-					{{.i18n.Tr "admin.repos.repo_manage_panel"}} ({{.i18n.Tr "admin.total" .Total}})
+					{{.i18n.Tr "admin.repositories"}} ({{.i18n.Tr "admin.total" .Total}})
 				</h4>
 				<div class="ui attached segment">
 					{{template "admin/base/search" .}}
 				</div>
-				<div class="ui attached table segment">
-					<table class="ui very basic striped table">
-						<thead>
-							<tr>
-								<th>ID</th>
-								<th>{{.i18n.Tr "admin.repos.owner"}}</th>
-								<th>{{.i18n.Tr "admin.repos.name"}}</th>
-								<th>{{.i18n.Tr "admin.repos.private"}}</th>
-								<th>{{.i18n.Tr "admin.repos.watches"}}</th>
-								<th>{{.i18n.Tr "admin.repos.stars"}}</th>
-								<th>{{.i18n.Tr "admin.repos.issues"}}</th>
-								<th>{{.i18n.Tr "admin.repos.size"}}</th>
-								<th>{{.i18n.Tr "admin.users.created"}}</th>
-								<th>{{.i18n.Tr "admin.notices.op"}}</th>
-							</tr>
-						</thead>
-						<tbody>
-							{{range .Repos}}
-								<tr>
-									<td>{{.ID}}</td>
-									<td><a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a></td>
-									<td><a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>
-									<td><i class="fa fa{{if .IsPrivate}}-check{{end}}-square-o"></i></td>
-									<td>{{.NumWatches}}</td>
-									<td>{{.NumStars}}</td>
-									<td>{{.NumIssues}}</td>
-									<td>{{.Size | FileSize}}</td>
-									<td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>
-									<td><a class="delete-button" href="" data-url="{{$.Link}}/delete?page={{$.Page.Current}}" data-id="{{.ID}}"><i class="trash icon text red"></i></a></td>
-								</tr>
+
+				{{range .Repos}}
+				<div class="ui attached segment repos">
+				<div class="ui list">
+						<div class="item">
+							<a href="{{AppSubUrl}}/{{.Owner.Name}}/{{.Name}}">
+								<span class="octicon octicon-repo text light grey"></span> 
+								{{.Owner.Name}}/{{.Name}}
+							</a> 
+							<span class="ui text light grey">{{.Size | FileSize}}</span>
+							{{if .IsPrivate}}
+							<div class="right floated content">
+								<a class="ui red tiny button inline text-thin delete-button" href="" data-url="{{$.Link}}/leave?page={{$.Page.Current}}" data-id="{{.ID}}">{{$.i18n.Tr "settings.leave"}}</a>
+							</div>
 							{{end}}
-						</tbody>
-					</table>
-				</div>
+						</div>
+					</div>
+					</div>
+				{{end}}
 
 				{{template "admin/base/page" .}}
 			</div>
@@ -52,15 +37,12 @@
 	</div>
 </div>
 
-<div class="ui small basic delete modal">
+<div class="ui small basic leave modal">
 	<div class="ui icon header">
-		<i class="trash icon"></i>
-		{{.i18n.Tr "repo.settings.delete"}}
+		{{.i18n.Tr "teams.leave"}}
 	</div>
 	<div class="content">
-		<p>{{.i18n.Tr "repo.settings.delete_desc"}}</p>
-		{{.i18n.Tr "repo.settings.delete_notices_2"}}<br>
-		{{.i18n.Tr "repo.settings.delete_notices_fork_1"}}<br>
+		<p>{{.i18n.Tr "teams.leave_desc"}}</p>
 	</div>
 	{{template "base/delete_modal_actions" .}}
 </div>


### PR DESCRIPTION
This is my first attempt at adding a personal repositories panel under "User Settings" (Issue #4277).  
One of the things that needs to be reviewed is my use of the ```[admin]``` localization variables since these do not exist under ```[settings]``` yet.  I'm not sure what the process is for adding to the localization files or if you even want to bother with that for this PR or not.  

Currently, it will only display repositories that the logged in user owns and will only allow the logged in user to delete his own repositories.