### PR TITLE
Avoid duplicated results in SearchRepositoryByName

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -1654,7 +1654,7 @@ func SearchRepositoryByName(opts *SearchRepoOptions) (repos []*Repository, _ int
 	if len(opts.OrderBy) > 0 {
 		sess.OrderBy("repo." + opts.OrderBy)
 	}
-	return repos, count, sess.Limit(opts.PageSize, (opts.Page-1)*opts.PageSize).Find(&repos)
+	return repos, count, sess.Distinct("repo.*").Limit(opts.PageSize, (opts.Page-1)*opts.PageSize).Find(&repos)
 }
 
 func DeleteOldRepositoryArchives() {


### PR DESCRIPTION
The list returned by SearchRepositoryByName has duplicate entries and, as consequence, `/explore/repos` list replicated entries too:

``` sql
SELECT  * FROM "repository" AS "repo" LEFT JOIN "access" ON access.repo_id = repo.id WHERE (repo.owner_id = 1 OR access.user_id = 1 OR repo.is_private = true) ORDER BY repo.updated_unix DESC LIMIT 10;
```

For example:

```
 id  | owner_id |         lower_name          |            name             |                 description                 | website | default_branch | num_watches | num_stars | num_forks | num_issues | num_closed_issues | num_pulls | num_closed_pulls | num_milestones | num_closed_milestones | is_private | is_bare | is_mirror | enable_wiki | enable_external_wiki | external_wiki_url | enable_issues | enable_external_tracker | external_tracker_format | external_tracker_style | enable_pulls | is_fork | fork_id | created_unix | updated_unix | external_tracker_url |    size    | allow_public_wiki | allow_public_issues |  id   | user_id | repo_id | mode 
-----+----------+-----------------------------+-----------------------------+---------------------------------------------+---------+----------------+-------------+-----------+-----------+------------+-------------------+-----------+------------------+----------------+-----------------------+------------+---------+-----------+-------------+----------------------+-------------------+---------------+-------------------------+-------------------------+------------------------+--------------+---------+---------+--------------+--------------+----------------------+------------+-------------------+---------------------+-------+---------+---------+------
 ...
 611 |       60 | example                  | example                   |                                             |         | master         |           9 |         0 |         0 |          0 |                 0 |         0 |                0 |              0 |                     0 | t          | f       | f         | t           | f                    |                   | t             | f                       |                         | numeric                | t            | f       |       0 |   1489693275 |   1489693818 |                      |   40594432 |                   |                     | 57898 |      62 |     611 |    4
 611 |       60 | example                  | example                   |                                             |         | master         |           9 |         0 |         0 |          0 |                 0 |         0 |                0 |              0 |                     0 | t          | f       | f         | t           | f                    |                   | t             | f                       |                         | numeric                | t            | f       |       0 |   1489693275 |   1489693818 |                      |   40594432 |                   |                     | 57895 |      15 |     611 |    4
...
```

The solution could be simple:


``` sql
SELECT DISTINCT 'repo.*'  FROM "repository" AS "repo" LEFT JOIN "access" ON access.repo_id = repo.id WHERE (repo.owner_id = 1 OR access.user_id = 1 OR repo.is_private = true) ORDER BY repo.updated_unix DESC LIMIT 10;
```

Related PR:  https://github.com/gogits/gogs/issues/3088
