### PR TITLE
Default to disabling federated avatar lookup

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -292,7 +292,7 @@ DISABLE_GRAVATAR = false
 ; Federated avatar lookup uses DNS to discover avatar associated
 ; with emails, see https://www.libravatar.org
 ; This value will be forced to be false in offline mode or Gravatar is disbaled.
-ENABLE_FEDERATED_AVATAR = true
+ENABLE_FEDERATED_AVATAR = false
 
 ; Attachment settings for issues
 [attachment]


### PR DESCRIPTION
It's a fun feature but `ENABLE_FEDERATED_AVATAR` being true by default leads to confusion and huge slowdowns (see #2838, #980, #914) — it's unexpected that Gogs requires DNS configured (?) for avatars.  

Avatar lookup is a niche feature that I don't believe should be enabled by default given how prone it is to causing problems.

Changes `ENABLE_FEDERATED_AVATAR` in `conf/app.ini` to be `false`.