### PR TITLE
Update pkgr spec to build on Debian 9 (Stretch)

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -7,6 +7,8 @@ targets:
       - git
   debian-8:
     <<: *debian
+  debian-9:
+    <<: *debian
   ubuntu-12.04:
     <<: *debian
   ubuntu-14.04:


### PR DESCRIPTION
Update pkgr specifications to enable builds on Debian 9 (Stretch) since the Debian 8 (Jessie) .deb files will not work out of the box on a clean Debian 9 install.