### PR TITLE
repo/http: add CORS headers to allow clone/push from browser agents

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -635,8 +635,10 @@ func runWeb(c *cli.Context) error {
 		// e.g. with or without ".git" suffix.
 		m.Group("/:reponame([\\d\\w-_\\.]+\\.git$)", func() {
 			m.Get("", ignSignIn, context.RepoAssignment(), context.RepoRef(), repo.Home)
+			m.Options("/*", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 			m.Route("/*", "GET,POST", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 		})
+		m.Options("/:reponame/*", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 		m.Route("/:reponame/*", "GET,POST", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 	})
 	// ***** END: Repository *****

--- a/routes/repo/http.go
+++ b/routes/repo/http.go
@@ -56,6 +56,18 @@ func askCredentials(c *context.Context, status int, text string) {
 
 func HTTPContexter() macaron.Handler {
 	return func(c *context.Context) {
+		if len(setting.HTTP.AccessControlAllowOrigin) > 0 {
+			// Set CORS headers for browser-based git clients
+			c.Resp.Header().Set("Access-Control-Allow-Origin", setting.HTTP.AccessControlAllowOrigin)
+			c.Resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+			// Handle preflight OPTIONS request
+			if c.Req.Method == "OPTIONS" {
+				c.Status(http.StatusOK)
+				return
+			}
+		}
+
 		ownerName := c.Params(":username")
 		repoName := strings.TrimSuffix(c.Params(":reponame"), ".git")
 		repoName = strings.TrimSuffix(repoName, ".wiki")


### PR DESCRIPTION
Hello, this is my first time contributing to Gogs! I am the author of [isomorphic-git](https://github.com/isomorphic-git/isomorphic-git) which is a JavaScript implementation of git that runs in the browser. This enables web-based IDEs that can clone and push directly with git! One downside is that unlike on the desktop, in browsers we have the same-origin policy. This means you cannot clone directly from Github/Bitbucket/etc but must go through a proxy.

I am working to change this by adding the necessary CORS headers so that git clients in the browser will be able to fetch directly. Since Gogs is open source (unlike Github) I was able to make the change. (I am also sending a pull request to Gitlab with a similar change.)

I expect lots of questions/pushback because CORS is often misunderstood. This does NOT reduce any security. It just makes it possible to do "git clone" and "git push" from one domain to another, e.g. so https://codesandbox.io can clone from https://gogs.io. It still requires Basic Authorization to push just like using git CLI.