### PR TITLE
Fix pointer mismatch with pam plugin

### DIFF
--- a/vendor/github.com/msteinert/pam/transaction.c
+++ b/vendor/github.com/msteinert/pam/transaction.c
@@ -39,13 +39,12 @@ error:
 	return PAM_CONV_ERR;
 }
 
-struct pam_conv *make_pam_conv(void *appdata_ptr)
+struct pam_conv *make_pam_conv()
 {
 	struct pam_conv* conv = malloc(sizeof *conv);
 	if (!conv) {
 		return NULL;
 	}
 	conv->conv = cb_pam_conv;
-	conv->appdata_ptr = appdata_ptr;
 	return conv;
 }

--- a/vendor/github.com/msteinert/pam/transaction.go
+++ b/vendor/github.com/msteinert/pam/transaction.go
@@ -4,7 +4,7 @@ package pam
 //#include <stdlib.h>
 //#cgo CFLAGS: -Wall -std=c99
 //#cgo LDFLAGS: -lpam
-//struct pam_conv *make_pam_conv(void *);
+//struct pam_conv *make_pam_conv();
 import "C"
 
 import (
@@ -61,7 +61,8 @@ type conversation struct {
 func newConversation(handler ConversationHandler) (*conversation, C.int) {
 	c := &conversation{}
 	c.handler = handler
-	c.conv = C.make_pam_conv(unsafe.Pointer(c))
+	c.conv = C.make_pam_conv()
+        c.conv.appdata_ptr = unsafe.Pointer(c)
 	if c.conv == nil {
 		return nil, C.PAM_BUF_ERR
 	}


### PR DESCRIPTION
I was trying to authenticate via the pam backend plugin and it failed with an exception:
[Macaron] PANIC: runtime error: cgo argument has Go pointer to Go pointer
Someone pointed me to
https://github.com/pmoody-/golang-pam/commit/e5f9028af25fd791b54a23e762ed4fc0505f59ab
which is a similar library. Making the equivalent changes seems to have fixed my issue.