### PR TITLE
Fix file commit history pagination

### DIFF
--- a/routes/repo/commit.go
+++ b/routes/repo/commit.go
@@ -45,6 +45,7 @@ func RenderIssueLinks(oldCommits *list.List, repoLink string) *list.List {
 func renderCommits(c *context.Context, filename string) {
 	c.Data["Title"] = c.Tr("repo.commits.commit_history") + " · " + c.Repo.Repository.FullName()
 	c.Data["PageIsCommits"] = true
+	c.Data["FileName"] = filename
 
 	page := c.QueryInt("page")
 	if page < 1 {


### PR DESCRIPTION
- The `commits_table.tmpl` pagination uses a `$.FileName` variable in
  order to generate the next/previous URLs, but it seems like that
  variable was no longer being populated in `renderCommits`.