### PR TITLE
Fix language names

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -441,7 +441,7 @@ COMMITS_PAGING_NUM = 30
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR,gl-ES,uk-UA
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台湾）,Deutsch,Français,Nederlands,Latviešu,Русский,日本語,Español,Português do Brasil,Polski,български,Italiano,Suomalainen,Türkçe,čeština,Српски,Svenska,한국어,Galego,Українська
+NAMES = English,简体中文,繁體中文（香港）,繁體中文（台湾）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어,galego,українська
 
 ; Used for datetimepicker
 [i18n.datelang]


### PR DESCRIPTION
This PR fixes the follow issues:

1. wrong language name: "Suomalainen" is incorrect name for Finnish language, should be "suomi".
2. wrong capitalization of language names: different languages have different conventions for capitalization.