### PR TITLE
Small JS improvement: Use jQuery .find()

### DIFF
--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -341,7 +341,7 @@ function initRepository() {
     if ($('.repository.view.issue').length > 0) {
         // Edit issue title
         var $issueTitle = $('#issue-title');
-        var $editInput = $('#edit-title-input input');
+        var $editInput = $('#edit-title-input').find('input');
         var editTitleToggle = function () {
             $issueTitle.toggle();
             $('.not-in-edit').toggle();


### PR DESCRIPTION
$('#id test') is a shortcut for $('#id').find('test')

By using find(), we are eliminating some function calls. which is always good ;)
