### PR TITLE
Rename app.ini attachment toggle from ENABLE to ENABLED

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -148,7 +148,7 @@ ANGLED_QUOTES = true
 
 [http]
 ; Value for Access-Control-Allow-Origin header, default is not to present
-ACCESS_CONTROL_ALLOW_ORIGIN = 
+ACCESS_CONTROL_ALLOW_ORIGIN =
 
 ; Define allowed algorithms and their minimum key length (use -1 to disable a type)
 [ssh.minimum_key_sizes]
@@ -294,7 +294,7 @@ ENABLE_FEDERATED_AVATAR = true
 ; Attachment settings for issues
 [attachment]
 ; Whether attachments are enabled. Defaults to `true`
-ENABLE = true
+ENABLED = true
 ; Path for attachments. Defaults to `data/attachments`
 PATH = data/attachments
 ; One or more allowed types, e.g. image/jpeg|image/png
@@ -346,7 +346,7 @@ MAX_DAYS = 7
 ; leave empty to inherit
 LEVEL =
 ; Webhook URL
-URL = 
+URL =
 
 [log.xorm]
 ; Enable file rotation

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -513,7 +513,7 @@ func NewContext() {
 	AttachmentAllowedTypes = strings.Replace(sec.Key("ALLOWED_TYPES").MustString("image/jpeg,image/png"), "|", ",", -1)
 	AttachmentMaxSize = sec.Key("MAX_SIZE").MustInt64(4)
 	AttachmentMaxFiles = sec.Key("MAX_FILES").MustInt(5)
-	AttachmentEnabled = sec.Key("ENABLE").MustBool(true)
+	AttachmentEnabled = sec.Key("ENABLED").MustBool(true)
 
 	TimeFormat = map[string]string{
 		"ANSIC":       time.ANSIC,


### PR DESCRIPTION
An update to the attachment enable/disable toggle to match language used with other config sections (e.g. `[repository.upload]`, `[release.attachment]` or `[mailer]`) - namely:

```
[attachment]
ENABLE = false
```

Becomes...

```
[attachment]
ENABLED = false
```

Understand this might be a backward breaking change for some - and documentation/wiki would require updates too. Happy to assist where possible.

  Peter
