### PR TITLE
Fix ListIssueComments API (#4587)

### DIFF
--- a/models/comment.go
+++ b/models/comment.go
@@ -110,6 +110,12 @@ func (c *Comment) loadAttributes(e Engine) (err error) {
 		if err != nil {
 			return fmt.Errorf("getIssueByID [%d]: %v", c.IssueID, err)
 		}
+		if c.Issue.Repo == nil {
+			c.Issue.Repo, err = getRepositoryByID(e, c.Issue.RepoID)
+			if err != nil {
+				return fmt.Errorf("getRepositoryByID [%d]: %v", c.Issue.RepoID, err)
+			}
+		}
 	}
 
 	if c.Attachments == nil {


### PR DESCRIPTION
This PR populates the `comment.Issue.Repo` struct using `getRepositoryByID()`. This is required to use the `ListIssueComments` API.

Fixes #4587.