### PR TITLE
Add doctype to go-get=1 reponse. Fixes #4926 

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -244,7 +244,7 @@ func Contexter() macaron.Handler {
 			}
 
 			prefix := setting.AppURL + path.Join(ownerName, repoName, "src", branchName)
-			c.PlainText(http.StatusOK, []byte(com.Expand(`
+			c.PlainText(http.StatusOK, []byte(com.Expand(`<!doctype html>
 <html>
 	<head>
 		<meta name="go-import" content="{GoGetImport} git {CloneLink}">


### PR DESCRIPTION
Fixes #4926 

go-get=1 response now contains `<!doctype html>` and godoc.org can parse meta tags correctly.