### PR TITLE
Fix for downloading zero bytes files.

### DIFF
--- a/routers/repo/download.go
+++ b/routers/repo/download.go
@@ -18,7 +18,7 @@ import (
 func ServeData(ctx *context.Context, name string, reader io.Reader) error {
 	buf := make([]byte, 1024)
 	n, _ := reader.Read(buf)
-	if n > 0 {
+	if n >= 0 {
 		buf = buf[:n]
 	}
 


### PR DESCRIPTION
Allocated buffer served to client and not properly truncated to number of bytes read.

Fix for #4433