### PR TITLE
Return valid LDAP string if user input lacks "%s"

### DIFF
--- a/pkg/auth/ldap/ldap.go
+++ b/pkg/auth/ldap/ldap.go
@@ -58,7 +58,7 @@ func (ls *Source) sanitizedUserQuery(username string) (string, bool) {
 		return "", false
 	}
 
-	return fmt.Sprintf(ls.Filter, username), true
+	return strings.Replace(ls.Filter, "%s", username, -1), true
 }
 
 func (ls *Source) sanitizedUserDN(username string) (string, bool) {
@@ -69,7 +69,7 @@ func (ls *Source) sanitizedUserDN(username string) (string, bool) {
 		return "", false
 	}
 
-	return fmt.Sprintf(ls.UserDN, username), true
+	return strings.Replace(ls.UserDN, "%s", username, -1), true
 }
 
 func (ls *Source) sanitizedGroupFilter(group string) (string, bool) {


### PR DESCRIPTION
This fixes #4375. When providing LDAP "User DN" and "User Filter", they usually contain the string "%s", which is replaced by the username during the login-process. There are however some edge cases, where "%s" is not needed in the user filter. If the user provides a string that does not contain "%s", fmt.Sprintf silently appends "%!(EXTRA type=value)" instead of failing loudly. This can be mitigated by using `strings.Replace`, which does what's expected when no "%s" is found.