### PR TITLE
Handle mysql error in migration

### DIFF
--- a/models/migrations/v17.go
+++ b/models/migrations/v17.go
@@ -12,7 +12,7 @@ import (
 
 func removeInvalidProtectBranchWhitelist(x *xorm.Engine) error {
 	_, err := x.Exec("DELETE FROM protect_branch_whitelist WHERE protect_branch_id = 0")
-	if err != nil && strings.Contains(err.Error(), "no such table") {
+	if err != nil && (strings.Contains(err.Error(), "no such table") || strings.Contains(err.Error(), "doesn't exist")) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
This patch adds error handling for mysql in addition to the existing sqlite error check. Without the additional error check, I'm seeing the following error:

`Fail to initialize ORM engine: migrate: do migrate: Error 1146: Table 'gogs.protect_branch_whitelist' doesn't exist`