### PR TITLE
Fix the language name for zh_TW

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -454,7 +454,7 @@ COMMITS_PAGING_NUM = 30
 
 [i18n]
 LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,ja-JP,es-ES,pt-BR,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR,gl-ES,uk-UA,en-GB,hu-HU
-NAMES = English,简体中文,繁體中文（香港）,繁體中文（台湾）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어,galego,українська,English (United Kingdom),Magyar
+NAMES = English,简体中文,繁體中文（香港）,繁體中文（臺灣）,Deutsch,français,Nederlands,latviešu,русский,日本語,español,português do Brasil,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어,galego,українська,English (United Kingdom),Magyar
 
 ; Used for datetimepicker
 [i18n.datelang]


### PR DESCRIPTION
台湾 is in Simplified Chinese (zh_CN), and 臺灣 is the correct version for Traditional Chinese (zh_TW).

Both 臺灣 and 台灣 are commonly used in Taiwan. According to [1][2], 臺灣 should be used in official documents, so I choose this version.

[1] http://news.ltn.com.tw/news/focus/paper/451629
[2] https://zh.wikipedia.org/wiki/%E8%87%BA%E7%81%A3#.E3.80.8C-.7B.E8.87.BA.7D-.E3.80.8D.E8.88.87.E3.80.8C-.7B.E5.8F.B0.7D-.E3.80.8D