### PR TITLE
Corrected Mirror.NextUpdate not set

### DIFF
--- a/models/mirror.go
+++ b/models/mirror.go
@@ -60,7 +60,7 @@ func (m *Mirror) AfterSet(colName string, _ xorm.Cell) {
 		}
 	case "updated_unix":
 		m.Updated = time.Unix(m.UpdatedUnix, 0).Local()
-	case "next_updated_unix":
+	case "next_update_unix":
 		m.NextUpdate = time.Unix(m.NextUpdateUnix, 0).Local()
 	}
 }


### PR DESCRIPTION
Mirror.NextUpdate is not properly set because the switch-case has the wrong column name. Changed from next_update**d**_unix to next_update_unix.