### PR TITLE
Fix #4706: Issue mentions should also render with square brackets

### DIFF
--- a/pkg/markup/markdown.go
+++ b/pkg/markup/markdown.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/russross/blackfriday"
 
-	"github.com/gogits/gogs/pkg/tool"
 	"github.com/gogits/gogs/pkg/setting"
+	"github.com/gogits/gogs/pkg/tool"
 )
 
 // IsMarkdownFile reports whether name looks like a Markdown file based on its extension.

--- a/pkg/markup/markup.go
+++ b/pkg/markup/markup.go
@@ -45,9 +45,9 @@ var (
 	// e.g. https://try.gogs.io/gogs/gogs/issues/4#issue-685
 	IssueFullPattern = regexp.MustCompile(`(\s|^)https?.*issues/[0-9]+(#+[0-9a-zA-Z-]*)?`)
 	// IssueNumericPattern matches string that references to a numeric issue, e.g. #1287
-	IssueNumericPattern = regexp.MustCompile(`( |^|\()#[0-9]+\b`)
+	IssueNumericPattern = regexp.MustCompile(`( |^|\(|\[)#[0-9]+\b`)
 	// IssueAlphanumericPattern matches string that references to an alphanumeric issue, e.g. ABC-1234
-	IssueAlphanumericPattern = regexp.MustCompile(`( |^|\()[A-Z]{1,10}-[1-9][0-9]*\b`)
+	IssueAlphanumericPattern = regexp.MustCompile(`( |^|\(|\[)[A-Z]{1,10}-[1-9][0-9]*\b`)
 	// CrossReferenceIssueNumericPattern matches string that references a numeric issue in a difference repository
 	// e.g. gogits/gogs#12345
 	CrossReferenceIssueNumericPattern = regexp.MustCompile(`( |^)[0-9a-zA-Z-_\.]+/[0-9a-zA-Z-_\.]+#[0-9]+\b`)
@@ -97,8 +97,9 @@ func RenderIssueIndexPattern(rawBytes []byte, urlPrefix string, metas map[string
 
 	ms := pattern.FindAll(rawBytes, -1)
 	for _, m := range ms {
-		if m[0] == ' ' || m[0] == '(' {
-			m = m[1:] // ignore leading space or opening parentheses
+		if m[0] == ' ' || m[0] == '(' || m[0] == '[' {
+			// ignore leading space, opening parentheses, or opening square brackets
+			m = m[1:]
 		}
 		var link string
 		if metas == nil {

--- a/pkg/markup/markup_test.go
+++ b/pkg/markup/markup_test.go
@@ -121,6 +121,19 @@ func Test_RenderIssueIndexPattern(t *testing.T) {
 					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
 				}
 			})
+			Convey("It should render issue mention in square brackets", func() {
+				testCases := []string{
+					"[#54321 issue]", "[<a href=\"/prefix/issues/54321\">#54321</a> issue]",
+					"test [#54321] issue", "test [<a href=\"/prefix/issues/54321\">#54321</a>] issue",
+					"test [#54321 extra] issue", "test [<a href=\"/prefix/issues/54321\">#54321</a> extra] issue",
+					"test [#54321 issue]", "test [<a href=\"/prefix/issues/54321\">#54321</a> issue]",
+					"test [#54321]", "test [<a href=\"/prefix/issues/54321\">#54321</a>]",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
 			Convey("It should render multiple issue mentions in the same line", func() {
 				testCases := []string{
 					"#54321 #1243", "<a href=\"/prefix/issues/54321\">#54321</a> <a href=\"/prefix/issues/1243\">#1243</a>",
@@ -259,6 +272,19 @@ func Test_RenderIssueIndexPattern(t *testing.T) {
 					"test (ABG-124 extra) issue", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> extra) issue",
 					"test (ABG-124 issue)", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> issue)",
 					"test (ABG-124)", "test (<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>)",
+				}
+
+				for i := 0; i < len(testCases); i += 2 {
+					So(string(RenderIssueIndexPattern([]byte(testCases[i]), urlPrefix, metas)), ShouldEqual, testCases[i+1])
+				}
+			})
+			Convey("It should render issue mention in square brackets", func() {
+				testCases := []string{
+					"[ABG-124] issue", "[<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>] issue",
+					"test [ABG-124] issue", "test [<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>] issue",
+					"test [ABG-124 extra] issue", "test [<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> extra] issue",
+					"test [ABG-124 issue]", "test [<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a> issue]",
+					"test [ABG-124]", "test [<a href=\"https://someurl.com/someuser/somerepo/?b=ABG-124\">ABG-124</a>]",
 				}
 
 				for i := 0; i < len(testCases); i += 2 {


### PR DESCRIPTION
Fixing issue #4706 

Issue mentions are now allowed between square brackets.
