### PR TITLE
Docker symlink fixes

### DIFF
--- a/docker/s6/gogs/setup
+++ b/docker/s6/gogs/setup
@@ -13,11 +13,11 @@ fi
 cd /app/gogs
 
 # Link volumed data with app data
-ln -sf /data/gogs/log  ./log
-ln -sf /data/gogs/data ./data
+ln -sfn /data/gogs/log  ./log
+ln -sfn /data/gogs/data ./data
 
 # Backward Compatibility with Gogs Container v0.6.15
-ln -sf /data/git /home/git
+ln -sfn /data/git /home/git
 
 chown -R git:git /data /app/gogs ~git/
 chmod 0755 /data /data/gogs ~git/


### PR DESCRIPTION
This pull request addresses an issue I found in the setup script that is run inside the docker container on startup. Due to how trivial it is there is no open issue for this.

What currently happens: On first run, the following symlinks are created:

* /app/gogs/log -> /data/gogs/log
* /app/gogs/data -> /data/gogs/data
* /home/git -> /data/git

On second run (upgrade/restart) the following links are created because the existing target links are followed:

* /data/gogs/log/log -> /data/gogs/log
* /data/gogs/data/data -> /data/gogs/data
* /data/git/git -> /data/git

These are circular links. This pull request uses the -n option (treat LINK_NAME as a normal file if it is a symbolic link to a directory) to prevent this from happening on container restart.
