### PR TITLE
Allow setting UID and GID when running a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,33 @@ FROM alpine:3.5
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
+  && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
+  && apk --no-cache --no-progress add \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    linux-pam \
+    openssh \
+    s6 \
+    shadow \
+    socat \
+    tzdata
 
 ENV GOGS_CUSTOM /data/gogs
 
-COPY . /app/gogs/build
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+COPY docker /app/gogs/docker
+COPY templates /app/gogs/templates
+COPY public /app/gogs/public
+
 WORKDIR /app/gogs/build
+COPY . .
 
 RUN    ./docker/build-go.sh \
     && ./docker/build.sh \
     && ./docker/finalize.sh
-
-# Configure LibC Name Service
-COPY docker/nsswitch.conf /etc/nsswitch.conf
 
 # Configure Docker Container
 VOLUME ["/data"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -3,19 +3,33 @@ FROM aarch64/alpine:3.5
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-arm64 /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
+  && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
+  && apk --no-cache --no-progress add \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    linux-pam \
+    openssh \
+    s6 \
+    shadow \
+    socat \
+    tzdata
 
 ENV GOGS_CUSTOM /data/gogs
 
-COPY . /app/gogs/build
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+COPY docker /app/gogs/docker
+COPY templates /app/gogs/templates
+COPY public /app/gogs/public
+
 WORKDIR /app/gogs/build
+COPY . .
 
 RUN    ./docker/build-go.sh \
     && ./docker/build.sh \
     && ./docker/finalize.sh
-
-# Configure LibC Name Service
-COPY docker/nsswitch.conf /etc/nsswitch.conf
 
 # Configure Docker Container
 VOLUME ["/data"]

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -3,19 +3,33 @@ FROM armhf/alpine:3.5
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
+  && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
+  && apk --no-cache --no-progress add \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    linux-pam \
+    openssh \
+    s6 \
+    shadow \
+    socat \
+    tzdata
 
 ENV GOGS_CUSTOM /data/gogs
 
-COPY . /app/gogs/build
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+COPY docker /app/gogs/docker
+COPY templates /app/gogs/templates
+COPY public /app/gogs/public
+
 WORKDIR /app/gogs/build
+COPY . .
 
 RUN    ./docker/build-go.sh \
     && ./docker/build.sh \
     && ./docker/finalize.sh
-
-# Configure LibC Name Service
-COPY docker/nsswitch.conf /etc/nsswitch.conf
 
 # Configure Docker Container
 VOLUME ["/data"]

--- a/Dockerfile.rpihub
+++ b/Dockerfile.rpihub
@@ -19,17 +19,31 @@ RUN [ "cross-build-start" ]
 # Install system utils & Gogs runtime dependencies
 ADD https://github.com/tianon/gosu/releases/download/1.9/gosu-armhf /usr/sbin/gosu
 RUN chmod +x /usr/sbin/gosu \
- && apk --no-cache --no-progress add ca-certificates bash git linux-pam s6 curl openssh socat tzdata
+  && echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
+  && apk --no-cache --no-progress add \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    linux-pam \
+    openssh \
+    s6 \
+    shadow \
+    socat \
+    tzdata
 
-COPY . /app/gogs/build
+# Configure LibC Name Service
+COPY docker/nsswitch.conf /etc/nsswitch.conf
+COPY docker /app/gogs/docker
+COPY templates /app/gogs/templates
+COPY public /app/gogs/public
+
 WORKDIR /app/gogs/build
+COPY . .
 
 RUN    ./docker/build-go.sh \
     && ./docker/build.sh \
     && ./docker/finalize.sh
-
-# Configure LibC Name Service
-COPY docker/nsswitch.conf /etc/nsswitch.conf
 
 # For cross compile on dockerhub
 ################################

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -25,7 +25,6 @@ rm -r $GOPATH
 apk --no-progress del build-deps
 
 # Create git user for Gogs
-mkdir -p /data/git
 addgroup -S git
-adduser -G git -g 'Gogs Git User' -h /data/git -s /sbin/nologin -D -S git
+adduser -G git -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && usermod -p '*' git && passwd -u git
 echo "export GOGS_CUSTOM=${GOGS_CUSTOM}" >> /etc/profile

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -25,5 +25,7 @@ rm -r $GOPATH
 apk --no-progress del build-deps
 
 # Create git user for Gogs
-adduser -H -D -g 'Gogs Git User' git -h /data/git -s /bin/bash && passwd -u git
+mkdir -p /data/git
+addgroup -S git
+adduser -G git -g 'Gogs Git User' -h /data/git -s /sbin/nologin -D -S git
 echo "export GOGS_CUSTOM=${GOGS_CUSTOM}" >> /etc/profile

--- a/docker/finalize.sh
+++ b/docker/finalize.sh
@@ -6,9 +6,6 @@ set -e
 
 # Move to final place
 mv /app/gogs/build/gogs /app/gogs/
-mv /app/gogs/build/templates /app/gogs/
-mv /app/gogs/build/public /app/gogs/
-mv /app/gogs/build/docker /app/gogs/
 
 # Final cleaning
 rm -rf /app/gogs/build

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -38,6 +38,14 @@ create_volume_subfolder() {
     done
 }
 
+setids() {
+    PUID=${PUID:-1000}
+    PGID=${PGID:-1000}
+    groupmod -o -g "$PGID" git
+    usermod -o -u "$PUID" git
+}
+
+setids
 cleanup
 create_volume_subfolder
 


### PR DESCRIPTION
Fix #3520 by allowing the UID and GID of the `git` user to be changed by passing the environment variables `PUID` and `GUID` in as part of the docker run command.

This is done using `usermod` and `groupmod` (included in the `shadow` package in the alpine testing repo). 

Prior to this pull request, gogs files are written using uid/gid 1000:1000 as these are the id's of the docker `git` user. Which in most cases, may not map to a meaningful user on the host. 

```
sudo docker create \
    --name=gogs \
    -p 22:22 \
    -p 3000:3000 \
    -e PUID=$(id $USER -u) -e PGID=$(id $USER -g) \
    -v /var/gogs:/data \
    -t gogs/gogs
```
Apologies for changing so much of the finalize.sh script. I had to in order for the container to build correctly (beforehand it would build, but /app/gogs/docker was empty) so that I could test it works.

I've also added a usermod command when creating the `git` user in a second commit. I believe simply doing `passwd -u` leaves the user in an insecure state. The usermod command means the user is unlocked but with password disabled. 