### PR TITLE
Fix some css bugs

### DIFF
--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1482,9 +1482,9 @@ footer .ui.language .menu {
 }
 .repository.file.list #file-content .code-view .blob-num {
   width: 1%;
-  min-width: 50px;
-  padding-right: 10px;
-  padding-left: 10px;
+  min-width: 50px; 
+  line-height: 20px;
+  cursor: pointer;
   text-align: right;
   white-space: nowrap;
   vertical-align: top;
@@ -1493,60 +1493,26 @@ footer .ui.language .menu {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.repository.file.list #file-content .code-view .lines-num {
-  vertical-align: top;
-  text-align: right;
   color: #999;
   background: #f5f5f5;
-  width: 1%;
 }
-.repository.file.list #file-content .code-view .lines-num span {
-  line-height: 20px;
+.repository.file.list #file-content .code-view .blob-num,
+.repository.file.list #file-content .code-view .blob-code {
   padding: 0 10px;
-  cursor: pointer;
-  display: block;
 }
-.repository.file.list #file-content .code-view .lines-num,
-.repository.file.list #file-content .code-view .lines-code {
-  padding: 0;
-}
-.repository.file.list #file-content .code-view .lines-num pre,
-.repository.file.list #file-content .code-view .lines-code pre,
-.repository.file.list #file-content .code-view .lines-num ol,
-.repository.file.list #file-content .code-view .lines-code ol,
-.repository.file.list #file-content .code-view .lines-num .hljs,
-.repository.file.list #file-content .code-view .lines-code .hljs {
+.repository.file.list #file-content .code-view .blob-code pre,
+.repository.file.list #file-content .code-view .blob-code .hljs {
   background-color: white;
   margin: 0;
   padding: 0 !important;
 }
-.repository.file.list #file-content .code-view .lines-num pre li,
-.repository.file.list #file-content .code-view .lines-code pre li,
-.repository.file.list #file-content .code-view .lines-num ol li,
-.repository.file.list #file-content .code-view .lines-code ol li,
-.repository.file.list #file-content .code-view .lines-num .hljs li,
-.repository.file.list #file-content .code-view .lines-code .hljs li {
-  display: inline-block;
-  width: 100%;
-}
-.repository.file.list #file-content .code-view .lines-num pre li.active,
-.repository.file.list #file-content .code-view .lines-code pre li.active,
-.repository.file.list #file-content .code-view .lines-num ol li.active,
-.repository.file.list #file-content .code-view .lines-code ol li.active,
-.repository.file.list #file-content .code-view .lines-num .hljs li.active,
-.repository.file.list #file-content .code-view .lines-code .hljs li.active {
+
+.repository.file.list #file-content .code-view .blob-code pre li.active,
+.repository.file.list #file-content .code-view .blob-code ol li.active,
+.repository.file.list #file-content .code-view .blob-code .hljs li.active {
   background: #ffffdd;
 }
-.repository.file.list #file-content .code-view .lines-num pre li:before,
-.repository.file.list #file-content .code-view .lines-code pre li:before,
-.repository.file.list #file-content .code-view .lines-num ol li:before,
-.repository.file.list #file-content .code-view .lines-code ol li:before,
-.repository.file.list #file-content .code-view .lines-num .hljs li:before,
-.repository.file.list #file-content .code-view .lines-code .hljs li:before {
-  content: ' ';
-}
+
 .repository.file.list .sidebar {
   padding-left: 0;
 }

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1480,6 +1480,21 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view table {
   width: 100%;
 }
+.repository.file.list #file-content .code-view .line-num {
+  width: 1%;
+  min-width: 50px;
+  padding-right: 10px;
+  padding-left: 10px;
+  text-align: right;
+  white-space: nowrap;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 .repository.file.list #file-content .code-view .lines-num {
   vertical-align: top;
   text-align: right;

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1480,12 +1480,11 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view table {
   width: 100%;
 }
-.repository.file.list #file-content .code-view td{
+.repository.file.list #file-content .code-view td {
   border: none;
 }
 .repository.file.list #file-content .code-view .blob-num {
   width: 1%;
-  min-width: 50px; 
   line-height: 20px;
   cursor: pointer;
   text-align: right;
@@ -1505,15 +1504,14 @@ footer .ui.language .menu {
 }
 .repository.file.list #file-content .code-view .blob-code pre,
 .repository.file.list #file-content .code-view .blob-code .hljs {
-  background-color: white;
   margin: 0;
   padding: 0 !important;
 }
