### PR TITLE
SSH Clone Link Fixes

### DIFF
--- a/models/repo.go
+++ b/models/repo.go
@@ -615,13 +615,14 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 	if isWiki {
 		repoName += ".wiki"
 	}
+	repoLowerName := strings.ToLower(repoName)
 
 	repo.Owner = repo.MustOwner()
 	cl := new(CloneLink)
 	if setting.SSH.Port != 22 {
-		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoName)
+		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoLowerName)
 	} else {
-		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoName)
+		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoLowerName)
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
 	return cl

--- a/models/repo.go
+++ b/models/repo.go
@@ -620,9 +620,9 @@ func (repo *Repository) cloneLink(isWiki bool) *CloneLink {
 	repo.Owner = repo.MustOwner()
 	cl := new(CloneLink)
 	if setting.SSH.Port != 22 {
-		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, repo.Owner.Name, repoLowerName)
+		cl.SSH = fmt.Sprintf("ssh://%s@%s:%d%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.SSH.Port, setting.RepoRootPath, repo.Owner.Name, repoLowerName)
 	} else {
-		cl.SSH = fmt.Sprintf("%s@%s:%s/%s.git", setting.RunUser, setting.SSH.Domain, repo.Owner.Name, repoLowerName)
+		cl.SSH = fmt.Sprintf("%s@%s:%s/%s/%s.git", setting.RunUser, setting.SSH.Domain, setting.RepoRootPath, repo.Owner.Name, repoLowerName)
 	}
 	cl.HTTPS = ComposeHTTPSCloneURL(repo.Owner.Name, repoName)
 	return cl


### PR DESCRIPTION
This PR fixes two issues (mentioned in #4788)
* repo name in SSH clone link should be in __lower case__
* SSH clone link will direct to a wrong directory under certain circumstances
