### PR TITLE
Make dropdowns menus work when JavaScript is disabled

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -80,7 +80,7 @@
 </head>
 <body>
 	<div class="full height">
-		<noscript>{{.i18n.Tr "This website works better with JavaScript"}}</noscript>
+		<noscript>This website works better with JavaScript"</noscript>
 
 		{{if not .PageIsInstall}}
 			<div class="following bar light">

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -61,6 +61,12 @@
 	<!-- Stylesheet -->
 	<link rel="stylesheet" href="{{AppSubURL}}/css/semantic-2.2.10.min.css">
 	<link rel="stylesheet" href="{{AppSubURL}}/css/gogs.css?v={{MD5 AppVer}}">
+	<noscript>
+		<style>
+			.dropdown:hover > .menu { display: block; }
+			.ui.secondary.menu .dropdown.item > .menu { margin-top: 0; }
+		 </style>
+	</noscript>
 
 	<!-- JavaScript -->
 	<script src="{{AppSubURL}}/js/semantic-2.2.10.min.js"></script>
@@ -74,7 +80,7 @@
 </head>
 <body>
 	<div class="full height">
-		<noscript>Please enable JavaScript in your browser!</noscript>
+		<noscript>{{.i18n.Tr "This website works better with JavaScript"}}</noscript>
 
 		{{if not .PageIsInstall}}
 			<div class="following bar light">

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -80,7 +80,7 @@
 </head>
 <body>
 	<div class="full height">
-		<noscript>This website works better with JavaScript"</noscript>
+		<noscript>This website works better with JavaScript</noscript>
 
 		{{if not .PageIsInstall}}
 			<div class="following bar light">


### PR DESCRIPTION
Attempt to make https://github.com/gogits/gogs/issues/4778 better. It localizes the message which appears for people who have JavaScript disabled and makes the dropdowns work with CSS (only for people who have JS disabled, using the `<noscript>` HTML tag) 