### PR TITLE
Add CLI subcommands for all admin dashboard actions

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -6,6 +6,8 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"runtime"
 
 	"github.com/urfave/cli"
 
@@ -21,6 +23,13 @@ var (
 to make automatic initialization process more smoothly`,
 		Subcommands: []cli.Command{
 			subcmdCreateUser,
+			subcmdDeleteInactivateUsers,
+			subcmdDeleteRepositoryArchives,
+			subcmdDeleteMissingRepositories,
+			subcmdGitGcRepos,
+			subcmdRewriteAllPublicKeys,
+			subcmdSyncRepositoryHooks,
+			subcmdReinitMissingRepositories,
 		},
 	}
 
@@ -33,6 +42,90 @@ to make automatic initialization process more smoothly`,
 			stringFlag("password", "", "User password"),
 			stringFlag("email", "", "User email address"),
 			boolFlag("admin", "User is an admin"),
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdDeleteInactivateUsers = cli.Command{
+		Name:  "delete-inactive-users",
+		Usage: "Delete all inactive accounts",
+		Action: adminDashboardOperation(
+			models.DeleteInactivateUsers,
+			"All inactivate accounts have been deleted successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdDeleteRepositoryArchives = cli.Command{
+		Name:  "delete-repository-archives",
+		Usage: "Delete all repositories archives",
+		Action: adminDashboardOperation(
+			models.DeleteRepositoryArchives,
+			"All repositories archives have been deleted successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdDeleteMissingRepositories = cli.Command{
+		Name:  "delete-missing-repositories",
+		Usage: "Delete all repository records that lost Git files",
+		Action: adminDashboardOperation(
+			models.DeleteMissingRepositories,
+			"All repositories archives have been deleted successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdGitGcRepos = cli.Command{
+		Name:  "collect-garbage",
+		Usage: "Do garbage collection on repositories",
+		Action: adminDashboardOperation(
+			models.GitGcRepos,
+			"All repositories have done garbage collection successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdRewriteAllPublicKeys = cli.Command{
+		Name:  "rewrite-public-keys",
+		Usage: "Rewrite '.ssh/authorized_keys' file (caution: non-Gogs keys will be lost)",
+		Action: adminDashboardOperation(
+			models.RewriteAllPublicKeys,
+			"All public keys have been rewritten successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdSyncRepositoryHooks = cli.Command{
+		Name:  "resync-hooks",
+		Usage: "Resync pre-receive, update and post-receive hooks",
+		Action: adminDashboardOperation(
+			models.SyncRepositoryHooks,
+			"All repositories' pre-receive, update and post-receive hooks have been resynced successfully",
+		),
+		Flags: []cli.Flag{
+			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
+		},
+	}
+
+	subcmdReinitMissingRepositories = cli.Command{
+		Name:  "reinit-missing-repositories",
+		Usage: "Reinitialize all repository records that lost Git files",
+		Action: adminDashboardOperation(
+			models.ReinitMissingRepositories,
+			"All repository records that lost Git files have been reinitialized successfully",
+		),
+		Flags: []cli.Flag{
 			stringFlag("config, c", "custom/conf/app.ini", "Custom configuration file path"),
 		},
 	}
@@ -67,4 +160,24 @@ func runCreateUser(c *cli.Context) error {
 
 	fmt.Printf("New user '%s' has been successfully created!\n", c.String("name"))
 	return nil
+}
+
+func adminDashboardOperation(operation func() error, successMessage string) func(*cli.Context) error {
+	return func(c *cli.Context) error {
+		if c.IsSet("config") {
+			setting.CustomConf = c.String("config")
+		}
+
+		setting.NewContext()
+		models.LoadConfigs()
+		models.SetEngine()
+
+		if err := operation(); err != nil {
+			functionName := runtime.FuncForPC(reflect.ValueOf(operation).Pointer()).Name()
+			return fmt.Errorf("%s: %v", functionName, err)
+		}
+
+		fmt.Printf("%s\n", successMessage)
+		return nil
+	}
 }


### PR DESCRIPTION
This PR adds CLI subcommands for all operations available in the web admin panel.
The `gogs admin` command now looks like this:
```
NAME:
   Gogs admin - Allow using internal logic of Gogs without hacking into the source code
to make automatic initialization process more smoothly

USAGE:
   Gogs admin command [command options] [arguments...]

COMMANDS:
     create-user                  Create a new user in database
     delete-inactive-users        Delete all inactive accounts
     delete-repository-archives   Delete all repositories archives
     delete-missing-repositories  Delete all repository records that lost Git files
     collect-garbage              Do garbage collection on repositories
     rewrite-public-keys          Rewrite '.ssh/authorized_keys' file (caution: non-Gogs keys will be lost)
     resync-hooks                 Resync pre-receive, update and post-receive hooks
     reinit-missing-repositories  Reinitialize all repository records that lost Git files

OPTIONS:
   --help, -h  show help
```