-
-.repository.file.list #file-content .code-view .blob-code pre li.active,
-.repository.file.list #file-content .code-view .blob-code ol li.active,
-.repository.file.list #file-content .code-view .blob-code .hljs li.active {
-  background: #ffffdd;
+.repository.file.list #file-content .code-view .blob-code {
+  background-color: white;
+}
+.repository.file.list #file-content .code-view .blob-code.active {
+  background: #ffffdd !important;;
 }
 
 .repository.file.list .sidebar {

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1480,7 +1480,7 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view table {
   width: 100%;
 }
-.repository.file.list #file-content .code-view .line-num {
+.repository.file.list #file-content .code-view .blob-num {
   width: 1%;
   min-width: 50px;
   padding-right: 10px;

--- a/public/css/gogs.css
+++ b/public/css/gogs.css
@@ -1480,6 +1480,9 @@ footer .ui.language .menu {
 .repository.file.list #file-content .code-view table {
   width: 100%;
 }
+.repository.file.list #file-content .code-view td{
+  border: none;
+}
 .repository.file.list #file-content .code-view .blob-num {
   width: 1%;
   min-width: 50px; 

--- a/public/js/gogs.js
+++ b/public/js/gogs.js
@@ -1048,11 +1048,11 @@ function searchRepositories() {
 
 function initCodeView() {
     if ($('.code-view .linenums').length > 0) {
-        $(document).on('click', '.lines-num span', function (e) {
+         $(document).on('click', '.blob-num', function (e) {
             var $select = $(this);
-            var $list = $select.parent().siblings('.lines-code').find('ol.linenums > li');
-            selectRange($list, $list.filter('[rel=' + $select.attr('id') + ']'), (e.shiftKey ? $list.filter('.active').eq(0) : null));
-            deSelect();
+            var $code = $select.parent().find('.blob-code');
+            $select.parent().parent().find(".blob-code").removeClass("active");
+            $code.addClass("active");
         });
 
         $(window).on('hashchange', function (e) {

--- a/public/less/_repository.less
+++ b/public/less/_repository.less
@@ -420,41 +420,39 @@
 				table {
 					width: 100%;
 				}
-				.lines-num {
-					vertical-align: top;
+				td {
+					border: none;
+				}
+				.blob-num {
+					width: 1%;
+					line-height: 20px;
+					cursor: pointer;
 					text-align: right;
+					white-space: nowrap;
+					vertical-align: top;
+					cursor: pointer;
+					-webkit-user-select: none;
+					-moz-user-select: none;
+					-ms-user-select: none;
+					user-select: none;
 					color: #999;
 					background: #f5f5f5;
-					width: 1%;
-
-					span {
-						line-height: 20px;
-						padding: 0 10px;
-						cursor: pointer;
-						display: block;
+				}
+				.blob-num,
+				.blob-code {
+					  padding: 0 10px;
+				}
+				.blob-code{
+					background-color: white;
+					pre, .hljs {
+					margin: 0;
+					padding: 0 !important;
 					}
 				}
-				.lines-num,
-				.lines-code {
-					padding: 0;
-					pre,
-					ol,
-					.hljs {
-						background-color: white;
-						margin: 0;
-						padding: 0 !important;
-						li {
-							display: inline-block;
-							width: 100%;
-							&.active {
-								background: #ffffdd;
-							}
-							&:before {
-								content: ' ';
-							}
-						}
-					}
+				.blob-code.active{
+					  background: #ffffdd !important;;
 				}
+				
 			}
 		}
 
@@ -1026,7 +1024,7 @@
 			background-color: #f7f7f7;
 		}
 		.file-body.file-code {
-			.lines-num {
+			.blob-num {
 				text-align: right;
 				color: #A7A7A7;
 				background: #fafafa;
@@ -1037,7 +1035,7 @@
 					text-align: center;
 				}
 			}
-			.lines-num-old {
+			.blob-num-old {
 				border-right: 1px solid #DDD;
 			}
 		}
@@ -1052,12 +1050,12 @@
 			pre {
 				margin: 0;
 			}
-			.lines-num {
+			.blob-num {
 				border-right: 1px solid #d4d4d5;
 				padding: 0 5px;
 				user-select: none;
 
-				&.lines-num-old, &.lines-num-new {
+				&.blob-num-old, &.blob-num-new {
 					cursor: pointer;
 					&:hover {
 						color: #383636;

--- a/routes/repo/view.go
+++ b/routes/repo/view.go
@@ -186,15 +186,15 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 			var output bytes.Buffer
 			lines := strings.Split(fileContent, "\n")
 			for index, line := range lines {
-				output.WriteString(fmt.Sprintf(`<li class="L%d" rel="L%d">%s</li>`, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
+				output.WriteString(fmt.Sprintf(`<tr><td>%d</td><td id="L%d" rel="L%d">%s</td></tr>`, index+1, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
 			}
 			c.Data["FileContent"] = gotemplate.HTML(output.String())
 
-			output.Reset()
-			for i := 0; i < len(lines); i++ {
-				output.WriteString(fmt.Sprintf(`<span id="L%d">%d</span>`, i+1, i+1))
-			}
-			c.Data["LineNums"] = gotemplate.HTML(output.String())
+			// output.Reset()
+			// for i := 0; i < len(lines); i++ {
+			// 	output.WriteString(fmt.Sprintf(`<span id="L%d">%d</span>`, i+1, i+1))
+			// }
+			// c.Data["LineNums"] = gotemplate.HTML(output.String())
 		}
 
 		if canEnableEditor {

--- a/routes/repo/view.go
+++ b/routes/repo/view.go
@@ -186,7 +186,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 			var output bytes.Buffer
 			lines := strings.Split(fileContent, "\n")
 			for index, line := range lines {
-				output.WriteString(fmt.Sprintf(`<tr><td class="blob-num">%d</td><td id="L%d" rel="L%d" class="blob-code">%s</td></tr>`, index+1, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
+				output.WriteString(fmt.Sprintf(`<tr><td class="blob-num">%d</td><td id="L%d" rel="L%d" class="blob-code"><pre><code class="hljs">%s</code></pre></td></tr>`, index+1, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
 			}
 			c.Data["FileContent"] = gotemplate.HTML(output.String())
 

--- a/routes/repo/view.go
+++ b/routes/repo/view.go
@@ -186,7 +186,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 			var output bytes.Buffer
 			lines := strings.Split(fileContent, "\n")
 			for index, line := range lines {
-				output.WriteString(fmt.Sprintf(`<tr><td>%d</td><td id="L%d" rel="L%d">%s</td></tr>`, index+1, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
+				output.WriteString(fmt.Sprintf(`<tr><td class="blob-num">%d</td><td id="L%d" rel="L%d" class="blob-code">%s</td></tr>`, index+1, index+1, index+1, gotemplate.HTMLEscapeString(strings.TrimRight(line, "\r"))) + "\n")
 			}
 			c.Data["FileContent"] = gotemplate.HTML(output.String())
 

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -82,14 +82,14 @@
 			{{else if .FileSize}}
 				<table>
 					<tbody>
-						<tr>
+						
 						{{if .IsFileTooLarge}}
-							<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td>
+							<tr>
+							<td><strong>{{.i18n.Tr "repo.file_too_large"}}</strong></td></tr>
 						{{else}}
-							<td class="lines-num">{{.LineNums}}</td>
-							<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol class="linenums">{{.FileContent}}</ol></code></pre></td>
+							{{.FileContent}}
 						{{end}}
-						</tr>
+						
 					</tbody>
 				</table>
 			{{end}}

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -35,7 +35,7 @@
 			</div>
 		{{end}}
 	</h4>
-	<div class="ui attached table segment">
+	<div class="ui attached table unstackable segment">
 		<div id="{{if .IsIPythonNotebook}}ipython-notebook{{end}}" class="file-view {{if .IsMarkdown}}markdown{{else if .IsIPythonNotebook}}ipython-notebook{{else if .ReadmeInList}}plain-text{{else if and .IsTextFile}}code-view{{end}} has-emoji">
 			{{if .IsMarkdown}}
 				{{if .FileContent}}{{.FileContent | Str2html}}{{end}}


### PR DESCRIPTION
Rewrite some of the code associated with file preview page. 
重写了与预览代码页相关的代码，用纯粹的table来替代table嵌套ol.。参考了github的实现。之所以重写，是因为在缩小浏览器窗口时，样式出现了问题，详见下图。


-----before-----
![before-1](https://user-images.githubusercontent.com/15082236/27667678-fcf7e9a0-5cae-11e7-93e4-a38c1e64b347.png)
![before-2](https://user-images.githubusercontent.com/15082236/27667679-fd0caa5c-5cae-11e7-9037-7353639687db.png)

-----after------
![after](https://user-images.githubusercontent.com/15082236/27667677-fcc5c6fa-5cae-11e7-9cd5-ba7fba411adb.png)

