### PR TITLE
Do not include line numbers in diff selection

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -2138,6 +2138,7 @@ footer .ui.language .menu {
 .repository .diff-file-box .code-diff .lines-num {
   border-right: 1px solid #d4d4d5;
   padding: 0 5px;
+  user-select: none;
 }
 .repository .diff-file-box .code-diff .lines-num.lines-num-old,
 .repository .diff-file-box .code-diff .lines-num.lines-num-new {


### PR DESCRIPTION
Marking text in a diff will include the line numbers, resulting in copy pastes like this:

```
43	37	
     /**
44		
-     * @return array
38	
+     * @inheritDoc
45	39	
      */
```

This pull request will tell browser to not include the line numbers when selecting text. Copy paste will then behave like the standard code-view. This is not a problem in code-view, since the structure of the table rendering the code is a bit different. 

This css property is [widely supported](http://caniuse.com/#feat=user-select-none). IE9 and lower is the only (most used) browsers not supporting it.

I could not find a relevant issue. 
