### PR TITLE
Add check for user for create/update on LDAP

### DIFF
--- a/models/login_source.go
+++ b/models/login_source.go
@@ -328,7 +328,10 @@ func LoginViaLDAP(user *User, login, password string, source *LoginSource, autoR
 		IsAdmin:     isAdmin,
 	}
 	
-	if IsUserExist(0, user.Name) {
+	if ok, err := IsUserExist(0, user.Name); err != nil {
+		return user, err
+	}
+	if ok {
 		return user, UpdateUser(user)
 	} else {
 		return user, CreateUser(user)

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -328,14 +328,16 @@ func LoginViaLDAP(user *User, login, password string, source *LoginSource, autoR
 		IsAdmin:     isAdmin,
 	}
 	
-	if ok, err := IsUserExist(0, user.Name); err != nil {
+	ok, err := IsUserExist(0, user.Name)
+	if err != nil {
 		return user, err
 	}
+	
 	if ok {
 		return user, UpdateUser(user)
-	} else {
-		return user, CreateUser(user)
 	}
+	
+	return user, CreateUser(user)
 }
 
 //   _________   __________________________

--- a/models/login_source.go
+++ b/models/login_source.go
@@ -327,7 +327,12 @@ func LoginViaLDAP(user *User, login, password string, source *LoginSource, autoR
 		IsActive:    true,
 		IsAdmin:     isAdmin,
 	}
-	return user, CreateUser(user)
+	
+	if IsUserExist(0, user.Name) {
+		return user, UpdateUser(user)
+	} else {
+		return user, CreateUser(user)
+	}
 }
 
 //   _________   __________________________


### PR DESCRIPTION
This is a fix to #2855. 

The first time a user logs in with LDAP the database saves if they have the admin flag or not. Because of this if the LDAP source changes the user will still have the flag set for admin. This fix does a check to see if the user already exists in the database. If they exist then update, else create.

I think it could be probably improved with some way of checking that the user being updated has the same login source. 