### PR TITLE
refine setup script for gogs service in Container

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -13,11 +13,11 @@ fi
 cd /app/gogs
 
 # Link volumed data with app data
-ln -sf /data/gogs/log  ./log
-ln -sf /data/gogs/data ./data
+[ -h ./log ] || ln -sf /data/gogs/log  ./log
+[ -h ./data ] || ln -sf /data/gogs/data ./data
 
 # Backward Compatibility with Gogs Container v0.6.15
-ln -sf /data/git /home/git
+[ -h /home/git ] || ln -sf /data/git /home/git
 
-chown -R git:git /data /app/gogs ~git/
+chown -R git:git /data/git /data/gogs /data/ssh /app/gogs
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
1. `ln` to an existing link will create a new link inside the linked directory. Add  checks to avoid.
2. Recursively `chown` is time consuming when directory is big and deep. `chown -R /data` will do this to the whole mounted volume, includes the repository. When repository is big, it takes too much time before start gogs web. This usually fail the readiness probe, and may cause container restart endlessly. This operation is not necessary on container restart.  Explicitly define the directories to `chown -R`, so that users can create repository under /data and link into /data/git to avoid `chown -R` on repository if they want to manage the ownership themselves.
3. As /home/git is soft link of /data/git, there is no need to `chown -R ~git/` again.
