### PR TITLE
Fix overextending of variable name

### DIFF
--- a/scripts/build_freebsd.sh
+++ b/scripts/build_freebsd.sh
@@ -1,6 +1,6 @@
 outPlattform=freebsd
 outArch=amd64
-outPath=./output_$outPlattform_$outArch
+outPath=./output_${outPlattform}_$outArch
 
 rm -rf $outPath
 mkdir $outPath

--- a/scripts/build_linux64.sh
+++ b/scripts/build_linux64.sh
@@ -1,6 +1,6 @@
 outPlattform=linux
 outArch=amd64
-outPath=./output_$outPlattform_$outArch
+outPath=./output_${outPlattform}_$outArch
 
 rm -rf $outPath
 mkdir $outPath


### PR DESCRIPTION
Before: `outPath=./output_$outPlattform_$outArch`
Variable referenced is `outPlattform_`

The shell includes the subsequent underscore as part of the variable name.

Before: `outPath=./output_${outPlattform}_$outArch`
Variable referenced is `outPlattform`