### PR TITLE
Add option to send the user to a login box for the landing page

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -46,6 +46,7 @@ type LandingPage string
 const (
 	LANDING_PAGE_HOME    LandingPage = "/"
 	LANDING_PAGE_EXPLORE LandingPage = "/explore"
+	LANDING_PAGE_LOGIN   LandingPage = "/user/login"
 )
 
 var (
@@ -481,6 +482,8 @@ func NewContext() {
 	switch sec.Key("LANDING_PAGE").MustString("home") {
 	case "explore":
 		LandingPageURL = LANDING_PAGE_EXPLORE
+	case "login":
+		LandingPageURL = LANDING_PAGE_LOGIN
 	default:
 		LandingPageURL = LANDING_PAGE_HOME
 	}


### PR DESCRIPTION
**Summary**: allow another configuration choice for the default landing page.

**Changes**: adds a new configuration choice `login` for the LandingPage option in `pkg/setting/setting.go`

**Rationale**: I send users directly to the login page when they visit the site rather than requiring them to click 'Sign in'. I am sharing this PR in case you thought that would be useful to others.
