### PR TITLE
Added mysql and postgresql as optional dependencies in LSB init scripts.

### DIFF
--- a/scripts/init/centos/gogs
+++ b/scripts/init/centos/gogs
@@ -12,6 +12,8 @@
 # Provides:          gogs
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
+# Should-Start:      mysql postgresql
+# Should-Stop:       mysql postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start gogs at boot time.

--- a/scripts/init/debian/gogs
+++ b/scripts/init/debian/gogs
@@ -3,6 +3,8 @@
 # Provides:          gogs
 # Required-Start:    $syslog $network
 # Required-Stop:     $syslog
+# Should-Start:      mysql postgresql
+# Should-Stop:       mysql postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: A self-hosted Git service written in Go.
@@ -122,5 +124,3 @@ case "$1" in
 		exit 3
 		;;
 esac
-
-:

--- a/scripts/init/suse/gogs
+++ b/scripts/init/suse/gogs
@@ -9,6 +9,8 @@
 # Provides:          gogs
 # Required-Start:    $remote_fs
 # Required-Stop:     $remote_fs
+# Should-Start:      mysql postgresql
+# Should-Stop:       mysql postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start gogs at boot time.


### PR DESCRIPTION
If using postgresql or mysql for the gogs database then gogs doesn't start and the logs claim "database connection refused".

This PR adds mysql and postgresql as optional dependencies to the LSB init scripts so gogs will always start after mysql/postgresql _if_ they are present on the system. Thus allowing the initial database connection to succeed.

I've been using this updated init script for a few days on 2 independent Debian 8 servers both with gogs/mysql. No issues yet. I no longer need to ssh into the servers to manually start gogs after a restart. I've done at least a dozen restarts in the name of testing.

Don't forget to run `insserv gogs` after overwriting the old script with the new one to update the dependencies.