### PR TITLE
Fix avatar email update error

### DIFF
--- a/routes/user/setting.go
+++ b/routes/user/setting.go
@@ -119,7 +119,7 @@ func UpdateAvatarSetting(c *context.Context, f form.Avatar, ctxUser *models.User
 		ctxUser.AvatarEmail = f.Gravatar
 	}
 
-	if f.Avatar != nil {
+	if f.Avatar != nil && f.Avatar.Filename != "" {
 		r, err := f.Avatar.Open()
 		if err != nil {
 			return fmt.Errorf("Avatar.Open: %v", err)


### PR DESCRIPTION
Updating avatar email yields "Uploaded file is not a image." error on https://try.gogs.io/user/settings/avatar.

![image](https://user-images.githubusercontent.com/5880908/40545626-7b993062-5ffa-11e8-8474-a4a81ed8dc50.png)

Taken from go-gitea/gitea#3793 and go-gitea/gitea#3988