### PR TITLE
Made the webhook timeout duration longer.

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -211,7 +211,7 @@ TYPES = gogs, slack, discord
 ; Hook task queue length, increase if webhook shooting starts hanging
 QUEUE_LENGTH = 1000
 ; Deliver timeout in seconds
-DELIVER_TIMEOUT = 5
+DELIVER_TIMEOUT = 15
 ; Allow insecure certification
 SKIP_TLS_VERIFY = false
 ; Number of history information in each page


### PR DESCRIPTION
A 5 seconds default timeout is too low and can cause random timeouts in certain setups.

15 seconds is a nice default timeout, it's not too long, but it has a much lower chance of triggering the timeout.