### PR TITLE
Add API endpoint /api/v1/user/orgs

### DIFF
--- a/routes/api/v1/admin/org.go
+++ b/routes/api/v1/admin/org.go
@@ -7,38 +7,12 @@ package admin
 import (
 	api "github.com/gogits/go-gogs-client"
 
-	"github.com/gogits/gogs/models"
 	"github.com/gogits/gogs/pkg/context"
-	"github.com/gogits/gogs/routes/api/v1/convert"
 	"github.com/gogits/gogs/routes/api/v1/user"
+	"github.com/gogits/gogs/routes/api/v1/org"
 )
 
 // https://github.com/gogits/go-gogs-client/wiki/Administration-Organizations#create-a-new-organization
 func CreateOrg(c *context.APIContext, form api.CreateOrgOption) {
-	u := user.GetUserByParams(c)
-	if c.Written() {
-		return
-	}
-
-	org := &models.User{
-		Name:        form.UserName,
-		FullName:    form.FullName,
-		Description: form.Description,
-		Website:     form.Website,
-		Location:    form.Location,
-		IsActive:    true,
-		Type:        models.USER_TYPE_ORGANIZATION,
-	}
-	if err := models.CreateOrganization(org, u); err != nil {
-		if models.IsErrUserAlreadyExist(err) ||
-			models.IsErrNameReserved(err) ||
-			models.IsErrNamePatternNotAllowed(err) {
-			c.Error(422, "", err)
-		} else {
-			c.Error(500, "CreateOrganization", err)
-		}
-		return
-	}
-
-	c.JSON(201, convert.ToOrganization(org))
+	org.CreateOrgForUser(c, form, user.GetUserByParams(c))
 }

--- a/routes/api/v1/api.go
+++ b/routes/api/v1/api.go
@@ -316,7 +316,8 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("/issues", reqToken(), repo.ListUserIssues)
 
 		// Organizations
-		m.Get("/user/orgs", reqToken(), org.ListMyOrgs)
+		m.Combo("/user/orgs", reqToken()).Get(org.ListMyOrgs).Post(bind(api.CreateOrgOption{}), org.CreateMyOrg)
+
 		m.Get("/users/:username/orgs", org.ListUserOrgs)
 		m.Group("/orgs/:orgname", func() {
 			m.Combo("").Get(org.Get).Patch(bind(api.EditOrgOption{}), org.Edit)


### PR DESCRIPTION
# Why is this needed?

We're more than pleased with Gogs and want to automate completely a migration from GitLab to Gogs.
We need API to create organizations.

# Why we're not using `/api/v1/admin/users/<username>/orgs` ?

Although the same can be achieved with the above mentioned endpoint, 
I don't feel it's correct since it's an admin endpoint and requires you to specify the `username` that will be the owner of the repo.

Also there's a feature request at https://github.com/gogits/go-gogs-client/issues/77.

~~Once this is merged I'll expose Client API for `go-gogs-client`.~~ Exposed `go-gogs-client` in https://github.com/gogits/go-gogs-client/pull/84

# Tests

I haven't invested time into better code coverage due to the fact that we need to ship this soon. I will add tests in a separate PR later if that's okay with you.


@Unknwon 