### PR TITLE
Removed fix config flag from default hooks

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -771,16 +771,16 @@ func cleanUpMigrateGitConfig(configPath string) error {
 }
 
 var hooksTpls = map[string]string{
-	"pre-receive":  "#!/usr/bin/env %s\n\"%s\" hook --config='%s' pre-receive\n",
-	"update":       "#!/usr/bin/env %s\n\"%s\" hook --config='%s' update $1 $2 $3\n",
-	"post-receive": "#!/usr/bin/env %s\n\"%s\" hook --config='%s' post-receive\n",
+	"pre-receive":  "#!/usr/bin/env %s\n\"%s\" hook pre-receive\n",
+	"update":       "#!/usr/bin/env %s\n\"%s\" hook update $1 $2 $3\n",
+	"post-receive": "#!/usr/bin/env %s\n\"%s\" hook post-receive\n",
 }
 
 func createDelegateHooks(repoPath string) (err error) {
 	for _, name := range git.HookNames {
 		hookPath := filepath.Join(repoPath, "hooks", name)
 		if err = ioutil.WriteFile(hookPath,
-			[]byte(fmt.Sprintf(hooksTpls[name], setting.ScriptType, setting.AppPath, setting.CustomConf)),
+			[]byte(fmt.Sprintf(hooksTpls[name], setting.ScriptType, setting.AppPath)),
 			os.ModePerm); err != nil {
 			return fmt.Errorf("create delegate hook '%s': %v", hookPath, err)
 		}


### PR DESCRIPTION
The targeted problem is not a bug particularly but it makes the created repos less flexible in the aspect of portability.
I had an issue with this.

The lines modified used unnecessary specification of the config file as module setting stores the full path to the custom config file and the module comd/hook uses it.

In my opinion, the path to the executable should also be eliminated from these files, but it would also include the installation documentation, and possibly other parts.

If you confirm that it would be a valuable improvement, I work it out.