### PR TITLE
api: fix nil pointer dereference on repo/forks

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -285,7 +285,7 @@ func (repo *Repository) HTMLURL() string {
 // This method assumes following fields have been assigned with valid values:
 // Required - BaseRepo (if fork)
 // Arguments that are allowed to be nil: permission
-func (repo *Repository) APIFormat(permission *api.Permission) *api.Repository {
+func (repo *Repository) APIFormat(permission *api.Permission, user ...*User) *api.Repository {
 	cloneLink := repo.CloneLink()
 	apiRepo := &api.Repository{
 		ID:            repo.ID,
@@ -312,8 +312,12 @@ func (repo *Repository) APIFormat(permission *api.Permission) *api.Repository {
 		Permissions:   permission,
 	}
 	if repo.IsFork {
-		// FIXME: check precise permission for base repository
-		apiRepo.Parent = repo.BaseRepo.APIFormat(nil)
+		p := &api.Permission{Pull: true}
+		if len(user) != 0 {
+			p.Admin = user[0].IsAdminOfRepo(repo)
+			p.Push = user[0].IsWriterOfRepo(repo)
+		}
+		apiRepo.Parent = repo.BaseRepo.APIFormat(p)
 	}
 	return apiRepo
 }
@@ -2333,7 +2337,14 @@ func ForkRepository(doer, owner *User, baseRepo *Repository, name, desc string) 
 
 func (repo *Repository) GetForks() ([]*Repository, error) {
 	forks := make([]*Repository, 0, repo.NumForks)
-	return forks, x.Find(&forks, &Repository{ForkID: repo.ID})
+	if err := x.Find(&forks, &Repository{ForkID: repo.ID}); err != nil {
+		return nil, err
+	}
+
+	for _, fork := range forks {
+		fork.BaseRepo = repo
+	}
+	return forks, nil
 }
 
 // __________                             .__


### PR DESCRIPTION
Sets BaseRepo value for each resulting fork in GetForks().
Finds correct permissions for parent repository in APIFormat().

The output JSON is a little redundant, perhaps we should offer a
different view of the api.Repository without the Parent attribute?

Signed-off-by: Dennis Chen <barracks510@gmail.com>
