### PR TITLE
getUserTeams uses includes always -1 in the IN statement to avoid SQL bad syntax errors

### DIFF
--- a/models/org_team.go
+++ b/models/org_team.go
@@ -450,10 +450,11 @@ func getUserTeams(e Engine, orgID, userID int64) ([]*Team, error) {
 		return nil, err
 	}
 
-	teamIDs := make([]int64, len(teamUsers))
+	teamIDs := make([]int64, len(teamUsers)+1)
 	for i := range teamUsers {
 		teamIDs[i] = teamUsers[i].TeamID
 	}
+	teamIDs[len(teamUsers)] = -1
 
 	teams := make([]*Team, 0, len(teamIDs))
 	return teams, e.Where("org_id = ?", orgID).In("id", teamIDs).Find(&teams)


### PR DESCRIPTION
Ensure that the IN clause contains one value at least. The idea is avoid a syntax error in the SQL sentence and rollbacks in the transactions.

For example:
    
```
        ERROR:  syntax error at or near ")"
        LINE 1: ...RE ... and team.id IN ();
```
    
We will always add the -1 value in the IN list so the IN clause always contains one element at least (`IN (-1)`. As `-1` is not a valid team `IN (-1)` acts like as a empty set.
