### PR TITLE
added missing word and fixed a typo

### DIFF
--- a/conf/locale/locale_en-US.ini
+++ b/conf/locale/locale_en-US.ini
@@ -792,7 +792,7 @@ settings.githook_edit_desc = If the hook is inactive, sample content will be pre
 settings.githook_name = Hook Name
 settings.githook_content = Hook Content
 settings.update_githook = Update Hook
-settings.add_webhook_desc = Gogs will send a <code>POST</code> request to the URL you specify, along with regarding the event that occured. You can also specify what kind of data format you'd like to get upon triggering the hook (JSON, x-www-form-urlencoded, XML, etc). More information can be found in our <a target="_blank" href="%s">Webhooks Guide</a>.
+settings.add_webhook_desc = Gogs will send a <code>POST</code> request to the URL you specify, along with details regarding the event that occurred. You can also specify what kind of data format you'd like to get upon triggering the hook (JSON, x-www-form-urlencoded, XML, etc). More information can be found in our <a target="_blank" href="%s">Webhooks Guide</a>.
 settings.payload_url = Payload URL
 settings.content_type = Content Type
 settings.secret = Secret


### PR DESCRIPTION
This adds a missing word in the description of the webhooks settings page and fixes a typo.