### PR TITLE
Disable password autocomplete

### DIFF
--- a/templates/user/auth/login.tmpl
+++ b/templates/user/auth/login.tmpl
@@ -15,7 +15,7 @@
 					</div>
 					<div class="required inline field {{if .Err_Password}}error{{end}}">
 						<label for="password">{{.i18n.Tr "password"}}</label>
-						<input id="password" name="password" type="password" value="{{.password}}" required>
+						<input id="password" name="password" type="password" autocomplete="off" value="{{.password}}" required>
 					</div>
 					<div class="inline field">
 						<label></label>


### PR DESCRIPTION
As gogs can be linked with PAM it is recommended to disable autocomplete on the password input.

