### PR TITLE
Use identicon image as the default gravatar.

### DIFF
--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -199,7 +199,7 @@ func AvatarLink(email string) (url string) {
 		}
 	}
 	if len(url) == 0 && !setting.DisableGravatar {
-		url = setting.GravatarSource + HashEmail(email)
+		url = setting.GravatarSource + HashEmail(email) + "?d=identicon"
 	}
 	if len(url) == 0 {
 		url = setting.AppSubURL + "/img/avatar_default.png"


### PR DESCRIPTION
Inspired by go-gitea/gitea#2767:
> Use geometric pattern image as default gravatar. It is easier to distinguish different people.
>
> Before:
> ![](https://camo.githubusercontent.com/bce3a056b81f604d890a84f83dff16691b7c82df/68747470733a2f2f692e696d6775722e636f6d2f4b41363738354b2e706e67)
> After:
> ![](https://camo.githubusercontent.com/334d84d544c561e67fc1c1016e7495e320d6950a/68747470733a2f2f692e696d6775722e636f6d2f5a7455344372682e706e67)