### PR TITLE
Disallow web ui to delete protected branch

### DIFF
--- a/routes/repo/issue.go
+++ b/routes/repo/issue.go
@@ -642,8 +642,14 @@ func viewIssue(c *context.Context, isPullList bool) {
 
 	if issue.IsPull && issue.PullRequest.HasMerged {
 		pull := issue.PullRequest
+		protectBranch, err := models.GetProtectBranchOfRepoByName(pull.BaseRepoID, pull.HeadBranch)
+		if err != nil {
+			c.Handle(500, "GetLabelsByRepoID", err)
+			return
+		}
 		c.Data["IsPullBranchDeletable"] = pull.BaseRepoID == pull.HeadRepoID &&
-			c.Repo.IsWriter() && c.Repo.GitRepo.IsBranchExist(pull.HeadBranch)
+			c.Repo.IsWriter() && c.Repo.GitRepo.IsBranchExist(pull.HeadBranch) &&
+			!protectBranch.Protected
 
 		deleteBranchUrl := c.Repo.RepoLink + "/branches/delete/" + pull.HeadBranch
 		c.Data["DeleteBranchLink"] = fmt.Sprintf("%s?commit=%s&redirect_to=%s", deleteBranchUrl, pull.MergedCommitID, c.Data["Link"])

--- a/routes/repo/issue.go
+++ b/routes/repo/issue.go
@@ -642,14 +642,14 @@ func viewIssue(c *context.Context, isPullList bool) {
 
 	if issue.IsPull && issue.PullRequest.HasMerged {
 		pull := issue.PullRequest
+		branchProtected := false
 		protectBranch, err := models.GetProtectBranchOfRepoByName(pull.BaseRepoID, pull.HeadBranch)
-		if err != nil {
-			c.Handle(500, "GetLabelsByRepoID", err)
-			return
+		if err == nil {
+			branchProtected = protectBranch.Protected
 		}
 		c.Data["IsPullBranchDeletable"] = pull.BaseRepoID == pull.HeadRepoID &&
 			c.Repo.IsWriter() && c.Repo.GitRepo.IsBranchExist(pull.HeadBranch) &&
-			!protectBranch.Protected
+			!branchProtected
 
 		deleteBranchUrl := c.Repo.RepoLink + "/branches/delete/" + pull.HeadBranch
 		c.Data["DeleteBranchLink"] = fmt.Sprintf("%s?commit=%s&redirect_to=%s", deleteBranchUrl, pull.MergedCommitID, c.Data["Link"])


### PR DESCRIPTION
Hi,

Addresses issue #4514 

Simple pull request that remove the ability for users to delete protected branches after a successful merge.

I have compiled and tested and it works as intended for me on Windows and Linux/amd64