### PR TITLE
Preform → Perform

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -16,7 +16,7 @@ import (
 var (
 	Admin = cli.Command{
 		Name:  "admin",
-		Usage: "Preform admin operations on command line",
+		Usage: "Perform admin operations on command line",
 		Description: `Allow using internal logic of Gogs without hacking into the source code
 to make automatic initialization process more smoothly`,
 		Subcommands: []cli.Command{


### PR DESCRIPTION
Just an English typo in the command line help.